### PR TITLE
Align the styles of multibrand SERP with the design

### DIFF
--- a/style.css
+++ b/style.css
@@ -4110,6 +4110,18 @@ ul {
   display: none;
 }
 
+.search-results-sidebar .multibrand-filter-list .doc-count {
+  color: #999;
+}
+
+.search-results-sidebar .multibrand-filter-list .doc-count::before {
+  content: "(";
+}
+
+.search-results-sidebar .multibrand-filter-list .doc-count::after {
+  content: ")";
+}
+
 .search-results-sidebar .see-all-filters {
   cursor: pointer;
   display: block;
@@ -4120,7 +4132,7 @@ ul {
   display: none;
 }
 
-.search-results-sidebar .see-all-filters:after {
+.search-results-sidebar .see-all-filters::after {
   content: ' \2304';
   font-weight: bold;
 }
@@ -4146,18 +4158,53 @@ ul {
   margin-bottom: 0;
 }
 
+.search-results .meta-group {
+  display: flex;
+  align-items: center;
+  clear: both;
+  color: #666;
+}
+
+[dir="ltr"] .search-results .meta-group li:first-child {
+  margin-right: auto;
+}
+
+[dir="rtl"] .search-results .meta-group li:first-child {
+  margin-left: auto;
+}
+
+.search-results .meta-group .meta-data {
+  color: inherit;
+}
+
+[dir="ltr"] .search-results .meta-group .meta-data:not(:last-child) {
+  margin-right: 20px;
+}
+
+[dir="rtl"] .search-results .meta-group .meta-data:not(:last-child) {
+  margin-left: 20px;
+}
+
+.search-results .meta-group .meta-data::after {
+  content: none;
+}
+
+.search-results-description {
+  margin-top: 10px;
+  word-break: break-word;
+}
+
 .search-result-title {
   font-size: 16px;
   display: inline-block;
 }
 
-.search-result-description {
-  margin-top: 15px;
-  word-break: break-word;
+[dir="ltr"] .search-result-icons {
+  float: right;
 }
 
-.search-result-icons {
-  float: right;
+[dir="rtl"] .search-result-icons {
+  float: left;
 }
 
 .search-result-votes, .search-result-meta-count {
@@ -4202,13 +4249,16 @@ ul {
 }
 
 .search-result-breadcrumbs {
+  display: table-row;
   margin: 0;
 }
 
-.search-result-breadcrumbs li:last-child::after {
-  content: "·";
-  display: inline-block;
-  margin: 0 5px;
+.search-result-breadcrumbs li {
+  display: table-cell;
+}
+
+.search-result-breadcrumbs li, .search-result-breadcrumbs li a, .search-result-breadcrumbs li a:visited {
+  color: inherit;
 }
 
 /* By default use bold instead of italic to highlight */

--- a/styles/_search_results.scss
+++ b/styles/_search_results.scss
@@ -46,6 +46,18 @@
       display: none;
     }
 
+    .multibrand-filter-list .doc-count {
+      color: $field-text-color;
+
+      &::before {
+        content: "(";
+      }
+
+      &::after {
+        content: ")";
+      }
+    }
+
     .see-all-filters {
       cursor: pointer;
       display: block;
@@ -55,7 +67,7 @@
         display: none;
       }
 
-      &:after {
+      &::after {
         content: ' \2304';
         font-weight: bold;
       }
@@ -80,6 +92,46 @@
       }
     }
   }
+
+  .meta-group {
+    display: flex;
+    align-items: center;
+    clear: both;
+    color: #666;
+
+    li:first-child {
+      [dir="ltr"] & {
+        margin-right: auto;
+      }
+
+      [dir="rtl"] & {
+        margin-left: auto;
+      }
+    }
+
+    .meta-data {
+      color: inherit;
+
+      &:not(:last-child) {
+        [dir="ltr"] & {
+          margin-right: 20px;
+        }
+
+        [dir="rtl"] & {
+          margin-left: 20px;
+        }
+      }
+
+      &::after {
+        content: none;
+      }
+    }
+  }
+
+  &-description {
+    margin-top: 10px;
+    word-break: break-word;
+  }
 }
 
 .search-result {
@@ -89,13 +141,14 @@
     display: inline-block;
   }
 
-  &-description {
-    margin-top: 15px;
-    word-break: break-word;
-  }
-
   &-icons {
-    float: right;
+    [dir="ltr"] & {
+      float: right;
+    }
+
+    [dir="rtl"] & {
+      float: left;
+    }
   }
 
   &-votes,
@@ -140,12 +193,15 @@
   }
 
   &-breadcrumbs {
+    display: table-row;
     margin: 0;
 
-    li:last-child::after {
-       content: "·";
-       display: inline-block;
-       margin: 0 5px;
+    li {
+      display: table-cell;
+    }
+
+    li, li a, li a:visited {
+      color: inherit;
     }
   }
 }

--- a/templates/search_results.hbs
+++ b/templates/search_results.hbs
@@ -14,7 +14,7 @@
           <ul class="multibrand-filter-list multibrand-filter-list--collapsed">
             {{#each help_center_filters}}
               <li>
-                <a href="{{url}}" class="sidenav-item" aria-selected="{{selected}}">{{name}} ({{count}})</a>
+                <a href="{{url}}" class="sidenav-item" aria-selected="{{selected}}">{{name}} <span class="doc-count">{{count}}</span></a>
               </li>
             {{/each}}
             <a tabindex="0" class="see-all-filters" aria-hidden="true" title="{{t 'show_more_help_centers'}}">{{t 'show_more_help_centers'}}</a>
@@ -25,10 +25,10 @@
         <section class="filters-in-section collapsible-sidebar">
           <button type="button" class="collapsible-sidebar-toggle" aria-expanded="false"></button>
           <h3 class="collapsible-sidebar-title sidenav-title">{{t 'filter_by_type'}}</h3>
-          <ul>
+          <ul class="multibrand-filter-list multibrand-filter-list--collapsed">
             {{#each filters}}
               <li>
-                <a href="{{url}}" class="sidenav-item" aria-selected="{{selected}}">{{name}} ({{count}})</a>
+                <a href="{{url}}" class="sidenav-item" aria-selected="{{selected}}">{{name}} <span class="doc-count">{{count}}</span></a>
               </li>
             {{/each}}
           </ul>
@@ -46,7 +46,7 @@
           <ul class="multibrand-filter-list multibrand-filter-list--collapsed">
             {{#each subfilters}}
               <li>
-                <a href="{{url}}" class="sidenav-item" aria-selected="{{selected}}">{{name}} ({{count}})</a>
+                <a href="{{url}}" class="sidenav-item" aria-selected="{{selected}}">{{name}} <span class="doc-count">{{count}}</span></a>
               </li>
             {{/each}}
             {{#is current_filter.identifier 'knowledge_base'}}
@@ -79,17 +79,17 @@
               <h2 class="search-result-title">
                 <a href="{{url}}" class="results-list-item-link">{{title}}</a>
               </h2>
+              <div class="search-result-icons">
+                {{#if vote_sum}}
+                  <span class="search-result-votes">{{vote_sum}}</span>
+                {{/if}}
+                {{#if comment_count}}
+                  <span class="search-result-meta-count">
+                    {{comment_count}}
+                  </span>
+                {{/if}}
+              </div>
               <article>
-                <div class="search-result-icons">
-                  {{#if vote_sum}}
-                    <span class="search-result-votes">{{vote_sum}}</span>
-                  {{/if}}
-                  {{#if comment_count}}
-                    <span class="search-result-meta-count">
-                      {{comment_count}}
-                    </span>
-                  {{/if}}
-                </div>
                 <ul class="meta-group">
                   <li>
                     <ol class="breadcrumbs search-result-breadcrumbs">


### PR DESCRIPTION
Change multibrand theme to be aligned with the design.

Changes:
- Align author name and updated time to the right
- Align # of votes to the right and in the same line as the title
- Change the color of breadcrumbs in search results
- Use different color for doc counts in multibrand filters

Accidently closed the previous PR. There were some good discussions there:
https://github.com/zendesk/copenhagen_theme/pull/97