### PR TITLE
Move parentheses inside result count and fix the layout in rtl

### DIFF
--- a/script.js
+++ b/script.js
@@ -204,7 +204,7 @@ document.addEventListener('DOMContentLoaded', function() {
   // If multibrand search has more than 5 help centers or categories collapse the list
   const multibrandFilterLists = document.querySelectorAll(".multibrand-filter-list");
   Array.prototype.forEach.call(multibrandFilterLists, function(filter) {
-    if (filter.children.length > 5) {
+    if (filter.children.length > 6) {
       // Display the show more button
       var trigger = filter.querySelector(".see-all-filters");
       trigger.setAttribute("aria-hidden", false);

--- a/style.css
+++ b/style.css
@@ -4102,6 +4102,10 @@ ul {
   text-decoration: none;
 }
 
+.search-results-sidebar .sidenav-subitem {
+  unicode-bidi: embed;
+}
+
 .search-results-sidebar .collapsible-sidebar {
   margin-bottom: 30px;
 }
@@ -4112,14 +4116,6 @@ ul {
 
 .search-results-sidebar .multibrand-filter-list .doc-count {
   color: #999;
-}
-
-.search-results-sidebar .multibrand-filter-list .doc-count::before {
-  content: "(";
-}
-
-.search-results-sidebar .multibrand-filter-list .doc-count::after {
-  content: ")";
 }
 
 .search-results-sidebar .see-all-filters {

--- a/styles/_search_results.scss
+++ b/styles/_search_results.scss
@@ -38,6 +38,10 @@
       }
     }
 
+    .sidenav-subitem {
+      unicode-bidi: embed;
+    }
+
     .collapsible-sidebar {
       margin-bottom: 30px;
     }
@@ -48,14 +52,6 @@
 
     .multibrand-filter-list .doc-count {
       color: $field-text-color;
-
-      &::before {
-        content: "(";
-      }
-
-      &::after {
-        content: ")";
-      }
     }
 
     .see-all-filters {

--- a/templates/search_results.hbs
+++ b/templates/search_results.hbs
@@ -14,7 +14,10 @@
           <ul class="multibrand-filter-list multibrand-filter-list--collapsed">
             {{#each help_center_filters}}
               <li>
-                <a href="{{url}}" class="sidenav-item" aria-selected="{{selected}}">{{name}} <span class="doc-count">{{count}}</span></a>
+                <a href="{{url}}" class="sidenav-item" aria-selected="{{selected}}">
+                  <span class="sidenav-subitem filter-name">{{name}}</span>
+                  <span class="sidenav-subitem doc-count">({{count}})</span>
+                </a>
               </li>
             {{/each}}
             <a tabindex="0" class="see-all-filters" aria-hidden="true" title="{{t 'show_more_help_centers'}}">{{t 'show_more_help_centers'}}</a>
@@ -28,7 +31,10 @@
           <ul class="multibrand-filter-list multibrand-filter-list--collapsed">
             {{#each filters}}
               <li>
-                <a href="{{url}}" class="sidenav-item" aria-selected="{{selected}}">{{name}} <span class="doc-count">{{count}}</span></a>
+                <a href="{{url}}" class="sidenav-item" aria-selected="{{selected}}">
+                  <span class="sidenav-subitem filter-name">{{name}}</span>
+                  <span class="sidenav-subitem doc-count">({{count}})</span>
+                </a>
               </li>
             {{/each}}
           </ul>
@@ -46,7 +52,10 @@
           <ul class="multibrand-filter-list multibrand-filter-list--collapsed">
             {{#each subfilters}}
               <li>
-                <a href="{{url}}" class="sidenav-item" aria-selected="{{selected}}">{{name}} <span class="doc-count">{{count}}</span></a>
+                <a href="{{url}}" class="sidenav-item" aria-selected="{{selected}}">
+                  <span class="sidenav-subitem filter-name">{{name}}</span>
+                  <span class="sidenav-subitem doc-count">({{count}})</span>
+                </a>
               </li>
             {{/each}}
             {{#is current_filter.identifier 'knowledge_base'}}


### PR DESCRIPTION
- Move parentheses inside result count elements as suggested by @augustocravosilva 
- Fix the broken layout of parentheses in rtl
- Fix the issue that `see more` button is displayed when there are more than 4 filters (should be 5)

Layout in rtl before fix:
<img width="308" alt="Screen Shot 2019-09-05 at 08 57 35" src="https://user-images.githubusercontent.com/36034626/64318894-6d3c1980-cfbb-11e9-8976-14f0e19effdc.png">

Layout in rtl after fix:
<img width="300" alt="Screen Shot 2019-09-05 at 08 57 49" src="https://user-images.githubusercontent.com/36034626/64318906-74fbbe00-cfbb-11e9-92c6-5c0fb56ffa6d.png">
