### PR TITLE
Remove unused styling for Google+ share button

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Copenhagen",
   "author": "Zendesk",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "api_version": 1,
   "default_locale": "en-us",
   "settings": [{

--- a/style.css
+++ b/style.css
@@ -1648,10 +1648,6 @@ ul {
   content: "\e900";
 }
 
-.share-googleplus::before {
-  content: "\e902";
-}
-
 /***** Comments *****/
 /* Styles comments inside articles, posts and requests */
 .comment {

--- a/styles/_share.scss
+++ b/styles/_share.scss
@@ -42,7 +42,3 @@
 .share-linkedin::before {
   content: "\e900";
 }
-
-.share-googleplus::before {
-  content: "\e902";
-}


### PR DESCRIPTION
Google+ share button is no longer in HC as of today, this PR removes redundant styling for that button.

/cc: @zendesk/guide-growth 