### PR TITLE
[GS-458] Change snippet highlight for non-latin languages

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Copenhagen",
   "author": "Zendesk",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "api_version": 1,
   "default_locale": "en-us",
   "settings": [{

--- a/style.css
+++ b/style.css
@@ -4117,7 +4117,7 @@ ul {
   margin: 0 5px;
 }
 
-/* Non-latin search results highlight*/
+/* Non-latin search results highlight */
 /* Add a yellow background for Chinese */
 html[lang|="zh"] .search-result-description em {
   font-style: normal;

--- a/style.css
+++ b/style.css
@@ -4117,11 +4117,22 @@ ul {
   margin: 0 5px;
 }
 
-/* Don't display CJK results in italic */
-/* Add a yellow background instead */
-html[lang|="zh"] .search-result-description em,
-html[lang|="ko"] .search-result-description em,
-html[lang|="ja"] .search-result-description em {
+/* Non-latin search results highlight*/
+/* Add a yellow background for Chinese */
+html[lang|="zh"] .search-result-description em {
   font-style: normal;
   background: yellow;
+}
+
+/* Use bold to highlight for the rest of supported non-latin languages */
+html[lang|="ar"] .search-result-description em,
+html[lang|="bg"] .search-result-description em,
+html[lang|="el"] .search-result-description em,
+html[lang|="he"] .search-result-description em,
+html[lang|="hi"] .search-result-description em,
+html[lang|="ko"] .search-result-description em,
+html[lang|="ja"] .search-result-description em,
+html[lang|="ru"] .search-result-description em,
+html[lang|="th"] .search-result-description em {
+  font-style: bold;
 }

--- a/styles/_search_results.scss
+++ b/styles/_search_results.scss
@@ -88,7 +88,7 @@
   }
 }
 
-/* Non-latin search results highlight*/
+/* Non-latin search results highlight */
 
 /* Add a yellow background for Chinese */
 html[lang|="zh"] {

--- a/styles/_search_results.scss
+++ b/styles/_search_results.scss
@@ -88,13 +88,27 @@
   }
 }
 
-/* Don't display CJK results in italic */
-/* Add a yellow background instead */
-html[lang|="zh"],
-html[lang|="ko"],
-html[lang|="ja"] {
+/* Non-latin search results highlight*/
+
+/* Add a yellow background for Chinese */
+html[lang|="zh"] {
   .search-result-description em {
     font-style: normal;
     background: yellow;
+  }
+}
+
+/* Use bold to highlight for the rest of supported non-latin languages */
+html[lang|="ar"],
+html[lang|="bg"],
+html[lang|="el"],
+html[lang|="he"],
+html[lang|="hi"],
+html[lang|="ko"],
+html[lang|="ja"],
+html[lang|="ru"],
+html[lang|="th"] {
+  .search-result-description em {
+    font-style: bold;
   }
 }


### PR DESCRIPTION
#### Description

As a continuation from #69 I've changed the way we highlight search results for all the supported non-latin languages. I've used Google as inspiration for this (huehue). 

They show a different background colour for Chinese, and show all the rest of the languages in bold.

@zendesk/guide-growth @zendesk/guide-search 