### PR TITLE
Fix color contrast for default status label

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Copenhagen",
   "author": "Zendesk",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "api_version": 1,
   "default_locale": "en-us",
   "settings": [{

--- a/style.css
+++ b/style.css
@@ -2228,7 +2228,7 @@ ul {
 /***** Status labels *****/
 /* Styles labels used in posts, articles and requests */
 .status-label {
-  background-color: #1eb848;
+  background-color: #038153;
   border-radius: 4px;
   color: #fff;
   font-size: 12px;

--- a/styles/_status-label.scss
+++ b/styles/_status-label.scss
@@ -1,7 +1,7 @@
 /***** Status labels *****/
 /* Styles labels used in posts, articles and requests */
 .status-label {
-  background-color: #1eb848;
+  background-color: #038153;
   border-radius: 4px;
   color: #fff;
   font-size: 12px;


### PR DESCRIPTION
Following up on https://github.com/zendesk/copenhagen_theme/pull/84

Default background color for status icon also has insufficient color contrast. I'm suggesting to use `#058541` instead.

![Screenshot 2019-06-12 at 15 36 27](https://user-images.githubusercontent.com/1819404/59355742-de0ac700-8d27-11e9-8d4e-7ba7d55e0062.png)
