### PR TITLE
Improve a11y for Menu Button

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Copenhagen",
   "author": "Zendesk",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "api_version": 1,
   "default_locale": "en-us",
   "settings": [{

--- a/script.js
+++ b/script.js
@@ -136,7 +136,7 @@ document.addEventListener('DOMContentLoaded', function() {
     toggle.focus();
   }
 
-  var burgerMenu = document.querySelector('.header .icon-menu');
+  var burgerMenu = document.querySelector('.header .menu-button');
   var userMenu = document.querySelector('#user-nav');
 
   burgerMenu.addEventListener('click', function(e) {
@@ -144,12 +144,6 @@ document.addEventListener('DOMContentLoaded', function() {
     toggleNavigation(this, userMenu);
   });
 
-  burgerMenu.addEventListener('keyup', function(e) {
-    if (e.keyCode === 13) { // Enter key
-      e.stopPropagation();
-      toggleNavigation(this, userMenu);
-    }
-  });
 
   userMenu.addEventListener('keyup', function(e) {
     if (e.keyCode === 27) { // Escape key

--- a/style.css
+++ b/style.css
@@ -502,10 +502,10 @@ ul {
   display: inline-block;
 }
 
-.nav-wrapper .icon-menu {
+.nav-wrapper .menu-button {
+  background: none;
   border: 0;
   color: $link_color;
-  cursor: pointer;
   display: inline-block;
   margin-right: 10px;
   padding: 0;
@@ -513,17 +513,23 @@ ul {
 }
 
 @media (min-width: 768px) {
-  .nav-wrapper .icon-menu {
+  .nav-wrapper .menu-button {
     display: none;
   }
 }
 
-[dir="rtl"] .nav-wrapper .icon-menu {
+.nav-wrapper .menu-button .icon-menu {
+  vertical-align: middle;
+  width: 13px;
+  height: 13px;
+}
+
+[dir="rtl"] .nav-wrapper .menu-button {
   margin-left: 10px;
   margin-right: 0;
 }
 
-.nav-wrapper .icon-menu:hover, .nav-wrapper .icon-menu:focus, .nav-wrapper .icon-menu:active {
+.nav-wrapper .menu-button:hover, .nav-wrapper .menu-button:focus, .nav-wrapper .menu-button:active {
   background-color: transparent;
   color: $link_color;
 }
@@ -3426,10 +3432,6 @@ ul {
 
 .icon-gear::before {
   content: "\2699";
-}
-
-.icon-menu::before {
-  content: "\2630";
 }
 
 .icon-article::before {

--- a/styles/_header.scss
+++ b/styles/_header.scss
@@ -62,15 +62,21 @@ $header-height: 71px;
     &.login { display: inline-block; }
   }
 
-  .icon-menu {
+  .menu-button {
     @include tablet { display: none; }
+    background: none;
     border: 0;
     color: $link_color;
-    cursor: pointer;
     display: inline-block;
     margin-right: 10px;
     padding: 0;
     width: auto;
+
+    .icon-menu {
+      vertical-align: middle;
+      width: 13px;
+      height: 13px;
+    }
 
     [dir="rtl"] & {
       margin-left: 10px;

--- a/styles/_icons.scss
+++ b/styles/_icons.scss
@@ -76,10 +76,6 @@
   content: "\2699";
 }
 
-.icon-menu::before {
-  content: "\2630";
-}
-
 .icon-article::before {
   content: "\1F4C4";
 }

--- a/templates/header.hbs
+++ b/templates/header.hbs
@@ -5,7 +5,11 @@
     {{/link}}
   </div>
   <div class="nav-wrapper">
-    <span class="icon-menu" tabindex="0" role="button" aria-controls="user-nav" aria-expanded="false" aria-label="{{t 'toggle_navigation'}}"></span>
+    <button class="menu-button" aria-controls="user-nav" aria-expanded="false" aria-label="{{t 'toggle_navigation'}}">
+      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" focusable="false" viewBox="0 0 16 16" class="icon-menu">
+        <path fill="none" stroke="currentColor" stroke-linecap="round" d="M1.5 3.5h13m-13 4h13m-13 4h13"/>
+      </svg>
+    </button>
     <nav class="user-nav" id="user-nav">
       {{link 'community'}}
       {{link 'new_request' class='submit-a-request'}}


### PR DESCRIPTION
This PR changes the menu button from a `<span role="button">` to a `<button>`, to improve a11y (e.g. keyboard navigation), and has the positive side effect that we can reduce the scripting logic.

This also adds an svg for the menu icon.

cc @zendesk/guide-growth 