### PR TITLE
Listen to input on textarea to enable request submit button

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Copenhagen",
   "author": "Zendesk",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "api_version": 1,
   "default_locale": "en-us",
   "settings": [{

--- a/script.js
+++ b/script.js
@@ -48,7 +48,7 @@ $(document).ready(function() {
   // Change Mark as solved text according to whether comment is filled
   var $requestCommentTextarea = $(".request-container .comment-container textarea");
 
-  $requestCommentTextarea.on("keyup", function() {
+  $requestCommentTextarea.on("input", function() {
     if ($requestCommentTextarea.val() !== "") {
       $requestMarkAsSolvedButton.text($requestMarkAsSolvedButton.data("solve-and-submit-translation"));
       $requestCommentSubmitButton.prop("disabled", false);


### PR DESCRIPTION
### Description
In the /requests/{id} interface, when pasting text into the comment text area using the mouse (via context menu or menu bar), the submit button does not enable. Likewise, when cutting or deleting all text from the comment box using the mouse, the submit button does not disable.

This is due to the current listener on the field only binding on `keyup`. Since mouse actions don't fire a keyup event, the interface doesn't respond to the text being entered/removed as we might intend.

This PR adjusts the default listener to bind on `input`, which should fire whenever the value of the field changes, not just on keyboard events.

### Tasks
- [x] :green_book:
- [x] :+1:

### Risks
- Low