### PR TITLE
Update manifest to v2

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Copenhagen",
   "author": "Zendesk",
-  "version": "1.8.2",
+  "version": "2.0.0-alpha.1",
   "api_version": 2,
   "default_locale": "en-us",
   "settings": [{

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Copenhagen",
   "author": "Zendesk",
   "version": "1.8.2",
-  "api_version": 1,
+  "api_version": 2,
   "default_locale": "en-us",
   "settings": [{
     "label": "colors_group_label",


### PR DESCRIPTION
I've created a branch for API v2 changes, and this commit bumps the api_version in the manifest.

Should the theme version be bumped to `2.0.0`?

cc @zendesk/guide-growth 