### PR TITLE
Copenhagen Theme Update for Multibrand Search

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Copenhagen",
   "author": "Zendesk",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "api_version": 1,
   "default_locale": "en-us",
   "settings": [{

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Copenhagen",
   "author": "Zendesk",
-  "version": "1.6.2",
+  "version": "1.7.0",
   "api_version": 1,
   "default_locale": "en-us",
   "settings": [{

--- a/script.js
+++ b/script.js
@@ -204,7 +204,7 @@ document.addEventListener('DOMContentLoaded', function() {
   // If multibrand search has more than 5 help centers or categories collapse the list
   const multibrandFilterLists = document.querySelectorAll(".multibrand-filter-list");
   Array.prototype.forEach.call(multibrandFilterLists, function(filter) {
-    if (filter.children.length > 5) {
+    if (filter.children.length > 6) {
       // Display the show more button
       var trigger = filter.querySelector(".see-all-filters");
       trigger.setAttribute("aria-hidden", false);

--- a/script.js
+++ b/script.js
@@ -200,4 +200,21 @@ document.addEventListener('DOMContentLoaded', function() {
       seeAllTrigger.parentNode.removeChild(seeAllTrigger);
     });
   }
+
+  // If multibrand search has more than 5 help centers or categories collapse the list
+  const multibrandFilterLists = document.querySelectorAll(".multibrand-filter-list");
+  Array.prototype.forEach.call(multibrandFilterLists, function(filter) {
+    if (filter.children.length > 5) {
+      // Display the show more button
+      var trigger = filter.querySelector(".see-all-filters");
+      trigger.setAttribute("aria-hidden", false);
+
+      // Add event handler for click
+      trigger.addEventListener("click", function(e) {
+        e.stopPropagation();
+        trigger.parentNode.removeChild(trigger);
+        filter.classList.remove("multibrand-filter-list--collapsed")
+      })
+    }
+  });
 });

--- a/style.css
+++ b/style.css
@@ -4162,18 +4162,30 @@ ul {
 }
 
 .search-results .meta-group {
-  display: flex;
+  display: block;
   align-items: center;
   clear: both;
   color: #666;
 }
 
-[dir="ltr"] .search-results .meta-group li:first-child {
-  margin-right: auto;
+@media (min-width: 1024px) {
+  .search-results .meta-group {
+    display: flex;
+  }
 }
 
-[dir="rtl"] .search-results .meta-group li:first-child {
-  margin-left: auto;
+.search-results .meta-group > li {
+  display: block;
+}
+
+@media (min-width: 1024px) {
+  .search-results .meta-group > li {
+    display: inline;
+  }
+}
+
+.search-results .meta-group li:first-child {
+  flex: 1;
 }
 
 .search-results .meta-group .meta-data {

--- a/style.css
+++ b/style.css
@@ -4110,6 +4110,18 @@ ul {
   display: none;
 }
 
+.search-results-sidebar .multibrand-filter-list .doc-count {
+  color: #999;
+}
+
+.search-results-sidebar .multibrand-filter-list .doc-count::before {
+  content: "(";
+}
+
+.search-results-sidebar .multibrand-filter-list .doc-count::after {
+  content: ")";
+}
+
 .search-results-sidebar .see-all-filters {
   cursor: pointer;
   display: block;
@@ -4120,7 +4132,7 @@ ul {
   display: none;
 }
 
-.search-results-sidebar .see-all-filters:after {
+.search-results-sidebar .see-all-filters::after {
   content: ' \2304';
   font-weight: bold;
 }
@@ -4146,18 +4158,53 @@ ul {
   margin-bottom: 0;
 }
 
+.search-results .meta-group {
+  display: flex;
+  align-items: center;
+  clear: both;
+  color: #666;
+}
+
+[dir="ltr"] .search-results .meta-group li:first-child {
+  margin-right: auto;
+}
+
+[dir="rtl"] .search-results .meta-group li:first-child {
+  margin-left: auto;
+}
+
+.search-results .meta-group .meta-data {
+  color: inherit;
+}
+
+[dir="ltr"] .search-results .meta-group .meta-data:not(:last-child) {
+  margin-right: 20px;
+}
+
+[dir="rtl"] .search-results .meta-group .meta-data:not(:last-child) {
+  margin-left: 20px;
+}
+
+.search-results .meta-group .meta-data::after {
+  content: none;
+}
+
+.search-results-description {
+  margin-top: 10px;
+  word-break: break-word;
+}
+
 .search-result-title {
   font-size: 16px;
   display: inline-block;
 }
 
-.search-result-description {
-  margin-top: 15px;
-  word-break: break-word;
+[dir="ltr"] .search-result-icons {
+  float: right;
 }
 
-.search-result-icons {
-  float: right;
+[dir="rtl"] .search-result-icons {
+  float: left;
 }
 
 .search-result-votes, .search-result-meta-count {
@@ -4202,13 +4249,16 @@ ul {
 }
 
 .search-result-breadcrumbs {
+  display: table-row;
   margin: 0;
 }
 
-.search-result-breadcrumbs li:last-child::after {
-  content: "·";
-  display: inline-block;
-  margin: 0 5px;
+.search-result-breadcrumbs li {
+  display: table-cell;
+}
+
+.search-result-breadcrumbs li, .search-result-breadcrumbs li a, .search-result-breadcrumbs li a:visited {
+  color: inherit;
 }
 
 /* By default use bold instead of italic to highlight */

--- a/style.css
+++ b/style.css
@@ -4077,8 +4077,29 @@ ul {
 
 @media (min-width: 1024px) {
   .search-results-column {
-    flex: 0 0 45%;
+    flex: 0 0 75%;
   }
+}
+
+.search-results-sidebar {
+  border-top: 1px solid #ddd;
+  flex: 1 0 auto;
+  margin-bottom: 20px;
+  padding: 0;
+}
+
+@media (min-width: 1024px) {
+  .search-results-sidebar {
+    border: 0;
+    flex: 0 0 20%;
+    height: auto;
+  }
+}
+
+.search-results-sidebar .sidenav-item[aria-selected="true"] {
+  background-color: $brand_color;
+  color: $brand_text_color;
+  text-decoration: none;
 }
 
 .search-results-subheading {
@@ -4091,12 +4112,19 @@ ul {
 }
 
 .search-results-list > li {
-  border-bottom: 1px solid #ddd;
   padding: 20px 0;
 }
 
 .search-results-list > li:first-child {
   border-top: 1px solid #ddd;
+}
+
+.search-results-list > li h2 {
+  margin-bottom: 0;
+}
+
+.search-result-title {
+  font-size: 16px;
 }
 
 .search-result-description {

--- a/style.css
+++ b/style.css
@@ -4119,13 +4119,20 @@ ul {
 }
 
 .search-results-sidebar .see-all-filters {
+  background: none;
+  border: none;
   cursor: pointer;
   display: block;
   padding: 10px;
+  color: $link_color;
 }
 
 .search-results-sidebar .see-all-filters[aria-hidden="true"] {
   display: none;
+}
+
+.search-results-sidebar .see-all-filters:hover {
+  text-decoration: underline;
 }
 
 .search-results-sidebar .see-all-filters::after {

--- a/style.css
+++ b/style.css
@@ -4110,6 +4110,16 @@ ul {
   margin-bottom: 30px;
 }
 
+.search-results-sidebar .collapsible-sidebar[aria-expanded="false"] .multibrand-filter-list {
+  display: none;
+}
+
+@media (min-width: 1024px) {
+  .search-results-sidebar .collapsible-sidebar[aria-expanded="false"] .multibrand-filter-list {
+    display: block;
+  }
+}
+
 .search-results-sidebar .multibrand-filter-list--collapsed li:nth-child(1n + 6) {
   display: none;
 }
@@ -4184,8 +4194,10 @@ ul {
   }
 }
 
-.search-results .meta-group li:first-child {
-  flex: 1;
+@media (min-width: 1024px) {
+  .search-results .meta-group li:first-child {
+    flex: 1;
+  }
 }
 
 .search-results .meta-group .meta-data {
@@ -4264,12 +4276,19 @@ ul {
 }
 
 .search-result-breadcrumbs {
-  display: table-row;
   margin: 0;
 }
 
-.search-result-breadcrumbs li {
-  display: table-cell;
+@media (min-width: 1024px) {
+  .search-result-breadcrumbs {
+    display: table-row;
+  }
+}
+
+@media (min-width: 1024px) {
+  .search-result-breadcrumbs li {
+    display: table-cell;
+  }
 }
 
 .search-result-breadcrumbs li, .search-result-breadcrumbs li a, .search-result-breadcrumbs li a:visited {

--- a/style.css
+++ b/style.css
@@ -4096,10 +4096,33 @@ ul {
   }
 }
 
-.search-results-sidebar .sidenav-item[aria-selected="true"] {
-  background-color: $brand_color;
-  color: $brand_text_color;
+.search-results-sidebar .sidenav-item:hover, .search-results-sidebar .sidenav-item[aria-selected="true"] {
+  background-color: #e9ebed;
+  color: inherit;
   text-decoration: none;
+}
+
+.search-results-sidebar .collapsible-sidebar {
+  margin-bottom: 30px;
+}
+
+.search-results-sidebar .multibrand-filter-list--collapsed li:nth-child(1n + 6) {
+  display: none;
+}
+
+.search-results-sidebar .see-all-filters {
+  cursor: pointer;
+  display: block;
+  padding: 10px;
+}
+
+.search-results-sidebar .see-all-filters[aria-hidden="true"] {
+  display: none;
+}
+
+.search-results-sidebar .see-all-filters:after {
+  content: ' \2304';
+  font-weight: bold;
 }
 
 .search-results-subheading {
@@ -4188,22 +4211,14 @@ ul {
   margin: 0 5px;
 }
 
-/* Non-latin search results highlight */
-/* Add a yellow background for Chinese */
-html[lang|="zh"] .search-result-description em {
+/* By default use bold instead of italic to highlight */
+.search-results-description em {
   font-style: normal;
-  background: yellow;
+  font-weight: bold;
 }
 
-/* Use bold to highlight for the rest of supported non-latin languages */
-html[lang|="ar"] .search-result-description em,
-html[lang|="bg"] .search-result-description em,
-html[lang|="el"] .search-result-description em,
-html[lang|="he"] .search-result-description em,
-html[lang|="hi"] .search-result-description em,
-html[lang|="ko"] .search-result-description em,
-html[lang|="ja"] .search-result-description em,
-html[lang|="ru"] .search-result-description em,
-html[lang|="th"] .search-result-description em {
-  font-style: bold;
+/* Add a yellow background for Chinese */
+html[lang|="zh"] .search-results-description em {
+  font-style: normal;
+  background: yellow;
 }

--- a/style.css
+++ b/style.css
@@ -4102,6 +4102,10 @@ ul {
   text-decoration: none;
 }
 
+.search-results-sidebar .sidenav-subitem {
+  unicode-bidi: embed;
+}
+
 .search-results-sidebar .collapsible-sidebar {
   margin-bottom: 30px;
 }
@@ -4112,14 +4116,6 @@ ul {
 
 .search-results-sidebar .multibrand-filter-list .doc-count {
   color: #999;
-}
-
-.search-results-sidebar .multibrand-filter-list .doc-count::before {
-  content: "(";
-}
-
-.search-results-sidebar .multibrand-filter-list .doc-count::after {
-  content: ")";
 }
 
 .search-results-sidebar .see-all-filters {

--- a/style.css
+++ b/style.css
@@ -4125,11 +4125,16 @@ ul {
 
 .search-result-title {
   font-size: 16px;
+  display: inline-block;
 }
 
 .search-result-description {
   margin-top: 15px;
   word-break: break-word;
+}
+
+.search-result-icons {
+  float: right;
 }
 
 .search-result-votes, .search-result-meta-count {

--- a/styles/_search_results.scss
+++ b/styles/_search_results.scss
@@ -46,6 +46,18 @@
       display: none;
     }
 
+    .multibrand-filter-list .doc-count {
+      color: $field-text-color;
+
+      &::before {
+        content: "(";
+      }
+
+      &::after {
+        content: ")";
+      }
+    }
+
     .see-all-filters {
       cursor: pointer;
       display: block;
@@ -55,7 +67,7 @@
         display: none;
       }
 
-      &:after {
+      &::after {
         content: ' \2304';
         font-weight: bold;
       }
@@ -80,6 +92,46 @@
       }
     }
   }
+
+  .meta-group {
+    display: flex;
+    align-items: center;
+    clear: both;
+    color: #666;
+
+    li:first-child {
+      [dir="ltr"] & {
+        margin-right: auto;
+      }
+
+      [dir="rtl"] & {
+        margin-left: auto;
+      }
+    }
+
+    .meta-data {
+      color: inherit;
+
+      &:not(:last-child) {
+        [dir="ltr"] & {
+          margin-right: 20px;
+        }
+
+        [dir="rtl"] & {
+          margin-left: 20px;
+        }
+      }
+
+      &::after {
+        content: none;
+      }
+    }
+  }
+
+  &-description {
+    margin-top: 10px;
+    word-break: break-word;
+  }
 }
 
 .search-result {
@@ -89,13 +141,14 @@
     display: inline-block;
   }
 
-  &-description {
-    margin-top: 15px;
-    word-break: break-word;
-  }
-
   &-icons {
-    float: right;
+    [dir="ltr"] & {
+      float: right;
+    }
+
+    [dir="rtl"] & {
+      float: left;
+    }
   }
 
   &-votes,
@@ -140,12 +193,15 @@
   }
 
   &-breadcrumbs {
+    display: table-row;
     margin: 0;
 
-    li:last-child::after {
-       content: "·";
-       display: inline-block;
-       margin: 0 5px;
+    li {
+      display: table-cell;
+    }
+
+    li, li a, li a:visited {
+      color: inherit;
     }
   }
 }

--- a/styles/_search_results.scss
+++ b/styles/_search_results.scss
@@ -38,6 +38,10 @@
       }
     }
 
+    .sidenav-subitem {
+      unicode-bidi: embed;
+    }
+
     .collapsible-sidebar {
       margin-bottom: 30px;
     }
@@ -48,14 +52,6 @@
 
     .multibrand-filter-list .doc-count {
       color: $field-text-color;
-
-      &::before {
-        content: "(";
-      }
-
-      &::after {
-        content: ")";
-      }
     }
 
     .see-all-filters {

--- a/styles/_search_results.scss
+++ b/styles/_search_results.scss
@@ -29,10 +29,36 @@
       height: auto;
     }
 
-    .sidenav-item[aria-selected="true"] {
-      background-color: $brand_color;
-      color: $brand_text_color;
-      text-decoration: none;
+    .sidenav-item {
+      &:hover,
+      &[aria-selected="true"] {
+        background-color: #e9ebed;
+        color: inherit;
+        text-decoration: none;
+      }
+    }
+
+    .collapsible-sidebar {
+      margin-bottom: 30px;
+    }
+
+    .multibrand-filter-list--collapsed li:nth-child(1n + 6) {
+      display: none;
+    }
+
+    .see-all-filters {
+      cursor: pointer;
+      display: block;
+      padding: 10px;
+
+      &[aria-hidden="true"] {
+        display: none;
+      }
+
+      &:after {
+        content: ' \2304';
+        font-weight: bold;
+      }
     }
   }
 
@@ -124,27 +150,16 @@
   }
 }
 
-/* Non-latin search results highlight */
+/* By default use bold instead of italic to highlight */
+.search-results-description em {
+  font-style: normal;
+  font-weight: bold;
+}
 
 /* Add a yellow background for Chinese */
 html[lang|="zh"] {
-  .search-result-description em {
+  .search-results-description em {
     font-style: normal;
     background: yellow;
-  }
-}
-
-/* Use bold to highlight for the rest of supported non-latin languages */
-html[lang|="ar"],
-html[lang|="bg"],
-html[lang|="el"],
-html[lang|="he"],
-html[lang|="hi"],
-html[lang|="ko"],
-html[lang|="ja"],
-html[lang|="ru"],
-html[lang|="th"] {
-  .search-result-description em {
-    font-style: bold;
   }
 }

--- a/styles/_search_results.scss
+++ b/styles/_search_results.scss
@@ -60,11 +60,16 @@
 
   &-title {
     font-size: $font-size-bigger;
+    display: inline-block;
   }
 
   &-description {
     margin-top: 15px;
     word-break: break-word;
+  }
+
+  &-icons {
+    float: right;
   }
 
   &-votes,

--- a/styles/_search_results.scss
+++ b/styles/_search_results.scss
@@ -11,10 +11,29 @@
 
   &-column {
     @include desktop {
-      flex: 0 0 45%;
+      flex: 0 0 75%;
     }
 
     flex: 1;
+  }
+
+  &-sidebar {
+    border-top: 1px solid $border-color;
+    flex: 1 0 auto;
+    margin-bottom: 20px;
+    padding: 0;
+
+    @include desktop {
+      border: 0;
+      flex: 0 0 20%;
+      height: auto;
+    }
+
+    .sidenav-item[aria-selected="true"] {
+      background-color: $brand_color;
+      color: $brand_text_color;
+      text-decoration: none;
+    }
   }
 
   &-subheading {
@@ -25,16 +44,23 @@
   &-list {
     margin-bottom: 25px;
     > li {
-      border-bottom: 1px solid $border-color;
       padding: 20px 0;
       &:first-child {
         border-top: 1px solid $border-color;
+      }
+
+      h2 {
+        margin-bottom: 0;
       }
     }
   }
 }
 
 .search-result {
+
+  &-title {
+    font-size: $font-size-bigger;
+  }
 
   &-description {
     margin-top: 15px;

--- a/styles/_search_results.scss
+++ b/styles/_search_results.scss
@@ -55,12 +55,19 @@
     }
 
     .see-all-filters {
+      background: none;
+      border: none;
       cursor: pointer;
       display: block;
       padding: 10px;
+      color: $link_color;
 
       &[aria-hidden="true"] {
         display: none;
+      }
+
+      &:hover {
+        text-decoration: underline;
       }
 
       &::after {

--- a/styles/_search_results.scss
+++ b/styles/_search_results.scss
@@ -97,19 +97,19 @@
   }
 
   .meta-group {
-    display: flex;
+    display: block;
+    @include desktop { display: flex; }
     align-items: center;
     clear: both;
     color: #666;
 
-    li:first-child {
-      [dir="ltr"] & {
-        margin-right: auto;
-      }
+    > li {
+      display: block;
+      @include desktop { display: inline }
+    }
 
-      [dir="rtl"] & {
-        margin-left: auto;
-      }
+    li:first-child {
+      flex: 1;
     }
 
     .meta-data {

--- a/styles/_search_results.scss
+++ b/styles/_search_results.scss
@@ -44,6 +44,13 @@
 
     .collapsible-sidebar {
       margin-bottom: 30px;
+
+      &[aria-expanded="false"] {
+        .multibrand-filter-list {
+          display: none;
+          @include desktop { display: block; }
+        }
+      }
     }
 
     .multibrand-filter-list--collapsed li:nth-child(1n + 6) {
@@ -109,7 +116,7 @@
     }
 
     li:first-child {
-      flex: 1;
+      @include desktop { flex: 1; }
     }
 
     .meta-data {
@@ -196,11 +203,11 @@
   }
 
   &-breadcrumbs {
-    display: table-row;
+    @include desktop { display: table-row; }
     margin: 0;
 
     li {
-      display: table-cell;
+      @include desktop { display: table-cell; }
     }
 
     li, li a, li a:visited {

--- a/templates/search_results.hbs
+++ b/templates/search_results.hbs
@@ -14,7 +14,7 @@
           <ul class="multibrand-filter-list multibrand-filter-list--collapsed">
             {{#each help_center_filters}}
               <li>
-                <a href="{{url}}" class="sidenav-item" aria-selected="{{selected}}">{{name}} ({{count}})</a>
+                <a href="{{url}}" class="sidenav-item" aria-selected="{{selected}}">{{name}} <span class="doc-count">{{count}}</span></a>
               </li>
             {{/each}}
             <a tabindex="0" class="see-all-filters" aria-hidden="true" title="{{t 'show_more_help_centers'}}">{{t 'show_more_help_centers'}}</a>
@@ -25,10 +25,10 @@
         <section class="filters-in-section collapsible-sidebar">
           <button type="button" class="collapsible-sidebar-toggle" aria-expanded="false"></button>
           <h3 class="collapsible-sidebar-title sidenav-title">{{t 'filter_by_type'}}</h3>
-          <ul>
+          <ul class="multibrand-filter-list multibrand-filter-list--collapsed">
             {{#each filters}}
               <li>
-                <a href="{{url}}" class="sidenav-item" aria-selected="{{selected}}">{{name}} ({{count}})</a>
+                <a href="{{url}}" class="sidenav-item" aria-selected="{{selected}}">{{name}} <span class="doc-count">{{count}}</span></a>
               </li>
             {{/each}}
           </ul>
@@ -46,7 +46,7 @@
           <ul class="multibrand-filter-list multibrand-filter-list--collapsed">
             {{#each subfilters}}
               <li>
-                <a href="{{url}}" class="sidenav-item" aria-selected="{{selected}}">{{name}} ({{count}})</a>
+                <a href="{{url}}" class="sidenav-item" aria-selected="{{selected}}">{{name}} <span class="doc-count">{{count}}</span></a>
               </li>
             {{/each}}
             {{#is current_filter.identifier 'knowledge_base'}}
@@ -79,17 +79,17 @@
               <h2 class="search-result-title">
                 <a href="{{url}}" class="results-list-item-link">{{title}}</a>
               </h2>
+              <div class="search-result-icons">
+                {{#if vote_sum}}
+                  <span class="search-result-votes">{{vote_sum}}</span>
+                {{/if}}
+                {{#if comment_count}}
+                  <span class="search-result-meta-count">
+                    {{comment_count}}
+                  </span>
+                {{/if}}
+              </div>
               <article>
-                <div class="search-result-icons">
-                  {{#if vote_sum}}
-                    <span class="search-result-votes">{{vote_sum}}</span>
-                  {{/if}}
-                  {{#if comment_count}}
-                    <span class="search-result-meta-count">
-                      {{comment_count}}
-                    </span>
-                  {{/if}}
-                </div>
                 <ul class="meta-group">
                   <li>
                     <ol class="breadcrumbs search-result-breadcrumbs">

--- a/templates/search_results.hbs
+++ b/templates/search_results.hbs
@@ -5,70 +5,81 @@
     {{search submit=false}}
   </nav>
 
-  <header class="page-header">
-    <h1>{{t 'search_results'}}</h1>
-    <p class="page-header-description">{{t 'results' query=query count=results_count}}</p>
-  </header>
-
   <div class="search-results">
-    <section class="search-results-column">
-      <h2 class="search-results-subheading">
-        {{t 'knowledge_base'}}
-      </h2>
-      {{#if article_results}}
-        <ul class="search-results-list">
-          {{#each article_results}}
-            <li class="search-result">
-              <a href="{{url}}" class="search-result-link">{{title}}</a>
-              {{#if vote_sum}}
-                <span class="search-result-votes meta-count">{{vote_sum}}</span>
-              {{/if}}
-              <ul class="meta-group">
-                <li>
-                  <ol class="breadcrumbs search-result-breadcrumbs">
-                    {{#each path_steps}}
-                      {{#is url '#'}}
-                        <li title="{{name}}">{{name}}</li>
-                      {{else}}
-                        <li title="{{name}}"><a href="{{url}}">{{name}}</a></li>
-                      {{/is}}
-                    {{/each}}
-                  </ol>
-                </li>
-                <li class="meta-data">
-                  {{#link 'user_profile' id=author.id}}
-                    {{author.name}}
-                  {{/link}}
-                </li>
-                <li class="meta-data">{{date created_at timeago=true}}</li>
-              </ul>
-              <div class="search-result-description">{{text}}</div>
-            </li>
-          {{/each}}
-        </ul>
-      {{else}}
-        <p>
-          {{t 'no_results' query=query}}
-          {{#link 'help_center'}}
-            {{t 'browse_knowledge_base'}}
-          {{/link}}
-        </p>
+    <section class="search-results-sidebar">
+      {{#if help_center_filters}}
+        <section class="filters-in-section collapsible-sidebar">
+          <h3 class="collapsible-sidebar-title sidenav-title">{{t 'filter_by_help_center'}}</h3>
+          <ul>
+            {{#each help_center_filters}}
+              <li>
+                <a href="{{url}}" class="sidenav-item" aria-selected="{{selected}}">{{name}} ({{count}})</a>
+              </li>
+            {{/each}}
+          </ul>
+        </section>
+      {{/if}}
+      {{#if help_center.community_enabled}}
+        <section class="filters-in-section collapsible-sidebar">
+          <h3 class="collapsible-sidebar-title sidenav-title">{{t 'filter_by_type'}}</h3>
+          <ul>
+            {{#each filters}}
+              <li>
+                <a href="{{url}}" class="sidenav-item" aria-selected="{{selected}}">{{name}} ({{count}})</a>
+              </li>
+            {{/each}}
+          </ul>
+        </section>
+      {{/if}}
+      {{#if subfilters}}
+        <section class="filters-in-section collapsible-sidebar">
+          {{#is current_filter.identifier 'knowledge_base'}}
+            <h3 class="collapsible-sidebar-title sidenav-title">{{t 'filter_by_category'}}</h3>
+          {{/is}}
+          {{#is current_filter.identifier 'community'}}
+            <h3 class="collapsible-sidebar-title sidenav-title">{{t 'filter_by_topic'}}</h3>
+          {{/is}}
+          <ul>
+            {{#each subfilters}}
+              <li>
+                <a href="{{url}}" class="sidenav-item" aria-selected="{{selected}}">{{name}} ({{count}})</a>
+              </li>
+            {{/each}}
+          </ul>
+        </section>
       {{/if}}
     </section>
 
-    {{#if help_center.community_enabled}}
-      <section class="search-results-column">
-        <h2 class="search-results-subheading">
-          {{t 'community'}}
-        </h2>
-        {{#if post_results}}
-          <ul class="search-results-list">
-            {{#each post_results}}
-              <li class="search-result">
-                <a href="{{url}}" class="search-result-link">{{title}}</a>
-                <span class="search-result-meta-count">
-                  {{comment_count}}
-                </span>
+    <section class="search-results-column">
+      <h1 class="search-results-subheading">
+        {{#is current_filter.identifier 'unified'}}
+          {{t 'results' query=query count=results_count}}
+        {{else}}
+          {{#unless current_subfilter.identifier}}
+            {{t 'results' query=query count=results_count}}
+          {{else}}
+            {{t 'results_with_scope' query=query count=results_count scope_name=current_subfilter.name}}
+          {{/unless}}
+        {{/is}}
+      </h1>
+      {{#if results}}
+        <ul class="search-results-list">
+          {{#each results}}
+            <li class="search-result-list-item result-{{type}}">
+              <h2 class="search-result-title">
+                <a href="{{url}}" class="results-list-item-link">{{title}}</a>
+              </h2>
+              <article>
+                <div class="search-result-icons">
+                  {{#if vote_sum}}
+                    <span class="search-result-votes">{{vote_sum}}</span>
+                  {{/if}}
+                  {{#if comment_count}}
+                    <span class="search-result-meta-count">
+                      {{comment_count}}
+                    </span>
+                  {{/if}}
+                </div>
                 <ul class="meta-group">
                   <li>
                     <ol class="breadcrumbs search-result-breadcrumbs">
@@ -77,31 +88,23 @@
                       {{/each}}
                     </ol>
                   </li>
-                  <li class="meta-data">
-                    {{#link 'user_profile' id=author.id}}
-                      {{author.name}}
-                    {{/link}}
-                  </li>
-                  <li class="meta-data">{{date created_at timeago=true}}</li>
+                  <li class="meta-data">{{author.name}}</li>
+                  <li class="meta-data">{{date created_at}}</li>
                 </ul>
-                <div class="search-result-description">
-                  {{text}}
-                </div>
-              </li>
-            {{/each}}
-          </ul>
-        {{else}}
-          <p>
-            {{t 'no_results' query=query}}
-            {{#link 'topics'}}
-              {{t 'browse_community'}}
-            {{/link}}
-          </p>
-        {{/if}}
-      </section>
-    {{/if}}
-
+                <div class="search-results-description">{{text}}</div>
+              </article>
+            </li>
+          {{/each}}
+        </ul>
+      {{else}}
+        <p>
+          {{t 'no_results_unified'}}
+          {{#link 'help_center'}}
+            {{t 'browse_help_center'}}
+          {{/link}}
+        </p>
+      {{/if}}
+    </section>
   </div>
-
   {{pagination}}
 </div>

--- a/templates/search_results.hbs
+++ b/templates/search_results.hbs
@@ -9,18 +9,21 @@
     <section class="search-results-sidebar">
       {{#if help_center_filters}}
         <section class="filters-in-section collapsible-sidebar">
+          <button type="button" class="collapsible-sidebar-toggle" aria-expanded="false"></button>
           <h3 class="collapsible-sidebar-title sidenav-title">{{t 'filter_by_help_center'}}</h3>
-          <ul>
+          <ul class="multibrand-filter-list multibrand-filter-list--collapsed">
             {{#each help_center_filters}}
               <li>
                 <a href="{{url}}" class="sidenav-item" aria-selected="{{selected}}">{{name}} ({{count}})</a>
               </li>
             {{/each}}
+            <a tabindex="0" class="see-all-filters" aria-hidden="true" title="{{t 'show_more_help_centers'}}">{{t 'show_more_help_centers'}}</a>
           </ul>
         </section>
       {{/if}}
       {{#if help_center.community_enabled}}
         <section class="filters-in-section collapsible-sidebar">
+          <button type="button" class="collapsible-sidebar-toggle" aria-expanded="false"></button>
           <h3 class="collapsible-sidebar-title sidenav-title">{{t 'filter_by_type'}}</h3>
           <ul>
             {{#each filters}}
@@ -33,18 +36,25 @@
       {{/if}}
       {{#if subfilters}}
         <section class="filters-in-section collapsible-sidebar">
+          <button type="button" class="collapsible-sidebar-toggle" aria-expanded="false"></button>
           {{#is current_filter.identifier 'knowledge_base'}}
             <h3 class="collapsible-sidebar-title sidenav-title">{{t 'filter_by_category'}}</h3>
           {{/is}}
           {{#is current_filter.identifier 'community'}}
             <h3 class="collapsible-sidebar-title sidenav-title">{{t 'filter_by_topic'}}</h3>
           {{/is}}
-          <ul>
+          <ul class="multibrand-filter-list multibrand-filter-list--collapsed">
             {{#each subfilters}}
               <li>
                 <a href="{{url}}" class="sidenav-item" aria-selected="{{selected}}">{{name}} ({{count}})</a>
               </li>
             {{/each}}
+            {{#is current_filter.identifier 'knowledge_base'}}
+              <a tabindex="0" class="see-all-filters" aria-hidden="true" title="{{t 'show_more_categories'}}">{{t 'show_more_categories'}}</a>
+            {{/is}}
+            {{#is current_filter.identifier 'community'}}
+              <a tabindex="0" class="see-all-filters" aria-hidden="true" title="{{t 'show_more_topics'}}">{{t 'show_more_topics'}}</a>
+            {{/is}}
           </ul>
         </section>
       {{/if}}

--- a/templates/search_results.hbs
+++ b/templates/search_results.hbs
@@ -14,7 +14,10 @@
           <ul class="multibrand-filter-list multibrand-filter-list--collapsed">
             {{#each help_center_filters}}
               <li>
-                <a href="{{url}}" class="sidenav-item" aria-selected="{{selected}}">{{name}} <span class="doc-count">{{count}}</span></a>
+                <a href="{{url}}" class="sidenav-item" aria-selected="{{selected}}">
+                  <span class="sidenav-subitem filter-name">{{name}}</span>
+                  <span class="sidenav-subitem doc-count">({{count}})</span>
+                </a>
               </li>
             {{/each}}
             <a tabindex="0" class="see-all-filters" aria-hidden="true" title="{{t 'show_more_help_centers'}}">{{t 'show_more_help_centers'}}</a>
@@ -28,7 +31,10 @@
           <ul class="multibrand-filter-list multibrand-filter-list--collapsed">
             {{#each filters}}
               <li>
-                <a href="{{url}}" class="sidenav-item" aria-selected="{{selected}}">{{name}} <span class="doc-count">{{count}}</span></a>
+                <a href="{{url}}" class="sidenav-item" aria-selected="{{selected}}">
+                  <span class="sidenav-subitem filter-name">{{name}}</span>
+                  <span class="sidenav-subitem doc-count">({{count}})</span>
+                </a>
               </li>
             {{/each}}
           </ul>
@@ -46,7 +52,10 @@
           <ul class="multibrand-filter-list multibrand-filter-list--collapsed">
             {{#each subfilters}}
               <li>
-                <a href="{{url}}" class="sidenav-item" aria-selected="{{selected}}">{{name}} <span class="doc-count">{{count}}</span></a>
+                <a href="{{url}}" class="sidenav-item" aria-selected="{{selected}}">
+                  <span class="sidenav-subitem filter-name">{{name}}</span>
+                  <span class="sidenav-subitem doc-count">({{count}})</span>
+                </a>
               </li>
             {{/each}}
             {{#is current_filter.identifier 'knowledge_base'}}

--- a/templates/search_results.hbs
+++ b/templates/search_results.hbs
@@ -8,7 +8,7 @@
   <div class="search-results">
     <aside class="search-results-sidebar">
       {{#if help_center_filters}}
-        <section class="filters-in-section collapsible-sidebar">
+        <section class="filters-in-section collapsible-sidebar" aria-expanded="false">
           <button type="button" class="collapsible-sidebar-toggle" aria-expanded="false"></button>
           <h3 class="collapsible-sidebar-title sidenav-title">{{t 'filter_by_help_center'}}</h3>
           <ul class="multibrand-filter-list multibrand-filter-list--collapsed">
@@ -25,7 +25,7 @@
         </section>
       {{/if}}
       {{#if help_center.community_enabled}}
-        <section class="filters-in-section collapsible-sidebar">
+        <section class="filters-in-section collapsible-sidebar" aria-expanded="false">
           <button type="button" class="collapsible-sidebar-toggle" aria-expanded="false"></button>
           <h3 class="collapsible-sidebar-title sidenav-title">{{t 'filter_by_type'}}</h3>
           <ul class="multibrand-filter-list multibrand-filter-list--collapsed">
@@ -41,7 +41,7 @@
         </section>
       {{/if}}
       {{#if subfilters}}
-        <section class="filters-in-section collapsible-sidebar">
+        <section class="filters-in-section collapsible-sidebar" aria-expanded="false">
           <button type="button" class="collapsible-sidebar-toggle" aria-expanded="false"></button>
           {{#is current_filter.identifier 'knowledge_base'}}
             <h3 class="collapsible-sidebar-title sidenav-title">{{t 'filter_by_category'}}</h3>

--- a/templates/search_results.hbs
+++ b/templates/search_results.hbs
@@ -6,7 +6,7 @@
   </nav>
 
   <div class="search-results">
-    <section class="search-results-sidebar">
+    <aside class="search-results-sidebar">
       {{#if help_center_filters}}
         <section class="filters-in-section collapsible-sidebar">
           <button type="button" class="collapsible-sidebar-toggle" aria-expanded="false"></button>
@@ -20,7 +20,7 @@
                 </a>
               </li>
             {{/each}}
-            <a tabindex="0" class="see-all-filters" aria-hidden="true" title="{{t 'show_more_help_centers'}}">{{t 'show_more_help_centers'}}</a>
+            <button class="see-all-filters" aria-hidden="true" aria-label="{{t 'show_more_help_centers'}}">{{t 'show_more_help_centers'}}</button>
           </ul>
         </section>
       {{/if}}
@@ -59,15 +59,15 @@
               </li>
             {{/each}}
             {{#is current_filter.identifier 'knowledge_base'}}
-              <a tabindex="0" class="see-all-filters" aria-hidden="true" title="{{t 'show_more_categories'}}">{{t 'show_more_categories'}}</a>
+              <button class="see-all-filters" aria-hidden="true" aria-label="{{t 'show_more_categories'}}">{{t 'show_more_categories'}}</button>
             {{/is}}
             {{#is current_filter.identifier 'community'}}
-              <a tabindex="0" class="see-all-filters" aria-hidden="true" title="{{t 'show_more_topics'}}">{{t 'show_more_topics'}}</a>
+              <button class="see-all-filters" aria-hidden="true" aria-label="{{t 'show_more_topics'}}">{{t 'show_more_topics'}}</button>
             {{/is}}
           </ul>
         </section>
       {{/if}}
-    </section>
+    </aside>
 
     <section class="search-results-column">
       <h1 class="search-results-subheading">


### PR DESCRIPTION
This PR is to update Copenhagen theme to support multibrand search.

Please don't merge it before the GA of multibrand search.

Main changes:
- Display search results of knowledge and community in one column instead of two.
- In sidebar show help center filters, type filters and sub filters. So users can scope by help center, type (knowledge or community) and category (or topic).
- If `multibrand_search` is not enabled or there is only one help center, hide help center filters. If community is not enabled, hide type filters.
- If there are more than 5 help centers, show the first 5 and hide the rest. Users can click the `see more` button to see the rest. Same case when there are more than 5 categories or topics.
- In the search result column, align number of votes, author name and timestamp to the right side.