### PR TITLE
Add multiselect styling

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Copenhagen",
   "author": "Zendesk",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "api_version": 1,
   "default_locale": "en-us",
   "settings": [{

--- a/styles/_forms.scss
+++ b/styles/_forms.scss
@@ -48,6 +48,12 @@
   }
 }
 
+.form-field .hc-multiselect-toggle:focus {
+  outline: none;
+  border: 1px solid $brand_color;
+  text-decoration: none;
+}
+
 .form-field textarea {
   vertical-align: middle;
 }


### PR DESCRIPTION
With https://github.com/zendesk/help_center/pull/16226 merged, multiselect has now focus that needs to be styled in the theme for consistency.

This PR adds the multiselect focus styles to the copenhagen theme.

![screen shot 2018-07-27 at 11 09 08](https://user-images.githubusercontent.com/1172767/43312421-85d2ab2a-918d-11e8-81a5-c9efc0c39341.png)

@zendesk/piratos @zendesk/delta 

#### Risks
- Low: multiselect styling may look weird.