### PR TITLE
 Mark optional form fields in the New Post form

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Copenhagen",
   "author": "Zendesk",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "api_version": 1,
   "default_locale": "en-us",
   "settings": [{

--- a/style.css
+++ b/style.css
@@ -364,6 +364,11 @@ ul {
   margin-left: 2px;
 }
 
+.form-field .optional {
+  color: lighten($text_color, 20%);
+  margin-left: 4px;
+}
+
 .form-field p {
   color: lighten($text_color, 20%);
   font-size: 12px;

--- a/styles/_forms.scss
+++ b/styles/_forms.scss
@@ -69,7 +69,7 @@
 }
 
 .form-field .optional {
-  color: #bbb;
+  color: $secondary-text-color;
   margin-left: 4px;
 }
 

--- a/styles/_forms.scss
+++ b/styles/_forms.scss
@@ -68,6 +68,11 @@
   margin-left: 2px;
 }
 
+.form-field .optional {
+  color: #bbb;
+  margin-left: 4px;
+}
+
 .form-field p {
   color: $secondary-text-color;
   font-size: 12px;

--- a/templates/new_community_post_page.hbs
+++ b/templates/new_community_post_page.hbs
@@ -11,8 +11,14 @@
 
   <div class="form">
     {{#form 'post' class='new_community_post'}}
-      <div class="form-field {{#required 'title'}} required {{/required}}">
-        {{label 'title'}}
+      <div class="form-field">
+        {{#required 'title'}}
+          {{label 'title'}}
+        {{else}}
+          {{#label 'title'}}
+            {{t 'title_label'}}<span class="optional">({{t 'optional'}})</span>
+          {{/label}}
+        {{/required}}
         {{input 'title' autofocus=true}}
         {{#validate 'title'}}
           <div class="notification notification-error notification-inline">
@@ -23,8 +29,14 @@
 
       {{suggestion_list class='suggestion-list'}}
 
-      <div class="form-field {{#required 'details'}} required {{/required}}">
-        {{label 'details'}}
+      <div class="form-field">
+        {{#required 'details'}}
+          {{label 'details'}}
+        {{else}}
+          {{#label 'details'}}
+            {{t 'details_label'}}<span class="optional">({{t 'optional'}})</span>
+          {{/label}}
+        {{/required}}
         {{wysiwyg 'details'}}
         {{#validate 'details'}}
           <div class="notification notification-error notification-inline">
@@ -33,8 +45,14 @@
         {{/validate}}
       </div>
 
-      <div class="form-field {{#required 'topic'}} required {{/required}}">
-        {{label 'topic'}}
+      <div class="form-field">
+        {{#required 'topic'}}
+          {{label 'topic'}}
+        {{else}}
+          {{#label 'topic'}}
+            {{t 'topic_label'}}<span class="optional">({{t 'optional'}})</span>
+          {{/label}}
+        {{/required}}
         {{select 'topic'}}
         {{#validate 'topic'}}
           <div class="notification notification-error notification-inline">


### PR DESCRIPTION
Following https://github.com/zendesk/help_center/pull/16923

In order to support a11y (for cognitive disability in this case) we need to replace asterisk with marking optional fields.

@zendesk/delta
cc/ @zendesk/piratos 