### PR TITLE
[GG-115] Use span in blocks, instead of headings

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Copenhagen",
   "author": "Zendesk",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "api_version": 1,
   "default_locale": "en-us",
   "settings": [{

--- a/style.css
+++ b/style.css
@@ -926,6 +926,7 @@ ul {
 
 .blocks-item-title {
   margin-bottom: 0;
+  font-size: 16px;
 }
 
 .blocks-item-description {

--- a/styles/_blocks.scss
+++ b/styles/_blocks.scss
@@ -76,6 +76,7 @@
 
   &-item-title {
     margin-bottom: 0;
+    font-size: 16px;
   }
 
   &-item-description {

--- a/templates/community_topic_list_page.hbs
+++ b/templates/community_topic_list_page.hbs
@@ -39,14 +39,14 @@
       {{#each topics}}
         <li class="blocks-item topics-item {{#if internal}}blocks-item-internal{{/if}}">
            <a href="{{url}}" class="blocks-item-link">
-             <h4 class="blocks-item-title">
+             <span class="blocks-item-title">
                {{name}}
 
                {{#if internal}}
                  <span class="icon-lock" title="{{t 'internal'}}"></span>
                {{/if}}
-             </h4>
-             <p class="blocks-item-description">{{excerpt description}}</p>
+             </span>
+             <span class="blocks-item-description">{{excerpt description}}</span>
              <ul class="meta-group">
                <li class="meta-data">{{t 'post_count' count=post_count}}</li>
                <li class="meta-data">{{t 'follower_count' count=follower_count}}</li>

--- a/templates/home_page.hbs
+++ b/templates/home_page.hbs
@@ -12,18 +12,18 @@
           {{#if ../has_multiple_categories}}
             <li class="blocks-item">
               <a href='{{url}}' class="blocks-item-link">
-                <h4 class="blocks-item-title">{{name}}</h4>
-                <p class="blocks-item-description">{{excerpt description}}</p>
+                <span class="blocks-item-title">{{name}}</span>
+                <span class="blocks-item-description">{{excerpt description}}</span>
               </a>
             </li>
           {{else}}
             {{#each sections}}
               <li class="blocks-item">
                 <a href='{{url}}' class="blocks-item-link">
-                  <h4 class="blocks-item-title">
+                  <span class="blocks-item-title">
                     {{name}}
-                  </h4>
-                  <p class="blocks-item-description">{{excerpt description}}</p>
+                  </span>
+                  <span class="blocks-item-description">{{excerpt description}}</span>
                 </a>
               </li>
             {{/each}}


### PR DESCRIPTION
I opted for `span` rather than `p`, because I think that's more semantically correct inside anchor tags.

I also updated the blocks for communities, YOLO

https://zendesk.atlassian.net/browse/GG-115

cc @zendesk/guide-growth 