### PR TITLE
Dropdowns with <button>

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Copenhagen",
   "author": "Zendesk",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "api_version": 1,
   "default_locale": "en-us",
   "settings": [{

--- a/style.css
+++ b/style.css
@@ -145,6 +145,18 @@ ul {
   }
 }
 
+.dropdown-toggle {
+  background: none;
+  border: 0;
+  padding: 0;
+  text-align: initial;
+}
+
+.dropdown-toggle:focus {
+  outline: 0;
+  text-decoration: underline;
+}
+
 .dropdown-toggle::after {
   color: inherit;
 }
@@ -1641,11 +1653,10 @@ ul {
   float: right;
 }
 
-.comment-sorter a {
+.comment-sorter .dropdown-toggle {
   color: lighten($text_color, 20%);
   font-weight: 300;
   font-size: 13px;
-  text-decoration: none;
 }
 
 [dir="rtl"] .comment-sorter {

--- a/styles/_base.scss
+++ b/styles/_base.scss
@@ -120,6 +120,17 @@ ul {
   @include max-width-container;
 }
 
+.dropdown-toggle {
+  background: none;
+  border: 0;
+  padding: 0;
+  text-align: initial;
+}
+ .dropdown-toggle:focus {
+  outline: 0;
+  text-decoration: underline;
+}
+
 .dropdown-toggle::after {
   color: inherit;
 }

--- a/styles/_comments.scss
+++ b/styles/_comments.scss
@@ -32,11 +32,10 @@
     display: inline-block;
     float: right;
 
-    a {
+    .dropdown-toggle {
       color: $secondary-text-color;
       font-weight: $font-weight-light;
       font-size: $font-size-small;
-      text-decoration: none;
     }
 
     [dir="rtl"] & {

--- a/templates/article_page.hbs
+++ b/templates/article_page.hbs
@@ -138,7 +138,9 @@
               <p class="comment-callout">{{t 'comments_count' count=article.comment_count}}</p>
               {{#if comments}}
                 <div class="dropdown comment-sorter">
-                  <a class="dropdown-toggle">{{t 'sort_by'}}</a>
+                  <button class="dropdown-toggle" aria-haspopup="true">
+                    {{t 'sort_by'}}
+                  </button>
                   <span class="dropdown-menu" role="menu">
                     {{#each comment_sorters}}
                       <a aria-selected="{{selected}}" href="{{url}}" role="menuitem">{{name}}</a>

--- a/templates/community_post_list_page.hbs
+++ b/templates/community_post_list_page.hbs
@@ -10,19 +10,21 @@
   </nav>
 
   <header class="page-header community-header">
-    <span class="dropdown">
-      <span class="dropdown-toggle">
-        <h4>{{t 'all_posts'}}</h4>
+    <h4>
+      <span class="dropdown">
+        <button class="dropdown-toggle" aria-haspopup="true">
+          {{t 'all_posts'}}
+        </button>
+        <span class="dropdown-menu" role="menu">
+          {{#link 'topics' role='menuitem'}}
+            {{t 'show_topics'}}
+          {{/link}}
+          {{#link 'posts' role='menuitem' selected='true'}}
+            {{t 'show_all_posts'}}
+          {{/link}}
+        </span>
       </span>
-      <span class="dropdown-menu" role="menu">
-        {{#link 'topics' role='menuitem'}}
-          {{t 'show_topics'}}
-        {{/link}}
-        {{#link 'posts' role='menuitem' selected='true'}}
-          {{t 'show_all_posts'}}
-        {{/link}}
-      </span>
-    </span>
+    </h4>
     <span class="post-to-community">
       {{link 'new_post' role='button' class='button-large'}}
     </span>
@@ -31,9 +33,9 @@
   <div class="topic-header">
     <span class="topic-filters">
       <span class="dropdown">
-        <span class="dropdown-toggle">
+        <button class="dropdown-toggle" aria-haspopup="true">
           {{current_filter.label}}
-        </span>
+        </button>
         <span class="dropdown-menu" role="menu">
           {{#each filters}}
             <a href="{{url}}" aria-selected="{{selected}}" role="menuitem">
@@ -43,9 +45,9 @@
         </span>
       </span>
       <span class="dropdown">
-        <span class="dropdown-toggle">
+        <button class="dropdown-toggle" aria-haspopup="true">
           {{current_sorter.label}}
-        </span>
+        </button>
         <span class="dropdown-menu" role="menu">
           {{#each sorters}}
             <a href="{{url}}" aria-selected="{{selected}}" role="menuitem">

--- a/templates/community_post_page.hbs
+++ b/templates/community_post_page.hbs
@@ -112,7 +112,9 @@
           <p class="comment-callout">{{t 'comments_count' count=post.comment_count}}</p>
           {{#if comments}}
             <div class="dropdown comment-sorter">
-              <a class="dropdown-toggle">{{t 'sort_by'}}</a>
+              <button class="dropdown-toggle" aria-haspopup="true">
+                {{t 'sort_by'}}
+              </button>
               <span class="dropdown-menu" role="menu">
                 {{#each comment_sorters}}
                   <a aria-selected="{{selected}}" href="{{url}}" role="menuitem">{{name}}</a>

--- a/templates/community_topic_list_page.hbs
+++ b/templates/community_topic_list_page.hbs
@@ -10,20 +10,22 @@
   </nav>
 
   <header class="page-header community-header">
-    <div class="page-header-item dropdown">
-      <div class="dropdown-toggle">
-        <h4>{{t 'community_topics'}}</h4>
-      </div>
-      <span class="dropdown-menu" role="menu">
-        {{#link 'topics' role='menuitem' selected='true'}}
-          {{t 'show_topics'}}
-        {{/link}}
-        {{#link 'posts' role='menuitem'}}
-          {{t 'show_all_posts'}}
-        {{/link}}
+    <h4>
+      <span class="dropdown">
+        <button class="dropdown-toggle" aria-haspopup="true">
+          {{t 'community_topics'}}
+        </button>
+        <span class="dropdown-menu" role="menu">
+          {{#link 'topics' role='menuitem' selected='true'}}
+            {{t 'show_topics'}}
+          {{/link}}
+          {{#link 'posts' role='menuitem'}}
+            {{t 'show_all_posts'}}
+          {{/link}}
+        </span>
       </span>
-    </div>
-    <span class="page-header-item post-to-community">
+    </h4>
+    <span class="post-to-community">
       {{link 'new_post' role='button' class='button-large'}}
     </span>
   </header>

--- a/templates/community_topic_page.hbs
+++ b/templates/community_topic_page.hbs
@@ -12,7 +12,7 @@
         <span class="icon-lock" title="{{t 'internal'}}"></span>
       {{/if}}
     </h1>
-    <span class="post-to-community page-header-item">
+    <span class="post-to-community">
       {{link 'new_post' role='button' topic_id=topic.id class='button button-large'}}
     </span>
   </header>
@@ -28,9 +28,9 @@
   <div class="topic-header">
     <span class="topic-filters">
       <span class="dropdown">
-        <span class="dropdown-toggle">
+        <button class="dropdown-toggle" aria-haspopup="true">
           {{current_filter.label}}
-        </span>
+        </button>
         <span class="dropdown-menu" role="menu">
           {{#each filters}}
             <a href="{{url}}" aria-selected="{{selected}}" role="menuitem">
@@ -40,9 +40,9 @@
         </span>
       </span>
       <span class="dropdown">
-        <span class="dropdown-toggle">
+        <button class="dropdown-toggle" aria-haspopup="true">
           {{current_sorter.label}}
-        </span>
+        </button>
         <span class="dropdown-menu" role="menu">
           {{#each sorters}}
             <a href="{{url}}" aria-selected="{{selected}}" role="menuitem">

--- a/templates/footer.hbs
+++ b/templates/footer.hbs
@@ -4,10 +4,10 @@
 
     <div class="footer-language-selector">
       {{#if alternative_locales}}
-        <div class="dropdown language-selector" aria-haspopup="true">
-          <a class="dropdown-toggle">
+        <div class="dropdown language-selector">
+          <button class="dropdown-toggle" aria-haspopup="true">
             {{current_locale.name}}
-          </a>
+          </button>
           <span class="dropdown-menu dropdown-menu-end" role="menu">
             {{#each alternative_locales}}
               <a href="{{url}}" dir="{{direction}}" rel="nofollow" role="menuitem">

--- a/templates/subscriptions_page.hbs
+++ b/templates/subscriptions_page.hbs
@@ -15,9 +15,9 @@
 
   <div class="my-activities-following-header">
     <span class="dropdown">
-      <span class="dropdown-toggle">
+      <button class="dropdown-toggle" aria-haspopup="true">
         {{current_filter.label}}
-      </span>
+      </button>
       <span class="dropdown-menu" role="menu">
         {{#each filters}}
           <a href="{{url}}" aria-selected="{{selected}}" role="menuitem">

--- a/templates/user_profile_page.hbs
+++ b/templates/user_profile_page.hbs
@@ -191,9 +191,9 @@
               {{#if sorters}}
                 <span class="profile-section-description">{{sorter_description}}</span>
                 <span class="profile-section-sorter dropdown">
-                  <span class="dropdown-toggle">
+                  <button class="dropdown-toggle" aria-haspopup="true">
                     {{current_sorter.label}}
-                  </span>
+                  </button>
                   <span class="dropdown-menu" role="menu">
                     {{#each sorters}}
                       <a href="{{url}}" aria-selected="{{selected}}" role="menuitem">


### PR DESCRIPTION
Same as https://github.com/zendesk/help_center/pull/16941, this PR changes all themeable dropdowns to use `<button>`, to improve accessibility and consistency. It also removes an unused class `.page-header-item`.

![dropdown_with_button](https://user-images.githubusercontent.com/1172767/46794972-417fc780-cd49-11e8-9a62-4866d993a01a.gif)

@zendesk/delta
cc/ @zendesk/piratos 

#### Risks
Medium. Copenhagen theme dropdowns may break or look weird.