### PR TITLE
Replace show comment container and mark as resolved with native buttons to support a11y

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Copenhagen",
   "author": "Zendesk",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "api_version": 1,
   "default_locale": "en-us",
   "settings": [{

--- a/style.css
+++ b/style.css
@@ -3029,20 +3029,14 @@ ul {
 .request-main .comment-show-container {
   border-radius: 2px;
   border: 1px solid #ddd;
-  cursor: pointer;
-  display: flex;
-  padding: 8px 15px;
+  color: lighten($text_color, 20%);
+  text-align: inherit;
+  padding: 8px 25px;
   width: 100%;
 }
 
 .request-main .comment-show-container.hidden {
   display: none;
-}
-
-.request-main .comment-show-container-content {
-  align-self: center;
-  color: lighten($text_color, 20%);
-  margin-left: 10px;
 }
 
 .request-main .form-field.comment-ccs > ul {

--- a/styles/_request.scss
+++ b/styles/_request.scss
@@ -46,19 +46,13 @@
     .comment-show-container {
       border-radius: 2px;
       border: 1px solid $border-color;
-      cursor: pointer;
-      display: flex;
-      padding: 8px 15px;
+      color: $secondary-text-color;
+      text-align: inherit;
+      padding: 8px 25px;
       width: 100%;
 
       &.hidden {
         display: none;
-      }
-
-      &-content {
-        align-self: center;
-        color: $secondary-text-color;
-        margin-left: 10px;
       }
     }
 

--- a/templates/request_page.hbs
+++ b/templates/request_page.hbs
@@ -75,11 +75,9 @@
         </div>
 
         <div class="comment-container">
-          <div class="comment-show-container {{#validate 'body'}}hidden{{/validate}}">
-            <span class="comment-show-container-content">
-              {{t 'add_to_conversation'}}
-            </span>
-          </div>
+          <button type="button" class="comment-show-container {{#validate 'body'}}hidden{{/validate}}">
+            {{t 'add_to_conversation'}}
+          </button>
 
           <div class="comment-fields {{#validate 'body'}}shown{{/validate}}">
             {{#if help_center.request_ccs_enabled}}
@@ -101,11 +99,11 @@
             {{checkbox 'mark_as_solved'}}
 
             {{#if request.can_be_marked_as_solved}}
-              <a role="button" class="button-large button-secondary mark-as-solved"
+              <button type="button" class="button-large button-secondary mark-as-solved"
                 data-solve-translation="{{t 'mark_as_solved'}}"
                 data-solve-and-submit-translation="{{t 'mark_as_solved_and_submit'}}">
                 {{t 'mark_as_solved'}}
-              </a>
+              </button>
             {{/if}}
 
             <span class="request-submit-comment {{#validate 'body'}}shown{{/validate}}">


### PR DESCRIPTION
Following https://github.com/zendesk/help_center/pull/17006

Users could not leave comments on requests using keyboard. In order to provide native keyboard navigation we should replace `div` and `a` tags with `button`.

@anpa @luis-almeida @zendesk/delta 

Jira: https://zendesk.atlassian.net/browse/HCJ-1715

#### Risks
Low - small ui update