### PR TITLE
Align the styles of multibrand SERP with the design

### DIFF
--- a/style.css
+++ b/style.css
@@ -4110,6 +4110,18 @@ ul {
   display: none;
 }
 
+.search-results-sidebar .multibrand-filter-list .doc-count {
+  color: #999;
+}
+
+.search-results-sidebar .multibrand-filter-list .doc-count::before {
+  content: "(";
+}
+
+.search-results-sidebar .multibrand-filter-list .doc-count::after {
+  content: ")";
+}
+
 .search-results-sidebar .see-all-filters {
   cursor: pointer;
   display: block;
@@ -4120,7 +4132,7 @@ ul {
   display: none;
 }
 
-.search-results-sidebar .see-all-filters:after {
+.search-results-sidebar .see-all-filters::after {
   content: ' \2304';
   font-weight: bold;
 }
@@ -4146,14 +4158,37 @@ ul {
   margin-bottom: 0;
 }
 
+.search-results .meta-group {
+  display: flex;
+  align-items: center;
+  clear: right;
+  color: #999;
+}
+
+.search-results .meta-group li:first-child {
+  margin-right: auto;
+}
+
+.search-results .meta-group .meta-data {
+  color: inherit;
+}
+
+.search-results .meta-group .meta-data:not(:last-child) {
+  margin-right: 20px;
+}
+
+.search-results .meta-group .meta-data::after {
+  content: none;
+}
+
+.search-results-description {
+  margin-top: 10px;
+  word-break: break-word;
+}
+
 .search-result-title {
   font-size: 16px;
   display: inline-block;
-}
-
-.search-result-description {
-  margin-top: 15px;
-  word-break: break-word;
 }
 
 .search-result-icons {
@@ -4202,13 +4237,16 @@ ul {
 }
 
 .search-result-breadcrumbs {
+  display: table-row;
   margin: 0;
 }
 
-.search-result-breadcrumbs li:last-child::after {
-  content: "·";
-  display: inline-block;
-  margin: 0 5px;
+.search-result-breadcrumbs li {
+  display: table-cell;
+}
+
+.search-result-breadcrumbs li, .search-result-breadcrumbs li a, .search-result-breadcrumbs li a:visited {
+  color: inherit;
 }
 
 /* By default use bold instead of italic to highlight */

--- a/styles/_search_results.scss
+++ b/styles/_search_results.scss
@@ -46,6 +46,18 @@
       display: none;
     }
 
+    .multibrand-filter-list .doc-count {
+      color: $field_text_color;
+
+      &::before {
+        content: "(";
+      }
+
+      &::after {
+        content: ")";
+      }
+    }
+
     .see-all-filters {
       cursor: pointer;
       display: block;
@@ -55,7 +67,7 @@
         display: none;
       }
 
-      &:after {
+      &::after {
         content: ' \2304';
         font-weight: bold;
       }
@@ -80,6 +92,34 @@
       }
     }
   }
+
+  .meta-group {
+    display: flex;
+    align-items: center;
+    clear: right;
+    color: $field_text_color;
+
+    li:first-child {
+      margin-right: auto;
+    }
+
+    .meta-data {
+      color: inherit;
+
+      &:not(:last-child) {
+        margin-right: 20px;
+      }
+
+      &::after {
+        content: none;
+      }
+    }
+  }
+
+  &-description {
+    margin-top: 10px;
+    word-break: break-word;
+  }
 }
 
 .search-result {
@@ -87,11 +127,6 @@
   &-title {
     font-size: $font-size-bigger;
     display: inline-block;
-  }
-
-  &-description {
-    margin-top: 15px;
-    word-break: break-word;
   }
 
   &-icons {
@@ -140,12 +175,15 @@
   }
 
   &-breadcrumbs {
+    display: table-row;
     margin: 0;
 
-    li:last-child::after {
-       content: "·";
-       display: inline-block;
-       margin: 0 5px;
+    li {
+      display: table-cell;
+    }
+
+    li, li a, li a:visited {
+      color: inherit;
     }
   }
 }

--- a/templates/search_results.hbs
+++ b/templates/search_results.hbs
@@ -14,7 +14,7 @@
           <ul class="multibrand-filter-list multibrand-filter-list--collapsed">
             {{#each help_center_filters}}
               <li>
-                <a href="{{url}}" class="sidenav-item" aria-selected="{{selected}}">{{name}} ({{count}})</a>
+                <a href="{{url}}" class="sidenav-item" aria-selected="{{selected}}">{{name}} <span class="doc-count">{{count}}</span></a>
               </li>
             {{/each}}
             <a tabindex="0" class="see-all-filters" aria-hidden="true" title="{{t 'show_more_help_centers'}}">{{t 'show_more_help_centers'}}</a>
@@ -25,10 +25,10 @@
         <section class="filters-in-section collapsible-sidebar">
           <button type="button" class="collapsible-sidebar-toggle" aria-expanded="false"></button>
           <h3 class="collapsible-sidebar-title sidenav-title">{{t 'filter_by_type'}}</h3>
-          <ul>
+          <ul class="multibrand-filter-list multibrand-filter-list--collapsed">
             {{#each filters}}
               <li>
-                <a href="{{url}}" class="sidenav-item" aria-selected="{{selected}}">{{name}} ({{count}})</a>
+                <a href="{{url}}" class="sidenav-item" aria-selected="{{selected}}">{{name}} <span class="doc-count">{{count}}</span></a>
               </li>
             {{/each}}
           </ul>
@@ -46,7 +46,7 @@
           <ul class="multibrand-filter-list multibrand-filter-list--collapsed">
             {{#each subfilters}}
               <li>
-                <a href="{{url}}" class="sidenav-item" aria-selected="{{selected}}">{{name}} ({{count}})</a>
+                <a href="{{url}}" class="sidenav-item" aria-selected="{{selected}}">{{name}} <span class="doc-count">{{count}}</span></a>
               </li>
             {{/each}}
             {{#is current_filter.identifier 'knowledge_base'}}
@@ -79,17 +79,17 @@
               <h2 class="search-result-title">
                 <a href="{{url}}" class="results-list-item-link">{{title}}</a>
               </h2>
+              <div class="search-result-icons">
+                {{#if vote_sum}}
+                  <span class="search-result-votes">{{vote_sum}}</span>
+                {{/if}}
+                {{#if comment_count}}
+                  <span class="search-result-meta-count">
+                    {{comment_count}}
+                  </span>
+                {{/if}}
+              </div>
               <article>
-                <div class="search-result-icons">
-                  {{#if vote_sum}}
-                    <span class="search-result-votes">{{vote_sum}}</span>
-                  {{/if}}
-                  {{#if comment_count}}
-                    <span class="search-result-meta-count">
-                      {{comment_count}}
-                    </span>
-                  {{/if}}
-                </div>
                 <ul class="meta-group">
                   <li>
                     <ol class="breadcrumbs search-result-breadcrumbs">


### PR DESCRIPTION
Change multibrand theme to be aligned with the design. Split this to a separate PR from the old one with `show more` button.

Changes:
- Align author name and updated time to the right
- Align # of votes to the right and in the same line as the title
- Change the color of breadcrumbs in search results
- Use different color for doc counts in multibrand filters
