### PR TITLE
Fix color contrast for status labels, unify color with support and garden

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Copenhagen",
   "author": "Zendesk",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "api_version": 1,
   "default_locale": "en-us",
   "settings": [{

--- a/style.css
+++ b/style.css
@@ -2232,6 +2232,7 @@ ul {
   border-radius: 4px;
   color: #fff;
   font-size: 12px;
+  font-weight: 600;
   margin-right: 2px;
   padding: 3px 10px;
   vertical-align: middle;
@@ -2270,29 +2271,27 @@ ul {
   right: auto;
 }
 
-.status-label-pending, .status-label-not-planned {
-  background-color: #eee;
+.status-label-not-planned, .status-label-closed {
+  background-color: #e9ebed;
   color: lighten($text_color, 20%);
 }
 
 .status-label-pending {
+  background-color: #1f73b7;
   text-align: center;
 }
 
 .status-label-open {
-  background-color: #cc3340;
-}
-
-.status-label-closed {
-  background-color: #ddd;
+  background-color: #c72a1c;
 }
 
 .status-label-solved {
-  background-color: #999;
+  background-color: #68737d;
 }
 
 .status-label-new {
-  background-color: #ffd12a;
+  background-color: #ffb648;
+  color: #703b15;
 }
 
 .status-label-hold {

--- a/styles/_status-label.scss
+++ b/styles/_status-label.scss
@@ -5,6 +5,7 @@
   border-radius: 4px;
   color: #fff;
   font-size: 12px;
+  font-weight: 600;
   margin-right: 2px;
   padding: 3px 10px;
   vertical-align: middle;
@@ -44,31 +45,28 @@
     }
   }
 
-  &-pending,
-  &-not-planned {
-    background-color: #eee;
+  &-not-planned,
+  &-closed {
+    background-color: #e9ebed;
     color: $secondary-text-color;
   }
 
   &-pending {
+    background-color: #1f73b7;
     text-align: center;
   }
 
   &-open {
-    background-color: #cc3340;
-  }
-
-
-  &-closed {
-    background-color: #ddd;
+    background-color: #c72a1c;
   }
 
   &-solved {
-    background-color: #999;
+    background-color: #68737d;
   }
 
   &-new {
-    background-color: #ffd12a;
+    background-color: #ffb648;
+    color: #703b15;
   }
 
   &-hold {


### PR DESCRIPTION
During a11y audit we figured out that some status labels had poor color contrast.
I tried unifying color with what we use in Support (`pending` status uses blue, `new` status uses yellow + red) and what closest accessible versions are available in Graden.
Also I've set `font-weight` to `600` as we do in Support and in `tag` component in Garden.

Reference: https://zendesk.atlassian.net/browse/HCJ-1946