### PR TITLE
Moderator actions: flagged, hidden

### DIFF
--- a/style.css
+++ b/style.css
@@ -2291,6 +2291,16 @@ ul {
   text-align: center;
 }
 
+.status-label-flagged {
+  background-color: #dea639;
+  text-align: center;
+}
+
+.status-label-hidden {
+  background-color: #c07160;
+  text-align: center;
+}
+
 .status-label-open {
   background-color: #c72a1c;
 }

--- a/styles/_status-label.scss
+++ b/styles/_status-label.scss
@@ -56,6 +56,16 @@
     text-align: center;
   }
 
+  &-flagged {
+    background-color: #dea639;
+    text-align: center;
+  }
+
+  &-hidden {
+    background-color: #c07160;
+    text-align: center;
+  }
+
   &-open {
     background-color: #c72a1c;
   }

--- a/templates/article_page.hbs
+++ b/templates/article_page.hbs
@@ -192,6 +192,12 @@
                           {{#if pending}}
                             <span class="comment-pending status-label status-label-pending">{{t 'pending_approval'}}</span>
                           {{/if}}
+                          {{#if flagged}}
+                            <span class="comment-flagged status-label status-label-flagged">{{t 'comment_flagged'}}</span>
+                          {{/if}}
+                          {{#if hidden}}
+                            <span class="comment-hidden status-label status-label-hidden">{{t 'comment_hidden'}}</span>
+                          {{/if}}
                         </div>
                       </div>
 

--- a/templates/community_post_list_page.hbs
+++ b/templates/community_post_list_page.hbs
@@ -79,6 +79,14 @@
                 <span class="status-label status-label-featured">{{t 'featured'}}</span>
               {{/if}}
 
+              {{#if flagged}}
+                <span class="status-label status-label-flagged">{{t 'post_flagged'}}</span>
+              {{/if}}
+
+              {{#if hidden}}
+                <span class="status-label status-label-hidden">{{t 'post_hidden'}}</span>
+              {{/if}}
+
               {{#is status 'none'}}
               {{else}}
                 <span class="status-label-{{status_dasherized}} status-label striped-list-status">{{status_name}}</span>

--- a/templates/community_post_page.hbs
+++ b/templates/community_post_page.hbs
@@ -170,6 +170,7 @@
                         {{t 'request'}} {{id}}
                       </a>
                     {{/with}}
+
                     {{#if pending}}
                       <span class="comment-pending status-label status-label-pending">{{t 'pending_approval'}}</span>
                     {{/if}}

--- a/templates/community_post_page.hbs
+++ b/templates/community_post_page.hbs
@@ -24,6 +24,14 @@
               <span class="status-label status-label-featured">{{t 'featured'}}</span>
             {{/if}}
 
+            {{#if post.flagged}}
+              <span class="status-label status-label-flagged">{{t 'post_flagged'}}</span>
+            {{/if}}
+
+            {{#if post.hidden}}
+              <span class="status-label status-label-hidden">{{t 'post_hidden'}}</span>
+            {{/if}}
+
             {{#is post.status 'none'}}
             {{else}}
               <span class="status-label-{{post.status_dasherized}} status-label">{{post.status_name}}</span>
@@ -164,6 +172,12 @@
                     {{/with}}
                     {{#if pending}}
                       <span class="comment-pending status-label status-label-pending">{{t 'pending_approval'}}</span>
+                    {{/if}}
+                    {{#if flagged}}
+                      <span class="comment-flagged status-label status-label-flagged">{{t 'comment_flagged'}}</span>
+                    {{/if}}
+                    {{#if hidden}}
+                      <span class="comment-hidden status-label status-label-hidden">{{t 'comment_hidden'}}</span>
                     {{/if}}
                   </div>
                 </div>

--- a/templates/community_topic_page.hbs
+++ b/templates/community_topic_page.hbs
@@ -69,6 +69,14 @@
                 <span class="status-label status-label-featured">{{t 'featured'}}</span>
               {{/if}}
 
+              {{#if flagged}}
+                <span class="status-label status-label-flagged">{{t 'post_flagged'}}</span>
+              {{/if}}
+
+              {{#if hidden}}
+                <span class="status-label status-label-hidden">{{t 'post_hidden'}}</span>
+              {{/if}}
+
               {{#is status 'none'}}
               {{else}}
                 <span class="status-label-{{status_dasherized}} status-label striped-list-status">{{status_name}}</span>

--- a/templates/user_profile_page.hbs
+++ b/templates/user_profile_page.hbs
@@ -132,6 +132,22 @@
                           <span class="status-label status-label-pending">{{t 'pending_approval'}}</span>
                         {{/if}}
 
+                        {{#if flagged}}
+                          {{#is object_type 'post'}}
+                            <span class="status-label status-label-flagged">{{t 'post_flagged'}}</span>
+                          {{else}}
+                            <span class="status-label status-label-flagged">{{t 'comment_flagged'}}</span>
+                          {{/is}}
+                        {{/if}}
+
+                        {{#if hidden}}
+                          {{#is object_type 'post'}}
+                            <span class="status-label status-label-hidden">{{t 'post_hidden'}}</span>
+                          {{else}}
+                            <span class="status-label status-label-hidden">{{t 'comment_hidden'}}</span>
+                          {{/is}}
+                        {{/if}}
+
                         {{#if official}}
                           <span class="status-label status-label-official">{{t 'official_comment'}}</span>
                         {{/if}}
@@ -225,6 +241,22 @@
 
                     {{#if pending}}
                       <span class="status-label status-label-pending">{{t 'pending_approval'}}</span>
+                    {{/if}}
+
+                    {{#if flagged}}
+                      {{#is object_type 'post'}}
+                        <span class="status-label status-label-flagged">{{t 'post_flagged'}}</span>
+                      {{else}}
+                        <span class="status-label status-label-flagged">{{t 'comment_flagged'}}</span>
+                      {{/is}}
+                    {{/if}}
+
+                    {{#if hidden}}
+                      {{#is object_type 'post'}}
+                        <span class="status-label status-label-hidden">{{t 'post_hidden'}}</span>
+                      {{else}}
+                        <span class="status-label status-label-hidden">{{t 'comment_hidden'}}</span>
+                      {{/is}}
                     {{/if}}
 
                     {{#if official}}


### PR DESCRIPTION
DO NOT MERGE YET (because the help center master branch does not yet expose the provided data)

Support the upcoming "flagged" and "hidden" properties of community posts, community comments, and article comments. The presenters will expose "flagged" and "hidden"; these booleans are independent. "flagged" will be false if you do not have permission to see flagged-ness; likewise for "hidden".

Currently the translations for the labels are separate for posts vs comments; maybe it would be better if that weren't the case?
