### PR TITLE
Fix promoted articles styling

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Copenhagen",
   "author": "Zendesk",
-  "version": "1.4.8",
+  "version": "1.4.9",
   "api_version": 1,
   "default_locale": "en-us",
   "settings": [{

--- a/style.css
+++ b/style.css
@@ -958,12 +958,10 @@ ul {
   padding-right: 0;
 }
 
-.promoted-articles-item div {
+.promoted-articles-item a {
+  display: block;
   border-bottom: 1px solid #ddd;
   padding: 15px 0;
-}
-
-.promoted-articles-item a {
   color: $text_color;
 }
 
@@ -971,12 +969,12 @@ ul {
   vertical-align: baseline;
 }
 
-.promoted-articles-item:last-child div {
+.promoted-articles-item:last-child a {
   border: 0;
 }
 
 @media (min-width: 1024px) {
-  .promoted-articles-item:last-child div {
+  .promoted-articles-item:last-child a {
     border-bottom: 1px solid #ddd;
   }
 }

--- a/style.css
+++ b/style.css
@@ -939,25 +939,28 @@ ul {
 
 .promoted-articles-item {
   flex: 1 0 auto;
-  border-bottom: 1px solid #ddd;
-  padding: 15px 0;
 }
 
 @media (min-width: 1024px) {
   .promoted-articles-item {
     align-self: flex-end;
     flex: 0 0 auto;
-    margin-right: 30px;
+    padding-right: 30px;
     width: 33%;
     /* Three columns on desktop */
   }
   [dir="rtl"] .promoted-articles-item {
-    margin: 0 0 0 30px;
+    padding: 0 0 0 30px;
   }
 }
 
 .promoted-articles-item:nth-child(3n) {
-  margin-right: 0;
+  padding-right: 0;
+}
+
+.promoted-articles-item div {
+  border-bottom: 1px solid #ddd;
+  padding: 15px 0;
 }
 
 .promoted-articles-item a {
@@ -968,12 +971,12 @@ ul {
   vertical-align: baseline;
 }
 
-.promoted-articles-item:last-child {
+.promoted-articles-item:last-child div {
   border: 0;
 }
 
 @media (min-width: 1024px) {
-  .promoted-articles-item:last-child {
+  .promoted-articles-item:last-child div {
     border-bottom: 1px solid #ddd;
   }
 }

--- a/styles/_home-page.scss
+++ b/styles/_home-page.scss
@@ -25,18 +25,21 @@
     @include desktop {
       align-self: flex-end;
       flex: 0 0 auto;
-      margin-right: 30px;
+      padding-right: 30px;
       width: 33%; /* Three columns on desktop */
 
-      [dir="rtl"] & { margin: 0 0 0 30px; }
+      [dir="rtl"] & { padding: 0 0 0 30px; }
     }
 
     flex: 1 0 auto;
-    border-bottom: 1px solid $border-color;
-    padding: 15px 0;
 
     &:nth-child(3n) {
-      margin-right: 0;
+      padding-right: 0;
+    }
+
+    div {
+      border-bottom: 1px solid $border-color;
+      padding: 15px 0;
     }
 
     a {
@@ -47,7 +50,7 @@
       vertical-align: baseline;
     }
 
-    &:last-child {
+    &:last-child div {
       @include desktop {
         border-bottom: 1px solid $border-color;
       }

--- a/styles/_home-page.scss
+++ b/styles/_home-page.scss
@@ -37,12 +37,10 @@
       padding-right: 0;
     }
 
-    div {
+    a {
+      display: block;
       border-bottom: 1px solid $border-color;
       padding: 15px 0;
-    }
-
-    a {
       color: $text_color;
     }
 
@@ -50,7 +48,7 @@
       vertical-align: baseline;
     }
 
-    &:last-child div {
+    &:last-child a {
       @include desktop {
         border-bottom: 1px solid $border-color;
       }

--- a/templates/home_page.hbs
+++ b/templates/home_page.hbs
@@ -39,12 +39,14 @@
         <ul class="article-list promoted-articles">
           {{#each promoted_articles}}
             <li class="promoted-articles-item">
-              <a href="{{url}}">
-                {{title}}
-              </a>
-              {{#if internal}}
-                <span class="icon-lock" title="{{t 'internal'}}"></span>
-              {{/if}}
+              <div>
+                <a href="{{url}}">
+                  {{title}}
+                </a>
+                {{#if internal}}
+                  <span class="icon-lock" title="{{t 'internal'}}"></span>
+                {{/if}}
+              </div>
             </li>
           {{/each}}
         </ul>

--- a/templates/home_page.hbs
+++ b/templates/home_page.hbs
@@ -39,14 +39,13 @@
         <ul class="article-list promoted-articles">
           {{#each promoted_articles}}
             <li class="promoted-articles-item">
-              <div>
                 <a href="{{url}}">
                   {{title}}
+
+                  {{#if internal}}
+                    <span class="icon-lock" title="{{t 'internal'}}"></span>
+                  {{/if}}
                 </a>
-                {{#if internal}}
-                  <span class="icon-lock" title="{{t 'internal'}}"></span>
-                {{/if}}
-              </div>
             </li>
           {{/each}}
         </ul>


### PR DESCRIPTION
Changes in my previous PR didn't behave exactly as expected for promoted articles. This should fix the columns.

<img width="1252" alt="screenshot 2018-11-15 at 09 55 12" src="https://user-images.githubusercontent.com/2392131/48542254-f5332480-e8be-11e8-9ab2-258a22ffc699.png">

<img width="746" alt="screenshot 2018-11-15 at 10 17 06" src="https://user-images.githubusercontent.com/2392131/48542523-a89c1900-e8bf-11e8-8a32-09b20a694e69.png">

It switches to using padding instead of margin (`33%` width doesn't behave well with margins) and wraps the content of the item in a `div`, which would actually have the border (I was considering adding a special class name for it, but we don't have it for `a` either 🤷‍♂️)

@zendesk/delta

### Edit
Updated removed the `div` and made `a` to wrap the icon. Also applied the similar styling to the `a` itself, also made it a block.