### PR TITLE
[GG-120] Fix collapsable-nav-list a11y

### DIFF
--- a/style.css
+++ b/style.css
@@ -2652,36 +2652,46 @@ ul {
   .collapsible-nav-list li:hover {
     border-bottom: 4px solid #ddd;
   }
-  .collapsible-nav-list li:hover a {
+  .collapsible-nav-list li:hover a:not([aria-current="page"]) {
     padding: 15px 0 11px 0;
     text-decoration: none;
   }
 }
 
-.collapsible-nav-list li:not([aria-selected="true"]) {
+.collapsible-nav-list li:not([aria-selected="true"]),
+.collapsible-nav-list li:not(.current) {
   display: none;
 }
 
 @media (min-width: 768px) {
-  .collapsible-nav-list li:not([aria-selected="true"]) {
+  .collapsible-nav-list li:not([aria-selected="true"]),
+  .collapsible-nav-list li:not(.current) {
     display: block;
   }
 }
 
-.collapsible-nav-list li[aria-selected="true"] {
+@media (min-width: 768px) {
+  .collapsible-nav-list li[aria-selected="true"] {
+    padding: 15px 0 11px 0;
+  }
+}
+
+.collapsible-nav-list li[aria-selected="true"],
+.collapsible-nav-list li.current {
   order: 0;
   position: relative;
 }
 
 @media (min-width: 768px) {
-  .collapsible-nav-list li[aria-selected="true"] {
+  .collapsible-nav-list li[aria-selected="true"],
+  .collapsible-nav-list li.current {
     border-bottom: 4px solid $brand_color;
     order: 1;
-    padding: 15px 0 11px 0;
   }
 }
 
-.collapsible-nav-list li[aria-selected="true"] a {
+.collapsible-nav-list li[aria-selected="true"] a,
+.collapsible-nav-list li.current a {
   color: $text_color;
 }
 
@@ -2689,7 +2699,8 @@ ul {
   content: "\2715";
 }
 
-.collapsible-nav[aria-expanded="true"] li:not([aria-selected="true"]) {
+.collapsible-nav[aria-expanded="true"] li:not([aria-selected="true"]),
+.collapsible-nav[aria-expanded="true"] li:not(.current) {
   display: block;
 }
 

--- a/styles/_collapsible-nav.scss
+++ b/styles/_collapsible-nav.scss
@@ -85,23 +85,30 @@
     @include tablet {
       border-bottom: 4px solid #ddd;
 
-      a {
+      a:not([aria-current="page"]) {
         padding: 15px 0 11px 0;
         text-decoration: none;
       }
     }
   }
 
-  li:not([aria-selected="true"]) {
+  li:not([aria-selected="true"]),
+  li:not(.current) {
     @include tablet { display: block; }
     display: none;
   }
 
   li[aria-selected="true"] {
     @include tablet {
+      padding: 15px 0 11px 0;
+    }
+  }
+
+  li[aria-selected="true"],
+  li.current {
+    @include tablet {
       border-bottom: 4px solid $brand_color;
       order: 1;
-      padding: 15px 0 11px 0;
     }
 
     order: 0; //Move to top of menu
@@ -117,7 +124,8 @@
     content: "\2715";
   }
 
-  li:not([aria-selected="true"]) {
+  li:not([aria-selected="true"]),
+  li:not(.current) {
     display: block;
   }
 }

--- a/templates/contributions_page.hbs
+++ b/templates/contributions_page.hbs
@@ -23,7 +23,9 @@
         <ul class="collapsible-nav-list">
           {{#each filters}}
             {{#if selected}}
-              <li aria-selected=true>{{name}}</li>
+              <li class="current">
+                <a href="{{url}}" aria-current="page">{{name}}</a>
+              </li>
             {{else}}
               <li>
                 <a href="{{url}}">{{name}}</a>

--- a/templates/user_profile_page.hbs
+++ b/templates/user_profile_page.hbs
@@ -87,7 +87,7 @@
           <ul class="collapsible-nav-list">
             {{#each filters}}
               {{#if selected}}
-                <li aria-selected=true>{{name}}</li>
+                <li class="current"><a href="{{url}}" aria-current="page">{{name}}</a></li>
               {{else}}
                 <li><a href="{{url}}">{{name}}</a></li>
               {{/if}}


### PR DESCRIPTION
Adresses `aria-selected` issues with `collapsible-nav-list` in User Profiles and Contributions navigations.

While not perfect, nor consistently supported yet, `aria-current="page"` is the best solution to communicate that a link is pointing to the current page.

This issue remains to be fixed here:
https://github.com/zendesk/copenhagen_theme/blob/c239929f6c6afd04fa619f3beaafbf31867d4afa/templates/contributions_page.hbs#L5-L11

https://github.com/zendesk/copenhagen_theme/blob/8ad266702dc97e955f3cf759615459a1762c4340/templates/request_page.hbs#L5-L9

https://github.com/zendesk/copenhagen_theme/blob/af6818124445722bd63b58a429ef820380d312c1/templates/requests_page.hbs#L5-L9

https://github.com/zendesk/copenhagen_theme/blob/af6818124445722bd63b58a429ef820380d312c1/templates/subscriptions_page.hbs#L5-L11

JIRA: https://zendesk.atlassian.net/browse/GG-120

cc @zendesk/guide-growth 