### PR TITLE
Collapse multibrand filters when there are more than 5 items

### DIFF
--- a/script.js
+++ b/script.js
@@ -200,4 +200,21 @@ document.addEventListener('DOMContentLoaded', function() {
       seeAllTrigger.parentNode.removeChild(seeAllTrigger);
     });
   }
+
+  // If multibrand search has more than 5 help centers or categories collapse the list
+  const multibrandFilterLists = document.querySelectorAll(".multibrand-filter-list");
+  Array.prototype.forEach.call(multibrandFilterLists, function(filter) {
+    if (filter.children.length > 5) {
+      // Display the show more button
+      var trigger = filter.querySelector(".see-all-filters-trigger");
+      trigger.setAttribute("aria-hidden", false);
+
+      // Add event handler for click
+      trigger.addEventListener("click", function(e) {
+        e.stopPropagation();
+        trigger.parentNode.removeChild(trigger);
+        filter.classList.remove("multibrand-filter-list--collapsed")
+      })
+    }
+  });
 });

--- a/script.js
+++ b/script.js
@@ -206,7 +206,7 @@ document.addEventListener('DOMContentLoaded', function() {
   Array.prototype.forEach.call(multibrandFilterLists, function(filter) {
     if (filter.children.length > 5) {
       // Display the show more button
-      var trigger = filter.querySelector(".see-all-filters-trigger");
+      var trigger = filter.querySelector(".see-all-filters");
       trigger.setAttribute("aria-hidden", false);
 
       // Add event handler for click

--- a/style.css
+++ b/style.css
@@ -4096,28 +4096,33 @@ ul {
   }
 }
 
-.search-results-sidebar .sidenav-item[aria-selected="true"] {
-  background-color: $brand_color;
-  color: $brand_text_color;
+.search-results-sidebar .sidenav-item:hover, .search-results-sidebar .sidenav-item[aria-selected="true"] {
+  background-color: #e9ebed;
+  color: inherit;
   text-decoration: none;
 }
 
 .search-results-sidebar .collapsible-sidebar {
-  padding-bottom: 15px;
+  margin-bottom: 30px;
 }
 
 .search-results-sidebar .multibrand-filter-list--collapsed li:nth-child(1n + 6) {
   display: none;
 }
 
-.search-results-sidebar .see-all-filters-trigger {
+.search-results-sidebar .see-all-filters {
   cursor: pointer;
   display: block;
   padding: 10px;
 }
 
-.search-results-sidebar .see-all-filters-trigger[aria-hidden="true"] {
+.search-results-sidebar .see-all-filters[aria-hidden="true"] {
   display: none;
+}
+
+.search-results-sidebar .see-all-filters:after {
+  content: ' \2304';
+  font-weight: bold;
 }
 
 .search-results-subheading {
@@ -4206,22 +4211,14 @@ ul {
   margin: 0 5px;
 }
 
-/* Non-latin search results highlight */
-/* Add a yellow background for Chinese */
-html[lang|="zh"] .search-result-description em {
+/* By default use bold instead of italic to highlight */
+.search-results-description em {
   font-style: normal;
-  background: yellow;
+  font-weight: bold;
 }
 
-/* Use bold to highlight for the rest of supported non-latin languages */
-html[lang|="ar"] .search-result-description em,
-html[lang|="bg"] .search-result-description em,
-html[lang|="el"] .search-result-description em,
-html[lang|="he"] .search-result-description em,
-html[lang|="hi"] .search-result-description em,
-html[lang|="ko"] .search-result-description em,
-html[lang|="ja"] .search-result-description em,
-html[lang|="ru"] .search-result-description em,
-html[lang|="th"] .search-result-description em {
-  font-style: bold;
+/* Add a yellow background for Chinese */
+html[lang|="zh"] .search-results-description em {
+  font-style: normal;
+  background: yellow;
 }

--- a/style.css
+++ b/style.css
@@ -4102,6 +4102,24 @@ ul {
   text-decoration: none;
 }
 
+.search-results-sidebar .collapsible-sidebar {
+  padding-bottom: 15px;
+}
+
+.search-results-sidebar .multibrand-filter-list--collapsed li:nth-child(1n + 6) {
+  display: none;
+}
+
+.search-results-sidebar .see-all-filters-trigger {
+  cursor: pointer;
+  display: block;
+  padding: 10px;
+}
+
+.search-results-sidebar .see-all-filters-trigger[aria-hidden="true"] {
+  display: none;
+}
+
 .search-results-subheading {
   font-size: 18px;
   font-weight: 600;

--- a/styles/_search_results.scss
+++ b/styles/_search_results.scss
@@ -34,6 +34,24 @@
       color: $brand_text_color;
       text-decoration: none;
     }
+
+    .collapsible-sidebar {
+      padding-bottom: 15px;
+    }
+
+    .multibrand-filter-list--collapsed li:nth-child(1n + 6) {
+      display: none;
+    }
+
+    .see-all-filters-trigger {
+      cursor: pointer;
+      display: block;
+      padding: 10px;
+
+      &[aria-hidden="true"] {
+        display: none;
+      }
+    }
   }
 
   &-subheading {

--- a/styles/_search_results.scss
+++ b/styles/_search_results.scss
@@ -29,27 +29,35 @@
       height: auto;
     }
 
-    .sidenav-item[aria-selected="true"] {
-      background-color: $brand_color;
-      color: $brand_text_color;
-      text-decoration: none;
+    .sidenav-item {
+      &:hover,
+      &[aria-selected="true"] {
+        background-color: #e9ebed;
+        color: inherit;
+        text-decoration: none;
+      }
     }
 
     .collapsible-sidebar {
-      padding-bottom: 15px;
+      margin-bottom: 30px;
     }
 
     .multibrand-filter-list--collapsed li:nth-child(1n + 6) {
       display: none;
     }
 
-    .see-all-filters-trigger {
+    .see-all-filters {
       cursor: pointer;
       display: block;
       padding: 10px;
 
       &[aria-hidden="true"] {
         display: none;
+      }
+
+      &:after {
+        content: ' \2304';
+        font-weight: bold;
       }
     }
   }
@@ -142,27 +150,16 @@
   }
 }
 
-/* Non-latin search results highlight */
+/* By default use bold instead of italic to highlight */
+.search-results-description em {
+  font-style: normal;
+  font-weight: bold;
+}
 
 /* Add a yellow background for Chinese */
 html[lang|="zh"] {
-  .search-result-description em {
+  .search-results-description em {
     font-style: normal;
     background: yellow;
-  }
-}
-
-/* Use bold to highlight for the rest of supported non-latin languages */
-html[lang|="ar"],
-html[lang|="bg"],
-html[lang|="el"],
-html[lang|="he"],
-html[lang|="hi"],
-html[lang|="ko"],
-html[lang|="ja"],
-html[lang|="ru"],
-html[lang|="th"] {
-  .search-result-description em {
-    font-style: bold;
   }
 }

--- a/templates/search_results.hbs
+++ b/templates/search_results.hbs
@@ -17,7 +17,7 @@
                 <a href="{{url}}" class="sidenav-item" aria-selected="{{selected}}">{{name}} ({{count}})</a>
               </li>
             {{/each}}
-            <a tabindex="0" class="see-all-filters-trigger" aria-hidden="true" title="{{t 'see_more'}}">{{t 'see_more'}}</a>
+            <a tabindex="0" class="see-all-filters" aria-hidden="true" title="{{t 'show_more_help_centers'}}">{{t 'show_more_help_centers'}}</a>
           </ul>
         </section>
       {{/if}}
@@ -49,7 +49,12 @@
                 <a href="{{url}}" class="sidenav-item" aria-selected="{{selected}}">{{name}} ({{count}})</a>
               </li>
             {{/each}}
-            <a tabindex="0" class="see-all-filters-trigger" aria-hidden="true" title="{{t 'see_more'}}">{{t 'see_more'}}</a>
+            {{#is current_filter.identifier 'knowledge_base'}}
+              <a tabindex="0" class="see-all-filters" aria-hidden="true" title="{{t 'show_more_categories'}}">{{t 'show_more_categories'}}</a>
+            {{/is}}
+            {{#is current_filter.identifier 'community'}}
+              <a tabindex="0" class="see-all-filters" aria-hidden="true" title="{{t 'show_more_topics'}}">{{t 'show_more_topics'}}</a>
+            {{/is}}
           </ul>
         </section>
       {{/if}}

--- a/templates/search_results.hbs
+++ b/templates/search_results.hbs
@@ -9,18 +9,21 @@
     <section class="search-results-sidebar">
       {{#if help_center_filters}}
         <section class="filters-in-section collapsible-sidebar">
+          <button type="button" class="collapsible-sidebar-toggle" aria-expanded="false"></button>
           <h3 class="collapsible-sidebar-title sidenav-title">{{t 'filter_by_help_center'}}</h3>
-          <ul>
+          <ul class="multibrand-filter-list multibrand-filter-list--collapsed">
             {{#each help_center_filters}}
               <li>
                 <a href="{{url}}" class="sidenav-item" aria-selected="{{selected}}">{{name}} ({{count}})</a>
               </li>
             {{/each}}
+            <a tabindex="0" class="see-all-filters-trigger" aria-hidden="true" title="{{t 'see_more'}}">{{t 'see_more'}}</a>
           </ul>
         </section>
       {{/if}}
       {{#if help_center.community_enabled}}
         <section class="filters-in-section collapsible-sidebar">
+          <button type="button" class="collapsible-sidebar-toggle" aria-expanded="false"></button>
           <h3 class="collapsible-sidebar-title sidenav-title">{{t 'filter_by_type'}}</h3>
           <ul>
             {{#each filters}}
@@ -33,18 +36,20 @@
       {{/if}}
       {{#if subfilters}}
         <section class="filters-in-section collapsible-sidebar">
+          <button type="button" class="collapsible-sidebar-toggle" aria-expanded="false"></button>
           {{#is current_filter.identifier 'knowledge_base'}}
             <h3 class="collapsible-sidebar-title sidenav-title">{{t 'filter_by_category'}}</h3>
           {{/is}}
           {{#is current_filter.identifier 'community'}}
             <h3 class="collapsible-sidebar-title sidenav-title">{{t 'filter_by_topic'}}</h3>
           {{/is}}
-          <ul>
+          <ul class="multibrand-filter-list multibrand-filter-list--collapsed">
             {{#each subfilters}}
               <li>
                 <a href="{{url}}" class="sidenav-item" aria-selected="{{selected}}">{{name}} ({{count}})</a>
               </li>
             {{/each}}
+            <a tabindex="0" class="see-all-filters-trigger" aria-hidden="true" title="{{t 'see_more'}}">{{t 'see_more'}}</a>
           </ul>
         </section>
       {{/if}}


### PR DESCRIPTION
Collapse multibrand search filters when there are more than 5 help centers or categories:

<img width="912" alt="Screen Shot 2019-08-21 at 20 08 45" src="https://user-images.githubusercontent.com/36034626/63456563-87201d00-c44f-11e9-9786-1518f65c9176.png">

And expand it when user clicks the button:

<img width="895" alt="Screen Shot 2019-08-21 at 20 10 19" src="https://user-images.githubusercontent.com/36034626/63456673-be8ec980-c44f-11e9-998d-8bfada4eb5e9.png">

This is a refined version of @ellimist's original branch.

Without toggle button our SERP looks like this in mobile web:
<img width="388" alt="Screen Shot 2019-08-22 at 14 39 38" src="https://user-images.githubusercontent.com/36034626/63710960-ae556080-c83a-11e9-8272-d1c17cb0f4e9.png">
Note that there is no way to expand filters.

With toggle button it looks like this in mobile web:
<img width="376" alt="Screen Shot 2019-08-26 at 19 51 24" src="https://user-images.githubusercontent.com/36034626/63711085-f4122900-c83a-11e9-9d69-36ec5e816c5e.png">
Once user clicks it, he/she will see all help centers or categories or topics.