### PR TITLE
[PUB-1270] Do not render anchor tag on empty breadcrumb pieces

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Copenhagen",
   "author": "Zendesk",
-  "version": "1.4.17",
+  "version": "1.4.18",
   "api_version": 1,
   "default_locale": "en-us",
   "settings": [{

--- a/templates/search_results.hbs
+++ b/templates/search_results.hbs
@@ -27,7 +27,11 @@
                 <li>
                   <ol class="breadcrumbs search-result-breadcrumbs">
                     {{#each path_steps}}
-                      <li title="{{name}}"><a href="{{url}}">{{name}}</a></li>
+                      {{#is url '#'}}
+                        <li title="{{name}}">{{name}}</li>
+                      {{else}}
+                        <li title="{{name}}"><a href="{{url}}">{{name}}</a></li>
+                      {{/is}}
                     {{/each}}
                   </ol>
                 </li>


### PR DESCRIPTION
The `path_steps` helper already returns '#' for the URL and '...' as name when a breadcrumb piece is a set of truncated items. We don't need these elipsis to have an anchor tag that points to nowhere.

* See JIRA: [PUB-1270: Remove link from ellipsis in search results in Copenhagen theme](https://zendesk.atlassian.net/browse/PUB-1270)