### PR TITLE
[GS-454] Highlight using colour rather than italics for CJK searches

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Copenhagen",
   "author": "Zendesk",
-  "version": "1.4.16",
+  "version": "1.4.17",
   "api_version": 1,
   "default_locale": "en-us",
   "settings": [{

--- a/style.css
+++ b/style.css
@@ -4080,3 +4080,12 @@ ul {
   display: inline-block;
   margin: 0 5px;
 }
+
+/* Don't display CJK results in italic */
+/* Add a yellow background instead */
+html[lang|="zh"] .search-result-description em,
+html[lang|="ko"] .search-result-description em,
+html[lang|="ja"] .search-result-description em {
+  font-style: normal;
+  background: yellow;
+}

--- a/styles/_search_results.scss
+++ b/styles/_search_results.scss
@@ -86,3 +86,14 @@
     }
   }
 }
+
+/* Don't display CJK results in italic */
+/* Add a yellow background instead */
+html[lang|="zh"],
+html[lang|="ko"],
+html[lang|="ja"] {
+  .search-result-description em {
+    font-style: normal;
+    background: yellow;
+  }
+}


### PR DESCRIPTION
@zendesk/guide-search 
@zendesk/guide-growth 

Not sure if this is the right place to add this, but CJK languages should not display search results matches in italics, they should instead use a normal style and a coloured background.

Example from google:
![image](https://user-images.githubusercontent.com/1541959/52296937-def9a980-297f-11e9-8e64-d7669bc3c0d8.png)

Before this change:
![image](https://user-images.githubusercontent.com/1541959/52296989-005a9580-2980-11e9-9acd-488b799891a2.png)

After this change:
![image](https://user-images.githubusercontent.com/1541959/52296998-03ee1c80-2980-11e9-9e85-41bd47658ba7.png)
