### PR TITLE
ZD#4402185 Fix splitting of the results search page

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Copenhagen",
   "author": "Zendesk",
-  "version": "1.4.18",
+  "version": "1.4.19",
   "api_version": 1,
   "default_locale": "en-us",
   "settings": [{

--- a/style.css
+++ b/style.css
@@ -4028,6 +4028,7 @@ ul {
 
 .search-result-description {
   margin-top: 15px;
+  word-break: break-word;
 }
 
 .search-result-votes, .search-result-meta-count {

--- a/styles/_search_results.scss
+++ b/styles/_search_results.scss
@@ -33,6 +33,7 @@
 
   &-description {
     margin-top: 15px;
+    word-break: break-word;
   }
 
   &-votes,


### PR DESCRIPTION
Fixes a layout issues when the result snippet contains a word that's too long.

Before:
https://cl.ly/c9e09a3fc39f

After:
https://cl.ly/2e345b324d22






@zendesk/guide-search 
@zendesk/guide-growth 