### PR TITLE
Handle html email request body width overflow in UI

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Copenhagen",
   "author": "Zendesk",
-  "version": "1.4.9",
+  "version": "1.4.10",
   "api_version": 1,
   "default_locale": "en-us",
   "settings": [{

--- a/style.css
+++ b/style.css
@@ -1805,6 +1805,7 @@ ul {
   word-wrap: break-word;
   font-family: $text_font;
   line-height: 1.6;
+  overflow-x: auto;
 }
 
 .comment-body img {

--- a/styles/_comments.scss
+++ b/styles/_comments.scss
@@ -152,6 +152,7 @@
     @include content-body;
     font-family: $text_font;
     line-height: 1.6;
+    overflow-x: auto;
   }
 
   &-mark-as-solved {


### PR DESCRIPTION
### Description
It is currently possible to cause UI overflow by sending an email request with HTML wherein an element specifies its width as much wider than the max container width in the request UI. This causes the content to interfere with surrounding elements.

This PR adds an `overflow-x` rule to that container so that the wide content will be scrollable, rather than breaking out.

**Before:**
![reqoverflowbefore](https://user-images.githubusercontent.com/9287144/47683703-6031eb00-db9e-11e8-9a10-70981d364800.gif)

**After:**
![reqoverflowafter](https://user-images.githubusercontent.com/9287144/47683717-6e800700-db9e-11e8-93aa-68026eba827c.gif)

/cc: @zendesk/delta