### PR TITLE
Add OOTB settings V2

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -194,5 +194,20 @@
       "label": "article_sharing_label",
       "value": true
     }]
+  }, {
+    "label": "community_post_group_label",
+    "variables": [{
+      "identifier": "show_follow_post",
+      "type": "checkbox",
+      "description": "follow_post_description",
+      "label": "follow_post_label",
+      "value": true
+    }, {
+      "identifier": "show_post_sharing",
+      "type": "checkbox",
+      "description": "post_sharing_description",
+      "label": "post_sharing_label",
+      "value": true
+    }]
   }]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -218,5 +218,14 @@
       "label": "post_sharing_label",
       "value": true
     }]
+  }, {
+    "label": "community_topic_group_label",
+    "variables": [{
+      "identifier": "show_follow_topic",
+      "type": "checkbox",
+      "description": "follow_topic_description",
+      "label": "follow_topic_label",
+      "value": true
+    }]
   }]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Copenhagen",
   "author": "Zendesk",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "api_version": 1,
   "default_locale": "en-us",
   "settings": [{

--- a/manifest.json
+++ b/manifest.json
@@ -195,6 +195,15 @@
       "value": true
     }]
   }, {
+    "label": "section_page_group_label",
+    "variables": [{
+      "identifier": "show_follow_section",
+      "type": "checkbox",
+      "description": "follow_section_description",
+      "label": "follow_section_label",
+      "value": true
+    }]
+  }, {
     "label": "community_post_group_label",
     "variables": [{
       "identifier": "show_follow_post",

--- a/manifest.json
+++ b/manifest.json
@@ -119,5 +119,26 @@
       "description": "community_image_description",
       "label": "community_image_label"
     }]
+  }, {
+    "label": "search_group_label",
+    "variables":[{
+      "identifier": "instant_search",
+      "type": "checkbox",
+      "description": "instant_search_description",
+      "label": "instant_search_label",
+      "value": true
+    }, {
+      "identifier": "scoped_kb_search",
+      "type": "checkbox",
+      "description": "scoped_knowledge_base_search_description",
+      "label": "scoped_knowledge_base_search_label",
+      "value": true
+    }, {
+      "identifier": "scoped_community_search",
+      "type": "checkbox",
+      "description": "scoped_community_search_description",
+      "label": "scoped_community_search_label",
+      "value": true
+    }]
   }]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -149,5 +149,50 @@
       "label": "recent_activity_label",
       "value": true
     }]
+  }, {
+    "label": "article_page_group_label",
+    "variables": [{
+      "identifier": "show_articles_in_section",
+      "type": "checkbox",
+      "description": "articles_in_section_description",
+      "label": "articles_in_section_label",
+      "value": true
+    }, {
+      "identifier": "show_article_author",
+      "type": "checkbox",
+      "description": "article_author_description",
+      "label": "article_author_label",
+      "value": true
+    }, {
+      "identifier": "show_article_comments",
+      "type": "checkbox",
+      "description": "article_comments_description",
+      "label": "article_comments_label",
+      "value": true
+    }, {
+      "identifier": "show_follow_article",
+      "type": "checkbox",
+      "description": "follow_article_description",
+      "label": "follow_article_label",
+      "value": true
+    }, {
+      "identifier": "show_recently_viewed_articles",
+      "type": "checkbox",
+      "description": "recently_viewed_articles_description",
+      "label": "recently_viewed_articles_label",
+      "value": true
+    }, {
+      "identifier": "show_related_articles",
+      "type": "checkbox",
+      "description": "related_articles_description",
+      "label": "related_articles_label",
+      "value": true
+    }, {
+      "identifier": "show_article_sharing",
+      "type": "checkbox",
+      "description": "article_sharing_description",
+      "label": "article_sharing_label",
+      "value": true
+    }]
   }]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -140,5 +140,14 @@
       "label": "scoped_community_search_label",
       "value": true
     }]
+  }, {
+    "label": "home_page_group_label",
+    "variables": [{
+      "identifier": "show_recent_activity",
+      "type": "checkbox",
+      "description": "recent_activity_description",
+      "label": "recent_activity_label",
+      "value": true
+    }]
   }]
 }

--- a/style.css
+++ b/style.css
@@ -2341,7 +2341,6 @@ ul {
 .post-meta {
   display: inline-block;
   flex: 1;
-  margin-left: 10px;
   vertical-align: middle;
 }
 

--- a/style.css
+++ b/style.css
@@ -561,6 +561,7 @@ ul {
 .avatar {
   display: inline-block;
   position: relative;
+  margin-right: 10px;
 }
 
 .avatar img {
@@ -1156,10 +1157,11 @@ ul {
 
 @media (min-width: 1024px) {
   .article {
-    flex: 1 0 66%;
+    flex: 1;
     max-width: 66%;
     min-width: 640px;
     padding: 0 30px;
+    margin: 0 auto;
   }
 }
 
@@ -1202,6 +1204,10 @@ ul {
   }
 }
 
+.article-title.no-author {
+  margin-bottom: 0.067em;
+}
+
 .article-title .icon-lock::before {
   content: "\1F512";
   font-size: 20px;
@@ -1228,7 +1234,6 @@ ul {
 
 .article-meta {
   display: inline-block;
-  margin-left: 10px;
   vertical-align: middle;
 }
 

--- a/templates/article_page.hbs
+++ b/templates/article_page.hbs
@@ -6,25 +6,27 @@
   </nav>
 
   <div class="article-container" id="article-container">
-    <section class="article-sidebar">
-      <section class="section-articles collapsible-sidebar">
-        <h3 class="collapsible-sidebar-title sidenav-title">{{t 'articles_in_section'}}</h3>
-        <ul>
-          {{#each section.articles}}
-            <li>
-              <a href="{{url}}" class="sidenav-item {{#is id ../article.id}}current-article{{/is}}">{{title}}</a>
-            </li>
-          {{/each}}
-        </ul>
-        {{#if section.more_articles}}
-          <a href="{{section.url}}" class="article-sidebar-item">{{t 'see_more'}}</a>
-        {{/if}}
+    {{#if settings.show_articles_in_section}}
+      <section class="article-sidebar">
+        <section class="section-articles collapsible-sidebar">
+          <h3 class="collapsible-sidebar-title sidenav-title">{{t 'articles_in_section'}}</h3>
+          <ul>
+            {{#each section.articles}}
+              <li>
+                <a href="{{url}}" class="sidenav-item {{#is id ../article.id}}current-article{{/is}}">{{title}}</a>
+              </li>
+            {{/each}}
+          </ul>
+          {{#if section.more_articles}}
+            <a href="{{section.url}}" class="article-sidebar-item">{{t 'see_more'}}</a>
+          {{/if}}
+        </section>
       </section>
-    </section>
+    {{/if}}
 
     <article class="article">
       <header class="article-header">
-        <h1 title="{{article.title}}" class="article-title">
+        <h1 title="{{article.title}}" class="article-title {{#unless settings.show_article_author}}no-author{{/unless}}">
           {{article.title}}
           {{#if article.internal}}
             <span class="icon-lock" title="{{t 'internal'}}"></span>
@@ -32,16 +34,20 @@
         </h1>
 
         <div class="article-author">
-          <div class="avatar article-avatar">
-            {{#if article.author.agent}}
-              <span class="icon-agent"></span>
-            {{/if}}
-            <img src="{{article.author.avatar_url}}" alt="" class="user-avatar"/>
-          </div>
+          {{#if settings.show_article_author}}
+            <div class="avatar article-avatar">
+              {{#if article.author.agent}}
+                <span class="icon-agent"></span>
+              {{/if}}
+              <img src="{{article.author.avatar_url}}" alt="" class="user-avatar"/>
+            </div>
+          {{/if}}
           <div class="article-meta">
-            {{#link 'user_profile' id=article.author.id}}
-              {{article.author.name}}
-            {{/link}}
+            {{#if settings.show_article_author}}
+              {{#link 'user_profile' id=article.author.id}}
+                {{article.author.name}}
+              {{/link}}
+            {{/if}}
 
             <ul class="meta-group">
               {{#is article.created_at article.edited_at}}
@@ -53,7 +59,10 @@
             </ul>
           </div>
         </div>
-        {{subscribe}}
+
+        {{#if settings.show_follow_article}}
+          {{subscribe}}
+        {{/if}}
       </header>
 
       <section class="article-info">
@@ -78,12 +87,16 @@
 
       <footer>
         <div class="article-footer">
-          <div class="article-share">{{share}}</div>
-          {{#if comments}}
-            <a href="#article-comments" class="article-comment-count">
-              <span class="icon-comments"></span>
-              {{article.comment_count}}
-            </a>
+          {{#if settings.show_article_sharing}}
+            <div class="article-share">{{share}}</div>
+          {{/if}}
+          {{#if settings.show_article_comments}}
+            {{#if comments}}
+              <a href="#article-comments" class="article-comment-count">
+                <span class="icon-comments"></span>
+                {{article.comment_count}}
+              </a>
+            {{/if}}
           {{/if}}
         </div>
         {{#with article}}
@@ -108,103 +121,109 @@
       </footer>
 
       <section class="article-relatives">
-        {{recent_articles}}
-        {{related_articles}}
+        {{#if settings.show_recently_viewed_articles}}
+          {{recent_articles}}
+        {{/if}}
+        {{#if settings.show_related_articles}}
+          {{related_articles}}
+        {{/if}}
       </section>
-      <div class="article-comments" id="article-comments">
-        <section class="comments">
-          <header class="comment-overview">
-            <h3 class="comment-heading">
-              {{t 'comments'}}
-            </h3>
-            <p class="comment-callout">{{t 'comments_count' count=article.comment_count}}</p>
-            {{#if comments}}
-              <div class="dropdown comment-sorter">
-                <a class="dropdown-toggle">{{t 'sort_by'}}</a>
-                <span class="dropdown-menu" role="menu">
-                  {{#each comment_sorters}}
-                    <a aria-selected="{{selected}}" href="{{url}}" role="menuitem">{{name}}</a>
-                  {{/each}}
-                </span>
-              </div>
-            {{/if}}
-          </header>
-
-          <ul id="comments" class="comment-list">
-            {{#each comments}}
-              <li id="{{anchor}}" class="comment">
-                <div class="comment-wrapper">
-                  <div class="comment-info">
-                    <div class="comment-author">
-                      <div class="avatar comment-avatar">
-                        {{#if author.agent}}
-                          <span class="icon-agent"></span>
-                        {{/if}}
-                        <img src="{{author.avatar_url}}" alt="" class="user-avatar"/>
-                      </div>
-                      <div class="comment-meta">
-                        <span title="{{author.name}}">
-                          {{#link 'user_profile' id=author.id}}
-                            {{author.name}}
-                          {{/link}}
-                        </span>
-
-                        <ul class="meta-group">
-                          {{#if editor}}
-                            <li class="meta-data">{{date edited_at timeago=true}}</li>
-                            <li class="meta-data">{{t 'edited'}}</li>
-                          {{else}}
-                            <li class="meta-data">{{date created_at timeago=true}}</li>
-                          {{/if}}
-                        </ul>
-                      </div>
-                      <div class="comment-labels">
-                        {{#with ticket}}
-                          <a href="{{url}}" target="_zendesk_lotus" class="status-label escalation-badge">
-                            {{t 'request'}}{{id}}
-                          </a>
-                        {{/with}}
-                        {{#if pending}}
-                          <span class="comment-pending status-label status-label-pending">{{t 'pending_approval'}}</span>
-                        {{/if}}
-                      </div>
-                    </div>
-
-                    <section class="comment-body">{{body}}</section>
-                  </div>
-
-                  <div class="comment-actions-container">
-                    <div class="comment-vote vote" role='radiogroup'>
-                      {{vote 'up' role='radio' class='vote-up' selected_class='vote-voted'}}
-                      {{vote 'sum' class='vote-sum'}}
-                      {{vote 'down' role='radio' class='vote-down' selected_class='vote-voted'}}
-                    </div>
-                    <div class="comment-actions actions">
-                      {{actions}}
-                    </div>
-                  </div>
+      {{#if settings.show_article_comments}}
+        <div class="article-comments" id="article-comments">
+          <section class="comments">
+            <header class="comment-overview">
+              <h3 class="comment-heading">
+                {{t 'comments'}}
+              </h3>
+              <p class="comment-callout">{{t 'comments_count' count=article.comment_count}}</p>
+              {{#if comments}}
+                <div class="dropdown comment-sorter">
+                  <a class="dropdown-toggle">{{t 'sort_by'}}</a>
+                  <span class="dropdown-menu" role="menu">
+                    {{#each comment_sorters}}
+                      <a aria-selected="{{selected}}" href="{{url}}" role="menuitem">{{name}}</a>
+                    {{/each}}
+                  </span>
                 </div>
-              </li>
-            {{/each}}
-          </ul>
+              {{/if}}
+            </header>
 
-          {{pagination}}
+            <ul id="comments" class="comment-list">
+              {{#each comments}}
+                <li id="{{anchor}}" class="comment">
+                  <div class="comment-wrapper">
+                    <div class="comment-info">
+                      <div class="comment-author">
+                        <div class="avatar comment-avatar">
+                          {{#if author.agent}}
+                            <span class="icon-agent"></span>
+                          {{/if}}
+                          <img src="{{author.avatar_url}}" alt="" class="user-avatar"/>
+                        </div>
+                        <div class="comment-meta">
+                          <span title="{{author.name}}">
+                            {{#link 'user_profile' id=author.id}}
+                              {{author.name}}
+                            {{/link}}
+                          </span>
 
-          {{#form 'comment' class='comment-form'}}
-            <div class="avatar comment-avatar">
-              {{user_avatar class='user-avatar'}}
-            </div>
-            <div class="comment-container">
-              {{wysiwyg 'body'}}
-              <div class="comment-form-controls">
-                {{input type='submit'}}
+                          <ul class="meta-group">
+                            {{#if editor}}
+                              <li class="meta-data">{{date edited_at timeago=true}}</li>
+                              <li class="meta-data">{{t 'edited'}}</li>
+                            {{else}}
+                              <li class="meta-data">{{date created_at timeago=true}}</li>
+                            {{/if}}
+                          </ul>
+                        </div>
+                        <div class="comment-labels">
+                          {{#with ticket}}
+                            <a href="{{url}}" target="_zendesk_lotus" class="status-label escalation-badge">
+                              {{t 'request'}}{{id}}
+                            </a>
+                          {{/with}}
+                          {{#if pending}}
+                            <span class="comment-pending status-label status-label-pending">{{t 'pending_approval'}}</span>
+                          {{/if}}
+                        </div>
+                      </div>
+
+                      <section class="comment-body">{{body}}</section>
+                    </div>
+
+                    <div class="comment-actions-container">
+                      <div class="comment-vote vote" role='radiogroup'>
+                        {{vote 'up' role='radio' class='vote-up' selected_class='vote-voted'}}
+                        {{vote 'sum' class='vote-sum'}}
+                        {{vote 'down' role='radio' class='vote-down' selected_class='vote-voted'}}
+                      </div>
+                      <div class="comment-actions actions">
+                        {{actions}}
+                      </div>
+                    </div>
+                  </div>
+                </li>
+              {{/each}}
+            </ul>
+
+            {{pagination}}
+
+            {{#form 'comment' class='comment-form'}}
+              <div class="avatar comment-avatar">
+                {{user_avatar class='user-avatar'}}
               </div>
-            </div>
-          {{/form}}
+              <div class="comment-container">
+                {{wysiwyg 'body'}}
+                <div class="comment-form-controls">
+                  {{input type='submit'}}
+                </div>
+              </div>
+            {{/form}}
 
-          <p class="comment-callout">{{comment_callout}}</p>
-        </section>
-      </div>
+            <p class="comment-callout">{{comment_callout}}</p>
+          </section>
+        </div>
+      {{/if}}
     </article>
   </div>
 </div>

--- a/templates/article_page.hbs
+++ b/templates/article_page.hbs
@@ -2,7 +2,7 @@
 <div class="container">
   <nav class="sub-nav">
     {{breadcrumbs}}
-    {{search scoped=true submit=false}}
+    {{search scoped=settings.scoped_kb_search submit=false}}
   </nav>
 
   <div class="article-container" id="article-container">

--- a/templates/community_post_list_page.hbs
+++ b/templates/community_post_list_page.hbs
@@ -1,6 +1,6 @@
 <section class="section hero community-hero">
   <div class="hero-inner">
-    {{search submit=false class='search search-full' scoped=true}}
+    {{search submit=false class='search search-full' scoped=settings.scoped_community_search}}
   </div>
 </section>
 

--- a/templates/community_post_page.hbs
+++ b/templates/community_post_page.hbs
@@ -2,7 +2,7 @@
 <div class="container">
   <nav class="sub-nav">
     {{breadcrumbs}}
-    {{search scoped=true submit=false}}
+    {{search scoped=settings.scoped_community_search submit=false}}
   </nav>
 
   <div class="post-container">

--- a/templates/community_post_page.hbs
+++ b/templates/community_post_page.hbs
@@ -29,7 +29,9 @@
               <span class="status-label-{{post.status_dasherized}} status-label">{{post.status_name}}</span>
             {{/is}}
           </div>
-          <div class="community-follow">{{subscribe}}</div>
+          {{#if settings.show_follow_post}}
+            <div class="community-follow">{{subscribe}}</div>
+          {{/if}}
         </header>
 
         <section class="post-info-container">
@@ -90,15 +92,17 @@
           </div>
         </section>
 
-        <footer class="post-footer">
-          <div class="post-share">{{share}}</div>
-          {{#if comments}}
-            <a href="#comment-overview" class="post-comment-count">
-              <span class="icon-comments"></span>
-              {{post.comment_count}}
-            </a>
-          {{/if}}
-        </footer>
+        {{#if settings.show_post_sharing}}
+          <footer class="post-footer">
+            <div class="post-share">{{share}}</div>
+            {{#if comments}}
+              <a href="#comment-overview" class="post-comment-count">
+                <span class="icon-comments"></span>
+                {{post.comment_count}}
+              </a>
+            {{/if}}
+          </footer>
+        {{/if}}
       </article>
 
       <section class="comment-overview" id="comment-overview">

--- a/templates/community_topic_list_page.hbs
+++ b/templates/community_topic_list_page.hbs
@@ -1,6 +1,6 @@
 <section class="section hero community-hero">
   <div class="hero-inner">
-    {{search submit=false class='search search-full' scoped=true}}
+    {{search submit=false class='search search-full' scoped=settings.scoped_community_search}}
   </div>
 </section>
 

--- a/templates/community_topic_page.hbs
+++ b/templates/community_topic_page.hbs
@@ -18,9 +18,11 @@
   </header>
   <div class="community-header">
     <p class="page-header-description">{{topic.description}}</p>
-    <div class="community-follow">
-      {{subscribe}}
-    </div>
+    {{#if settings.show_follow_topic}}
+      <div class="community-follow">
+        {{subscribe}}
+      </div>
+    {{/if}}
   </div>
 
   <div class="topic-header">

--- a/templates/community_topic_page.hbs
+++ b/templates/community_topic_page.hbs
@@ -2,7 +2,7 @@
 <div class="container">
    <nav class="sub-nav">
     {{breadcrumbs}}
-    {{search scoped=true submit=false}}
+    {{search scoped=settings.scoped_community_search submit=false}}
   </nav>
 
   <header class="page-header">

--- a/templates/home_page.hbs
+++ b/templates/home_page.hbs
@@ -64,6 +64,8 @@
   {{/if}}
 
   <section class="section activity">
-    {{recent_activity}}
+    {{#if settings.show_recent_activity}}
+      {{recent_activity}}
+    {{/if}}
   </section>
 </div>

--- a/templates/home_page.hbs
+++ b/templates/home_page.hbs
@@ -1,6 +1,6 @@
 <section class="section hero">
   <div class="hero-inner">
-    {{search submit=false instant=true class='search search-full'}}
+    {{search submit=false instant=settings.instant_search class='search search-full'}}
   </div>
 </section>
 

--- a/templates/section_page.hbs
+++ b/templates/section_page.hbs
@@ -14,7 +14,9 @@
             <span class="icon-lock" title="{{t 'internal'}}"></span>
           {{/if}}
         </h1>
-        {{subscribe}}
+        {{#if settings.show_follow_section}}
+          {{subscribe}}
+        {{/if}}
         {{#if section.description}}
           <p class="page-header-description">{{section.description}}</p>
         {{/if}}


### PR DESCRIPTION
This PR adds the OOTB settings to Copenhagen theme and encloses the related code in a conditional block throughout all the templates. This PR is an alternative to #26.

JIRA: [HCD-1828](https://zendesk.atlassian.net/browse/HCD-1828), [HCD-1856](https://zendesk.atlassian.net/browse/HCD-1856)

@zendesk/delta 

### UI
![element_visibility_settings 11 20 32](https://user-images.githubusercontent.com/5737996/43068467-c3a38256-8e6a-11e8-9c90-c633baf81c0d.png)

### TO DO
- [x] Wait for the translation strings to come back (#32, #34)

### Risks
Medium - might break the layout.