### PR TITLE
Refactor jQuery to vanilla JS

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Copenhagen",
   "author": "Zendesk",
-  "version": "1.4.14",
+  "version": "1.4.15",
   "api_version": 1,
   "default_locale": "en-us",
   "settings": [{

--- a/script.js
+++ b/script.js
@@ -95,8 +95,9 @@ document.addEventListener('DOMContentLoaded', function() {
 
   // Submit requests filter form in the request list page
   Array.prototype.forEach.call(document.querySelectorAll('#request-status-select, #request-organization-select'), function(el) {
-    el.addEventListener('change', function() {
-      search();
+    el.addEventListener('change', function(e) {
+      e.stopPropagation();
+      closest(this, 'form').submit();
     });
   });
 
@@ -105,20 +106,8 @@ document.addEventListener('DOMContentLoaded', function() {
   if (quickSearch) {
     quickSearch.addEventListener('keypress', function(e) {
       if (e.which === 13) { // Enter key
-        search();
+        e.stopPropagation();
       }
-    });
-  }
-
-  function search() {
-    var quickSearch = document.querySelector('#quick-search');
-    var requestStatusSelect = document.querySelector('#request-status-select');
-    var requestOrganizationSelect = document.querySelector('#request-organization-select');
-
-    window.location.search = $.param({
-      query: quickSearch && quickSearch.value,
-      status: requestStatusSelect && requestStatusSelect.value,
-      organization_id: requestOrganizationSelect && requestOrganizationSelect.value
     });
   }
 


### PR DESCRIPTION
We want to not be dependent on jQuery anymore, therefore we must refactor to vanilla JS.

I missed a spot on my last PR, so here's another attempt at removing jQuery completely from the code.

* JIRA: [GG-249: Refactor script.js file in CPH theme to use pure vanilla JS](https://zendesk.atlassian.net/browse/GG-249)

cc @zendesk/guide-growth 

#### Risks:
Change touches logic that handles search queries and filtering in My activities / My requests.
It's tested manually in IE11 and newest version of Chrome already.