### PR TITLE
[GG-121] Change link color to improve contrast ratio

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Copenhagen",
   "author": "Zendesk",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "api_version": 1,
   "default_locale": "en-us",
   "settings": [{

--- a/manifest.json
+++ b/manifest.json
@@ -29,7 +29,7 @@
       "type": "color",
       "description": "link_color_description",
       "label": "link_color_label",
-      "value": "#0072EF"
+      "value": "#1F73B7"
     }, {
       "identifier": "background_color",
       "type": "color",


### PR DESCRIPTION
Changes the default link color to `#1F73B7` to have an acceptable contrast ratio for backgrounds with color `#FFFFFF` and `#F7F7F7`

JIRA: https://zendesk.atlassian.net/browse/GG-121

cc @zendesk/guide-growth 