### PR TITLE
Check for obsolete keys during translation updates

### DIFF
--- a/bin/update-translations.js
+++ b/bin/update-translations.js
@@ -3,8 +3,14 @@
 const fetch = require('node-fetch');
 const path = require('path');
 const fs = require('fs');
+const yaml = require('js-yaml');
 
 const LOCALE_ENDPOINT = `https://support.zendesk.com/api/v2/locales`;
+
+const translationDefinitions = yaml.safeLoad(fs.readFileSync('translations.yml', 'utf8')).parts;
+const obsoleteKeys = translationDefinitions
+  .filter(part => part.translation.obsolete)
+  .reduce((acc, part) => acc.concat(part.translation.key), []);
 
 (async function() {
   const resp = await fetch(`${LOCALE_ENDPOINT}/default`);
@@ -17,11 +23,13 @@ const LOCALE_ENDPOINT = `https://support.zendesk.com/api/v2/locales`;
     const resp = await fetch(`${LOCALE_ENDPOINT}/${localeId}.json?include=translations&packages=help_center_copenhagen_theme`);
     const translations = await resp.json();
 
-    const formatttedTranslations = Object.entries(translations.locale.translations).reduce((accumulator, [key, value]) => {
+    const formattedTranslations = Object.entries(translations.locale.translations).reduce((accumulator, [key, value]) => {
+      if (obsoleteKeys.includes(key)) return accumulator;
+
       accumulator[key.replace(/.+\./, '')] = value;
       return accumulator;
-    }, {})
+    }, {});
 
-    fs.writeFileSync(path.join('translations', `${localeId}.json`), JSON.stringify(formatttedTranslations, null, 2) + '\n', 'utf8');
+    fs.writeFileSync(path.join('translations', `${localeId}.json`), JSON.stringify(formattedTranslations, null, 2) + '\n', 'utf8');
   }
 })();

--- a/package.json
+++ b/package.json
@@ -4,5 +4,8 @@
   "repository": "git@github.com:zendesk/copenhagen_theme.git",
   "dependencies": {
     "node-fetch": "^2.1.2"
+  },
+  "devDependencies": {
+    "js-yaml": "^3.12.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,27 @@
 # yarn lockfile v1
 
 
+argparse@^1.0.7:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
+  dependencies:
+    sprintf-js "~1.0.2"
+
+esprima@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
+
+js-yaml@^3.12.0:
+  version "3.12.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.0.tgz#eaed656ec8344f10f527c6bfa1b6e2244de167d1"
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
+
 node-fetch@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.1.2.tgz#ab884e8e7e57e38a944753cec706f788d1768bb5"
+
+sprintf-js@~1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"


### PR DESCRIPTION
This PR solves the issue of exposed obsolete translation keys in the translation files. It reads the translation definitions from the `.yml` file and then it filters the keys based on the presence of the `obsolete` property.

@zendesk/delta 

### Risks
Low.