### PR TITLE
Adding support for Flexible Hierarchies in section page

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Copenhagen",
   "author": "Zendesk",
-  "version": "1.4.19",
+  "version": "1.5.0",
   "api_version": 1,
   "default_locale": "en-us",
   "settings": [{

--- a/script.js
+++ b/script.js
@@ -162,7 +162,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
     seeAllTrigger.addEventListener("click", function(e) {
       subsectionsList.classList.remove("section-list--collapsed");
-      seeAllTrigger.remove();
+      seeAllTrigger.parentNode.removeChild(seeAllTrigger);
     });
   }
 });

--- a/script.js
+++ b/script.js
@@ -152,4 +152,17 @@ document.addEventListener('DOMContentLoaded', function() {
       this.setAttribute('aria-expanded', !isExpanded);
     });
   });
+
+  // If a section has more than 6 subsections, we collapse the list, and show a trigger to display them all
+  const seeAllTrigger = document.querySelector("#see-all-sections-trigger");
+  const subsectionsList = document.querySelector(".section-list");
+
+  if (subsectionsList && subsectionsList.children.length > 6) {
+    seeAllTrigger.setAttribute("aria-hidden", false);
+
+    seeAllTrigger.addEventListener("click", function(e) {
+      subsectionsList.classList.remove("section-list--collapsed");
+      seeAllTrigger.remove();
+    });
+  }
 });

--- a/style.css
+++ b/style.css
@@ -1142,7 +1142,6 @@ ul {
 }
 
 .article-list-item {
-  border-bottom: 1px solid #ddd;
   font-size: 16px;
   padding: 15px 0;
 }
@@ -1177,6 +1176,62 @@ ul {
 }
 
 .section-subscribe .dropdown-toggle::after {
+  display: none;
+}
+
+.section-list {
+  margin: 40px 0;
+}
+
+.section-list-item:first-child {
+  border-top: 1px solid #ddd;
+}
+
+.section-list-item {
+  border-bottom: 1px solid #ddd;
+  font-size: 16px;
+  padding: 15px 0;
+}
+
+.section-list-item a {
+  align-items: center;
+  color: $text_color;
+  display: flex;
+  justify-content: space-between;
+}
+
+.section-list {
+  margin: 40px 0;
+}
+
+.section-list-item:first-child {
+  border-top: 1px solid #ddd;
+}
+
+.section-list--collapsed .section-list-item:nth-child(1n + 6) {
+  display: none;
+}
+
+.section-list-item {
+  border-bottom: 1px solid #ddd;
+  font-size: 16px;
+  padding: 15px 0;
+}
+
+.section-list-item a {
+  align-items: center;
+  color: $text_color;
+  display: flex;
+  justify-content: space-between;
+}
+
+.see-all-sections-trigger {
+  display: block;
+  padding: 15px;
+  text-align: center;
+}
+
+.see-all-sections-trigger[aria-hidden="true"] {
   display: none;
 }
 

--- a/style.css
+++ b/style.css
@@ -1226,6 +1226,7 @@ ul {
 }
 
 .see-all-sections-trigger {
+  cursor: pointer;
   display: block;
   padding: 15px;
   text-align: center;

--- a/style.css
+++ b/style.css
@@ -1183,31 +1183,6 @@ ul {
   margin: 40px 0;
 }
 
-.section-list-item:first-child {
-  border-top: 1px solid #ddd;
-}
-
-.section-list-item {
-  border-bottom: 1px solid #ddd;
-  font-size: 16px;
-  padding: 15px 0;
-}
-
-.section-list-item a {
-  align-items: center;
-  color: $text_color;
-  display: flex;
-  justify-content: space-between;
-}
-
-.section-list {
-  margin: 40px 0;
-}
-
-.section-list-item:first-child {
-  border-top: 1px solid #ddd;
-}
-
 .section-list--collapsed .section-list-item:nth-child(1n + 6) {
   display: none;
 }
@@ -1216,6 +1191,10 @@ ul {
   border-bottom: 1px solid #ddd;
   font-size: 16px;
   padding: 15px 0;
+}
+
+.section-list-item:first-child {
+  border-top: 1px solid #ddd;
 }
 
 .section-list-item a {

--- a/styles/_category.scss
+++ b/styles/_category.scss
@@ -40,7 +40,6 @@
 
 .article-list {
   &-item {
-    border-bottom: 1px solid $border-color;
     font-size: $font-size-bigger;
     padding: 15px 0;
 

--- a/styles/_section.scss
+++ b/styles/_section.scss
@@ -66,6 +66,7 @@
 }
 
 .see-all-sections-trigger {
+  cursor: pointer;
   display: block;
   padding: 15px;
   text-align: center;

--- a/styles/_section.scss
+++ b/styles/_section.scss
@@ -13,6 +13,64 @@
   }
 
   &-subscribe {
-    .dropdown-toggle::after { display: none; }
+    .dropdown-toggle::after {
+      display: none;
+    }
   }
+}
+
+.section-list {
+  margin: 40px 0;
+}
+
+.section-list-item:first-child {
+  border-top: 1px solid $border-color;
+}
+
+.section-list-item {
+  border-bottom: 1px solid $border-color;
+  font-size: $font-size-bigger;
+  padding: 15px 0;
+}
+
+.section-list-item a {
+  align-items: center;
+  color: $text_color;
+  display: flex;
+  justify-content: space-between;
+}
+
+.section-list {
+  margin: 40px 0;
+}
+
+.section-list-item:first-child {
+  border-top: 1px solid $border-color;
+}
+
+.section-list--collapsed .section-list-item:nth-child(1n + 6) {
+  display: none;
+}
+
+.section-list-item {
+  border-bottom: 1px solid $border-color;
+  font-size: $font-size-bigger;
+  padding: 15px 0;
+}
+
+.section-list-item a {
+  align-items: center;
+  color: $text_color;
+  display: flex;
+  justify-content: space-between;
+}
+
+.see-all-sections-trigger {
+  display: block;
+  padding: 15px;
+  text-align: center;
+}
+
+.see-all-sections-trigger[aria-hidden="true"] {
+  display: none;
 }

--- a/styles/_section.scss
+++ b/styles/_section.scss
@@ -23,31 +23,6 @@
   margin: 40px 0;
 }
 
-.section-list-item:first-child {
-  border-top: 1px solid $border-color;
-}
-
-.section-list-item {
-  border-bottom: 1px solid $border-color;
-  font-size: $font-size-bigger;
-  padding: 15px 0;
-}
-
-.section-list-item a {
-  align-items: center;
-  color: $text_color;
-  display: flex;
-  justify-content: space-between;
-}
-
-.section-list {
-  margin: 40px 0;
-}
-
-.section-list-item:first-child {
-  border-top: 1px solid $border-color;
-}
-
 .section-list--collapsed .section-list-item:nth-child(1n + 6) {
   display: none;
 }
@@ -56,13 +31,17 @@
   border-bottom: 1px solid $border-color;
   font-size: $font-size-bigger;
   padding: 15px 0;
-}
 
-.section-list-item a {
-  align-items: center;
-  color: $text_color;
-  display: flex;
-  justify-content: space-between;
+  &:first-child {
+    border-top: 1px solid $border-color;
+  }
+
+  a {
+    align-items: center;
+    color: $text_color;
+    display: flex;
+    justify-content: space-between;
+  }
 }
 
 .see-all-sections-trigger {
@@ -70,8 +49,8 @@
   display: block;
   padding: 15px;
   text-align: center;
-}
 
-.see-all-sections-trigger[aria-hidden="true"] {
-  display: none;
+  &[aria-hidden="true"] {
+    display: none;
+  }
 }

--- a/templates/category_page.hbs
+++ b/templates/category_page.hbs
@@ -39,10 +39,6 @@
                   {{t 'show_all_articles' count=article_count}}
                 </a>
               {{/if}}
-            {{else}}
-              <i class="section-empty">
-                <a href="{{url}}">{{t 'empty'}}</a>
-              </i>
             {{/if}}
           </section>
         {{else}}

--- a/templates/section_page.hbs
+++ b/templates/section_page.hbs
@@ -19,6 +19,22 @@
         {{/if}}
       </header>
 
+      {{#if section.sections}}
+        <ul class="section-list section-list--collapsed">
+          {{#each section.sections}}
+          <li class="section-list-item">
+              <a href="{{url}}">
+                <span>{{name}}</span>
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" focusable="false" viewBox="0 0 16 16" aria-hidden="true">
+                  <path fill="none" stroke="currentColor" stroke-linecap="round" stroke-width="2" d="M5 14.5l6.1-6.1c.2-.2.2-.5 0-.7L5 1.5"/>
+                </svg>
+              </a>
+            </li>
+          {{/each}}
+          <a tabindex="0" class="see-all-sections-trigger" aria-hidden="true" id="see-all-sections-trigger" title="{{t 'see_all_sections'}}">{{t 'see_all_sections'}}</a>
+        </ul>
+      {{/if}}
+
 
       {{#if section.articles}}
         <ul class="article-list">
@@ -41,6 +57,7 @@
       {{/if}}
 
       {{pagination}}
+
     </section>
   </div>
 </div>


### PR DESCRIPTION
~For the upcoming feature of flexible hierarchies we are exposing the sections that are direct children of a section, as well as its articles.
I'm taking the section tree html from the category page and added it to the section page.~

Update:
After talking to product and design, the template design has changed, adding the subsections at the top, therefore keeping the pagination at the bottom.
It also adds an interaction with the subsections list that displays only the first 6 subsections and displays a "See all sections..." trigger to show them all.
There are many ways to do this, and I'm a little bit rusty on semantic HTML and a11y, so please let me know if you have any concerns.

The new designs also removed the border from the article list.

 Some decisions that were made:
- Using an inline SVG for the chevron icon. Reference: https://css-tricks.com/can-make-icon-system-accessible/
- Hiding the sections after the 6th one with CSS

Impacted templates:
- Category
![Screenshot 2019-03-22 at 10 19 14](https://user-images.githubusercontent.com/1421493/54813860-ca9f1100-4c8e-11e9-9322-4241f20ff311.png)

- Section with more than 6 subsections
![Screenshot 2019-03-22 at 10 19 20](https://user-images.githubusercontent.com/1421493/54813895-e0acd180-4c8e-11e9-8e71-29fde5673794.png)
![subsections](https://user-images.githubusercontent.com/1421493/54813907-e7d3df80-4c8e-11e9-97a2-fb838b4c6c33.gif)

- Section with less than 6 subsections
![Screenshot 2019-03-22 at 10 21 46](https://user-images.githubusercontent.com/1421493/54813923-f3270b00-4c8e-11e9-8c44-ae8688862bbd.png)

- Section without subsections
![Screenshot 2019-03-22 at 10 40 58](https://user-images.githubusercontent.com/1421493/54813945-0043fa00-4c8f-11e9-8361-d4c64ff75adb.png)
