### PR TITLE
[COMM-145] Add classes to differentiate the meta data in user profiles page

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Copenhagen",
   "author": "Zendesk",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "api_version": 1,
   "default_locale": "en-us",
   "settings": [{

--- a/templates/user_profile_page.hbs
+++ b/templates/user_profile_page.hbs
@@ -147,14 +147,14 @@
 
                       <ul class="meta-group">
                         {{#is object_type 'comment'}}
-                          <li class="meta-data">
+                          <li class="meta-data comment">
                             <a class="comment-link" href={{url}}>{{t 'view_comment'}}</a>
                           </li>
                         {{/is}}
-                        <li class="meta-data">{{author.name}}</li>
+                        <li class="meta-data author">{{author.name}}</li>
                         {{#if editor}}
-                          <li class="meta-data">{{date edited_at timeago=true}}</li>
-                          <li class="meta-data">
+                          <li class="meta-data edit-date">{{date edited_at timeago=true}}</li>
+                          <li class="meta-data edit-action">
                             {{#is object_type 'article'}}
                               {{t 'updated'}}
                             {{else}}
@@ -162,10 +162,10 @@
                             {{/is}}
                           </li>
                         {{else}}
-                          <li class="meta-data">{{date created_at timeago=true}}</li>
+                          <li class="meta-data create-date">{{date created_at timeago=true}}</li>
                         {{/if}}
                         {{#each stats}}
-                          <li class="meta-data">{{label}}</li>
+                          <li class="meta-data stat-label">{{label}}</li>
                         {{/each}}
                       </ul>
                     </div>
@@ -242,14 +242,14 @@
 
                   <ul class="meta-group">
                     {{#is object_type 'comment'}}
-                      <li class="meta-data">
+                      <li class="meta-data comment">
                         <a class="comment-link" href={{url}}>{{t 'view_comment'}}</a>
                       </li>
                     {{/is}}
-                    <li class="meta-data">{{author.name}}</li>
+                    <li class="meta-data author">{{author.name}}</li>
                     {{#if editor}}
-                      <li class="meta-data">{{date edited_at timeago=true}}</li>
-                      <li class="meta-data">
+                      <li class="meta-data edit-date">{{date edited_at timeago=true}}</li>
+                      <li class="meta-data edit-action">
                         {{#is object_type 'article'}}
                           {{t 'updated'}}
                         {{else}}
@@ -257,10 +257,10 @@
                         {{/is}}
                       </li>
                     {{else}}
-                      <li class="meta-data">{{date created_at timeago=true}}</li>
+                      <li class="meta-data create-date">{{date created_at timeago=true}}</li>
                     {{/if}}
                     {{#each stats}}
-                      <li class="meta-data">{{label}}</li>
+                      <li class="meta-data stat-label">{{label}}</li>
                     {{/each}}
                   </ul>
                 </li>


### PR DESCRIPTION
@TetianaG, what would be the most appropriate way to distinguish between different meta data in the user profile page with regards to browser testing?

JIRA: [COMM-145]

[COMM-145]: https://zendesk.atlassian.net/browse/COMM-145