### PR TITLE
Fix styling breaking on recently viewed and related articles

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Copenhagen",
   "author": "Zendesk",
-  "version": "1.4.13",
+  "version": "1.4.14",
   "api_version": 1,
   "default_locale": "en-us",
   "settings": [{

--- a/style.css
+++ b/style.css
@@ -1389,17 +1389,19 @@ ul {
 }
 
 .article-relatives > * {
-  flex: 1 0 auto;
+  flex: 1 0 50%;
+  min-width: 50%;
+  overflow-wrap: break-word;
   margin-right: 0;
 }
 
 .article-relatives > *:last-child {
-  margin: 0;
+  padding: 0;
 }
 
 @media (min-width: 768px) {
   .article-relatives > * {
-    margin-right: 20px;
+    padding-right: 20px;
   }
 }
 

--- a/styles/_article.scss
+++ b/styles/_article.scss
@@ -135,12 +135,14 @@
     padding: 20px 0;
 
     > * {
-      flex: 1 0 auto; //Explicit values needed whith flex-direction: column for IE11
+      flex: 1 0 50%; //Explicit values needed whith flex-direction: column for IE11
+      min-width: 50%;
+      overflow-wrap: break-word;
       margin-right: 0;
 
-      &:last-child { margin: 0; }
+      &:last-child { padding: 0; }
 
-      @include tablet { margin-right: 20px; }
+      @include tablet { padding-right: 20px; }
     }
   }
 


### PR DESCRIPTION
cc: @zendesk/guide-growth 

#### At 768px:
<img width="769" alt="screen shot 2019-01-21 at 22 31 18" src="https://user-images.githubusercontent.com/5737996/51501477-52bd8300-1dd2-11e9-869c-2698f52afff7.png">

#### At 767px:
<img width="768" alt="screen shot 2019-01-21 at 22 31 50" src="https://user-images.githubusercontent.com/5737996/51501483-5b15be00-1dd2-11e9-8993-4f2819a65537.png">

#### When there are no recently viewed articles at 767px:
<img width="767" alt="screen shot 2019-01-21 at 22 32 21" src="https://user-images.githubusercontent.com/5737996/51501504-6ec12480-1dd2-11e9-8269-ca0933ef43d4.png">

#### When there are no recently viewed articles at 768px:
<img width="768" alt="screen shot 2019-01-21 at 23 19 55" src="https://user-images.githubusercontent.com/5737996/51501652-1fc7bf00-1dd3-11e9-80d7-26844ecbc51f.png">

#### Risks
Low