### PR TITLE
Refactor jQuery to vanilla JS

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Copenhagen",
   "author": "Zendesk",
-  "version": "1.4.12",
+  "version": "1.4.13",
   "api_version": 1,
   "default_locale": "en-us",
   "settings": [{

--- a/script.js
+++ b/script.js
@@ -1,5 +1,21 @@
-
 document.addEventListener('DOMContentLoaded', function() {
+
+  function matches (element, selector) {
+    return Element.prototype.matches && element.matches(selector)
+      || Element.prototype.msMatchesSelector && element.msMatchesSelector(selector)
+      || Element.prototype.webkitMatchesSelector && element.webkitMatchesSelector(selector);
+  }
+
+  function closest (element, selector) {
+    if (Element.prototype.closest) {
+      return element.closest(selector);
+    }
+    do {
+      if (matches(element, selector)) return element;
+      element = element.parentElement || element.parentNode;
+    } while (element !== null && element.nodeType === 1);
+    return null;
+  }
 
   // social share popups
   [].forEach.call(document.querySelectorAll('.share a'), function(anchor) {
@@ -50,10 +66,8 @@ document.addEventListener('DOMContentLoaded', function() {
     requestMarkAsSolvedCheckbox.setAttribute('checked', true);
     requestCommentSubmitButton.disabled = true;
     this.setAttribute('data-disabled', true);
-    // Element.closest is supported in modern browsers and has a polyfill available for still in use outdated versions
-    // See https://caniuse.com/#feat=element-closest
-    // TODO: Should polyfill be installed? 
-    this.closest('form').submit();
+    // Element.closest is not supported in IE11
+    closest(this, 'form').submit();
   });
 
   // Change Mark as solved text according to whether comment is filled

--- a/script.js
+++ b/script.js
@@ -1,129 +1,159 @@
-/*
- * jQuery v1.9.1 included
- */
 
-$(document).ready(function() {
+document.addEventListener('DOMContentLoaded', function() {
 
   // social share popups
-  $(".share a").click(function(e) {
-    e.preventDefault();
-    window.open(this.href, "", "height = 500, width = 500");
+  [].forEach.call(document.querySelectorAll('.share a'), function(anchor) {
+    anchor.addEventListener('click', function(e) {
+      e.preventDefault();
+      window.open(this.href, '', 'height = 500, width = 500');
+    });
   });
 
   // show form controls when the textarea receives focus or backbutton is used and value exists
-  var $commentContainerTextarea = $(".comment-container textarea"),
-    $commentContainerFormControls = $(".comment-form-controls, .comment-ccs");
+  var commentContainerTextarea = document.querySelector('.comment-container textarea'),
+    commentContainerFormControls = document.querySelector('.comment-form-controls, .comment-ccs');
 
-  $commentContainerTextarea.one("focus", function() {
-    $commentContainerFormControls.show();
-  });
+  if (commentContainerTextarea) {
+    commentContainerTextarea.addEventListener('focus', function focusCommentContainerTextarea() {
+      commentContainerFormControls.style.display = 'block';
+      commentContainerTextarea.removeEventListener('focus', focusCommentContainerTextarea);
+    });
 
-  if ($commentContainerTextarea.val() !== "") {
-    $commentContainerFormControls.show();
+    if (commentContainerTextarea.value !== '') {
+      commentContainerFormControls.style.display = 'block';
+    }
   }
 
   // Expand Request comment form when Add to conversation is clicked
-  var $showRequestCommentContainerTrigger = $(".request-container .comment-container .comment-show-container"),
-    $requestCommentFields = $(".request-container .comment-container .comment-fields"),
-    $requestCommentSubmit = $(".request-container .comment-container .request-submit-comment");
+  var showRequestCommentContainerTrigger = document.querySelector('.request-container .comment-container .comment-show-container'),
+    requestCommentFields = document.querySelectorAll('.request-container .comment-container .comment-fields'),
+    requestCommentSubmit = document.querySelector('.request-container .comment-container .request-submit-comment');
 
-  $showRequestCommentContainerTrigger.on("click", function() {
-    $showRequestCommentContainerTrigger.hide();
-    $requestCommentFields.show();
-    $requestCommentSubmit.show();
-    $commentContainerTextarea.focus();
-  });
+  if (showRequestCommentContainerTrigger) {
+    showRequestCommentContainerTrigger.addEventListener('click', function() {
+      showRequestCommentContainerTrigger.style.display = 'none';
+      [].forEach.call(requestCommentFields, function(e) { e.style.display = 'block'; });
+      requestCommentSubmit.style.display = 'inline-block';
+
+      if (commentContainerTextarea) {
+        commentContainerTextarea.focus();
+      }
+    });
+  }
 
   // Mark as solved button
-  var $requestMarkAsSolvedButton = $(".request-container .mark-as-solved:not([data-disabled])"),
-    $requestMarkAsSolvedCheckbox = $(".request-container .comment-container input[type=checkbox]"),
-    $requestCommentSubmitButton = $(".request-container .comment-container input[type=submit]");
+  var requestMarkAsSolvedButton = document.querySelector('.request-container .mark-as-solved:not([data-disabled])'),
+    requestMarkAsSolvedCheckbox = document.querySelector('.request-container .comment-container input[type=checkbox]'),
+    requestCommentSubmitButton = document.querySelector('.request-container .comment-container input[type=submit]');
 
-  $requestMarkAsSolvedButton.on("click", function () {
-    $requestMarkAsSolvedCheckbox.attr("checked", true);
-    $requestCommentSubmitButton.prop("disabled", true);
-    $(this).attr("data-disabled", true).closest("form").submit();
+  requestMarkAsSolvedButton && requestMarkAsSolvedButton.addEventListener('click', function () {
+    requestMarkAsSolvedCheckbox.setAttribute('checked', true);
+    requestCommentSubmitButton.disabled = true;
+    this.setAttribute('data-disabled', true);
+    // Element.closest is supported in modern browsers and has a polyfill available for still in use outdated versions
+    // See https://caniuse.com/#feat=element-closest
+    // TODO: Should polyfill be installed? 
+    this.closest('form').submit();
   });
 
   // Change Mark as solved text according to whether comment is filled
-  var $requestCommentTextarea = $(".request-container .comment-container textarea");
+  var requestCommentTextarea = document.querySelector('.request-container .comment-container textarea');
 
-  $requestCommentTextarea.on("input", function() {
-    if ($requestCommentTextarea.val() !== "") {
-      $requestMarkAsSolvedButton.text($requestMarkAsSolvedButton.data("solve-and-submit-translation"));
-      $requestCommentSubmitButton.prop("disabled", false);
+  requestCommentTextarea && requestCommentTextarea.addEventListener('input', function() {
+    if (requestCommentTextarea.value !== '') {
+      if (requestMarkAsSolvedButton) {
+        requestMarkAsSolvedButton.innerText = requestMarkAsSolvedButton.getAttribute('data-solve-and-submit-translation');
+      }
+      requestCommentSubmitButton.disabled = false;
     } else {
-      $requestMarkAsSolvedButton.text($requestMarkAsSolvedButton.data("solve-translation"));
-      $requestCommentSubmitButton.prop("disabled", true);
+      if (requestMarkAsSolvedButton) {
+        requestMarkAsSolvedButton.innerText = requestMarkAsSolvedButton.getAttribute('data-solve-translation');
+      }
+      requestCommentSubmitButton.disabled = true;
     }
   });
 
   // Disable submit button if textarea is empty
-  if ($requestCommentTextarea.val() === "") {
-    $requestCommentSubmitButton.prop("disabled", true);
+  if (requestCommentTextarea && requestCommentTextarea.value === '') {
+    requestCommentSubmitButton.disabled = true;
   }
 
   // Submit requests filter form in the request list page
-  $("#request-status-select, #request-organization-select")
-    .on("change", function() {
+  [].forEach.call(document.querySelectorAll('#request-status-select, #request-organization-select'), function(el) {
+    el.addEventListener('change', function() {
       search();
     });
+  });
 
   // Submit requests filter form in the request list page
-  $("#quick-search").on("keypress", function(e) {
-    if (e.which === 13) {
+  const quickSearch = document.querySelector('#quick-search')
+  quickSearch && quickSearch.addEventListener('keypress', function(e) {
+    if (e.which === 13) { // Enter key
       search();
     }
   });
 
   function search() {
+    const quickSearch = document.querySelector('#quick-search');
+    const requestStatusSelect = document.querySelector('#request-status-select');
+    const requestOrganizationSelect = document.querySelector('#request-organization-select');
+
     window.location.search = $.param({
-      query: $("#quick-search").val(),
-      status: $("#request-status-select").val(),
-      organization_id: $("#request-organization-select").val()
+      query: quickSearch && quickSearch.value,
+      status: requestStatusSelect && requestStatusSelect.value,
+      organization_id: requestOrganizationSelect && requestOrganizationSelect.value
     });
   }
 
   function toggleNavigation(toggleElement) {
-    var menu = document.getElementById("user-nav");
-    var isExpanded = menu.getAttribute("aria-expanded") === "true";
-    menu.setAttribute("aria-expanded", !isExpanded);
-    toggleElement.setAttribute("aria-expanded", !isExpanded);
+    var menu = document.getElementById('user-nav');
+    var isExpanded = menu.getAttribute('aria-expanded') === 'true';
+    menu.setAttribute('aria-expanded', !isExpanded);
+    toggleElement.setAttribute('aria-expanded', !isExpanded);
   }
 
-  $(".header .icon-menu").on("click", function(e) {
+  const burgerMenu = document.querySelector('.header .icon-menu');
+  const userMenu = document.querySelector('#user-nav');
+
+  burgerMenu.addEventListener('click', function(e) {
     e.stopPropagation();
     toggleNavigation(this);
   });
 
-  $(".header .icon-menu").on("keyup", function(e) {
+  burgerMenu.addEventListener('keyup', function(e) {
     if (e.keyCode === 13) { // Enter key
       e.stopPropagation();
       toggleNavigation(this);
     }
   });
 
-  $("#user-nav").on("keyup", function(e) {
+  userMenu.addEventListener('keyup', function(e) {
     if (e.keyCode === 27) { // Escape key
       e.stopPropagation();
-      this.setAttribute("aria-expanded", false);
-      $(".header .icon-menu").attr("aria-expanded", false);
+      this.setAttribute('aria-expanded', false);
+      burgerMenu.setAttribute('aria-expanded', false);
     }
   });
 
-  if ($("#user-nav").children().length === 0) {
-    $(".header .icon-menu").hide();
+  if (userMenu.children.length === 0) {
+    burgerMenu.style.display = 'none';
   }
 
   // Submit organization form in the request page
-  $("#request-organization select").on("change", function() {
-    this.form.submit();
-  });
+  const requestOrganisationSelect = document.querySelector('#request-organization select');
+
+  if (requestOrganisationSelect) {
+    requestOrganisationSelect.addEventListener('change', function() {
+      closest(this, 'form').submit();
+    });
+  }
 
   // Toggles expanded aria to collapsible elements
-  $(".collapsible-nav, .collapsible-sidebar").on("click", function(e) {
-    e.stopPropagation();
-    var isExpanded = this.getAttribute("aria-expanded") === "true";
-    this.setAttribute("aria-expanded", !isExpanded);
+  [].forEach.call(document.querySelectorAll('.collapsible-nav, .collapsible-sidebar'), function(el) {
+    el.addEventListener('click', function(e) {
+      e.stopPropagation();
+      var isExpanded = this.getAttribute('aria-expanded') === 'true';
+      this.setAttribute('aria-expanded', !isExpanded);
+    });
   });
 });

--- a/script.js
+++ b/script.js
@@ -1,24 +1,21 @@
 document.addEventListener('DOMContentLoaded', function() {
-
-  function matches (element, selector) {
-    return Element.prototype.matches && element.matches(selector)
-      || Element.prototype.msMatchesSelector && element.msMatchesSelector(selector)
-      || Element.prototype.webkitMatchesSelector && element.webkitMatchesSelector(selector);
-  }
-
   function closest (element, selector) {
     if (Element.prototype.closest) {
       return element.closest(selector);
     }
     do {
-      if (matches(element, selector)) return element;
+      if (Element.prototype.matches && element.matches(selector)
+        || Element.prototype.msMatchesSelector && element.msMatchesSelector(selector)
+        || Element.prototype.webkitMatchesSelector && element.webkitMatchesSelector(selector)) {
+        return element;
+      }
       element = element.parentElement || element.parentNode;
     } while (element !== null && element.nodeType === 1);
     return null;
   }
 
   // social share popups
-  [].forEach.call(document.querySelectorAll('.share a'), function(anchor) {
+  Array.prototype.forEach.call(document.querySelectorAll('.share a'), function(anchor) {
     anchor.addEventListener('click', function(e) {
       e.preventDefault();
       window.open(this.href, '', 'height = 500, width = 500');
@@ -48,7 +45,7 @@ document.addEventListener('DOMContentLoaded', function() {
   if (showRequestCommentContainerTrigger) {
     showRequestCommentContainerTrigger.addEventListener('click', function() {
       showRequestCommentContainerTrigger.style.display = 'none';
-      [].forEach.call(requestCommentFields, function(e) { e.style.display = 'block'; });
+      Array.prototype.forEach.call(requestCommentFields, function(e) { e.style.display = 'block'; });
       requestCommentSubmit.style.display = 'inline-block';
 
       if (commentContainerTextarea) {
@@ -62,30 +59,34 @@ document.addEventListener('DOMContentLoaded', function() {
     requestMarkAsSolvedCheckbox = document.querySelector('.request-container .comment-container input[type=checkbox]'),
     requestCommentSubmitButton = document.querySelector('.request-container .comment-container input[type=submit]');
 
-  requestMarkAsSolvedButton && requestMarkAsSolvedButton.addEventListener('click', function () {
-    requestMarkAsSolvedCheckbox.setAttribute('checked', true);
-    requestCommentSubmitButton.disabled = true;
-    this.setAttribute('data-disabled', true);
-    // Element.closest is not supported in IE11
-    closest(this, 'form').submit();
-  });
+  if (requestMarkAsSolvedButton) {
+    requestMarkAsSolvedButton.addEventListener('click', function () {
+      requestMarkAsSolvedCheckbox.setAttribute('checked', true);
+      requestCommentSubmitButton.disabled = true;
+      this.setAttribute('data-disabled', true);
+      // Element.closest is not supported in IE11
+      closest(this, 'form').submit();
+    });
+  }
 
   // Change Mark as solved text according to whether comment is filled
   var requestCommentTextarea = document.querySelector('.request-container .comment-container textarea');
 
-  requestCommentTextarea && requestCommentTextarea.addEventListener('input', function() {
-    if (requestCommentTextarea.value !== '') {
-      if (requestMarkAsSolvedButton) {
-        requestMarkAsSolvedButton.innerText = requestMarkAsSolvedButton.getAttribute('data-solve-and-submit-translation');
+  if (requestCommentTextarea) {
+    requestCommentTextarea.addEventListener('input', function() {
+      if (requestCommentTextarea.value === '') {
+        if (requestMarkAsSolvedButton) {
+          requestMarkAsSolvedButton.innerText = requestMarkAsSolvedButton.getAttribute('data-solve-translation');
+        }
+        requestCommentSubmitButton.disabled = true;
+      } else {
+        if (requestMarkAsSolvedButton) {
+          requestMarkAsSolvedButton.innerText = requestMarkAsSolvedButton.getAttribute('data-solve-and-submit-translation');
+        }
+        requestCommentSubmitButton.disabled = false;
       }
-      requestCommentSubmitButton.disabled = false;
-    } else {
-      if (requestMarkAsSolvedButton) {
-        requestMarkAsSolvedButton.innerText = requestMarkAsSolvedButton.getAttribute('data-solve-translation');
-      }
-      requestCommentSubmitButton.disabled = true;
-    }
-  });
+    });
+  }
 
   // Disable submit button if textarea is empty
   if (requestCommentTextarea && requestCommentTextarea.value === '') {
@@ -93,24 +94,26 @@ document.addEventListener('DOMContentLoaded', function() {
   }
 
   // Submit requests filter form in the request list page
-  [].forEach.call(document.querySelectorAll('#request-status-select, #request-organization-select'), function(el) {
+  Array.prototype.forEach.call(document.querySelectorAll('#request-status-select, #request-organization-select'), function(el) {
     el.addEventListener('change', function() {
       search();
     });
   });
 
   // Submit requests filter form in the request list page
-  const quickSearch = document.querySelector('#quick-search')
-  quickSearch && quickSearch.addEventListener('keypress', function(e) {
-    if (e.which === 13) { // Enter key
-      search();
-    }
-  });
+  var quickSearch = document.querySelector('#quick-search');
+  if (quickSearch) {
+    quickSearch.addEventListener('keypress', function(e) {
+      if (e.which === 13) { // Enter key
+        search();
+      }
+    });
+  }
 
   function search() {
-    const quickSearch = document.querySelector('#quick-search');
-    const requestStatusSelect = document.querySelector('#request-status-select');
-    const requestOrganizationSelect = document.querySelector('#request-organization-select');
+    var quickSearch = document.querySelector('#quick-search');
+    var requestStatusSelect = document.querySelector('#request-status-select');
+    var requestOrganizationSelect = document.querySelector('#request-organization-select');
 
     window.location.search = $.param({
       query: quickSearch && quickSearch.value,
@@ -126,8 +129,8 @@ document.addEventListener('DOMContentLoaded', function() {
     toggleElement.setAttribute('aria-expanded', !isExpanded);
   }
 
-  const burgerMenu = document.querySelector('.header .icon-menu');
-  const userMenu = document.querySelector('#user-nav');
+  var burgerMenu = document.querySelector('.header .icon-menu');
+  var userMenu = document.querySelector('#user-nav');
 
   burgerMenu.addEventListener('click', function(e) {
     e.stopPropagation();
@@ -154,7 +157,7 @@ document.addEventListener('DOMContentLoaded', function() {
   }
 
   // Submit organization form in the request page
-  const requestOrganisationSelect = document.querySelector('#request-organization select');
+  var requestOrganisationSelect = document.querySelector('#request-organization select');
 
   if (requestOrganisationSelect) {
     requestOrganisationSelect.addEventListener('change', function() {
@@ -163,7 +166,7 @@ document.addEventListener('DOMContentLoaded', function() {
   }
 
   // Toggles expanded aria to collapsible elements
-  [].forEach.call(document.querySelectorAll('.collapsible-nav, .collapsible-sidebar'), function(el) {
+  Array.prototype.forEach.call(document.querySelectorAll('.collapsible-nav, .collapsible-sidebar'), function(el) {
     el.addEventListener('click', function(e) {
       e.stopPropagation();
       var isExpanded = this.getAttribute('aria-expanded') === 'true';


### PR DESCRIPTION
We want to not be dependent on jQuery anymore, therefore we must refactor to vanilla JS.
Please comment if you can see that the proposed code can be simplified further without using browser support.

* JIRA: [GG-249: Refactor script.js file in CPH theme to use pure vanilla JS](https://zendesk.atlassian.net/browse/GG-249)

cc @zendesk/guide-growth 

#### Risks:
The script is responsible for a number of important interactions in the UI. In order to move away from jQuery, a special version of Element.prototype.closest is added to support IE11 which doesn't have that prototype yet. (.closest() used to be just a jQuery feature, but was added to most modern browsers https://caniuse.com/#feat=element-closest)

Due to these risks, following features should be manually tested on all supported browsers before a merge

#### Features possibly affected by scripts.js changes:

##### Features on article pages:

_Social Share buttons_
Script contains logic to open an iframe

_Comments area_
Script expands comment textarea and shows relevant buttons to submit comments when user clicks on comment textbox

##### Features on requests pages:

_Submit requests_
 Script sets marked as solved form data before submitting when ‘Mark as solved’ button is clicked or ‘Marked as solved and submit’ button is clicked

_Request comments area_
Script expands comment textarea and shows relevant buttons to submit comments when user clicks on comment textbox. Also changes text of ‘Marked as solved’ button and shows/disables ‘Submit’ button dependent on whether input is empty or not

_Reopen request_
When a request has been solved, end-user should still be able to submit a new comment (thus reopening the request). Script is responsible for enabling the submit button when input field is not empty. If script fails at doing this, the user can't reopen the request.

_Collapsible sidebar (Ticked details sidebar)_
This sidebar is by default collapsed when render size is mobile screen sizes. Script toggles it upon clicking.

_Multiple organizations_
When the end-user is a member of multiple organisations (and this has to be enabled in Support), they see a dropdown in the tickets details sidebar. Script is responsible for catching changes to this drowdown and submit them.

_Search bar in ‘My activities’ / ‘My requests’ page_
 Script listens for enter key keypress to filter results based on the search string

##### Features in navbar menu (all pages):

Accessibility features such as listening for enter key and escape key to open / collapse menus. This applies to the hamburger menu which appears on responsive layout for mobile screen sizes.