### PR TITLE
Add check in case quick search element is not present

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Copenhagen",
   "author": "Zendesk",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "api_version": 1,
   "default_locale": "en-us",
   "settings": [{

--- a/script.js
+++ b/script.js
@@ -115,7 +115,8 @@ document.addEventListener('DOMContentLoaded', function() {
   });
 
   // Submit requests filter form on search in the request list page
-  document.querySelector('#quick-search').addEventListener('keyup', function(e) {
+  var quickSearch = document.querySelector('#quick-search');
+  quickSearch && quickSearch.addEventListener('keyup', function(e) {
     if (e.keyCode === 13) { // Enter key
       e.stopPropagation();
       saveFocus();


### PR DESCRIPTION
As `script.js` is included in all pages, `#quick-search` is not always present on the page. The PR adds a check to guard from this.