### PR TITLE
[GG-771] Fix a11y for comments link on Article page

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Copenhagen",
   "author": "Zendesk",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "api_version": 1,
   "default_locale": "en-us",
   "settings": [{

--- a/style.css
+++ b/style.css
@@ -1418,12 +1418,11 @@ ul {
   text-decoration: none;
 }
 
-.article-comment-count .icon-comments {
+.article-comment-count-icon {
+  vertical-align: middle;
   color: $brand_color;
-  content: "\1F4AC";
-  display: inline-block;
-  font-size: 18px;
-  padding: 5px;
+  width: 18px;
+  height: 18px;
 }
 
 .article-sidebar {

--- a/styles/_article.scss
+++ b/styles/_article.scss
@@ -101,12 +101,11 @@
       text-decoration: none;
     }
 
-    .icon-comments {
+    &-icon {
+      vertical-align: middle;
       color: $brand_color;
-      content: "\1F4AC";
-      display: inline-block;
-      font-size: 18px;
-      padding: 5px;
+      width: 18px;
+      height: 18px;
     }
   }
 

--- a/templates/article_page.hbs
+++ b/templates/article_page.hbs
@@ -97,9 +97,16 @@
           {{/if}}
           {{#if settings.show_article_comments}}
             {{#if comments}}
-              <a href="#article-comments" class="article-comment-count">
-                <span class="icon-comments"></span>
-                {{article.comment_count}}
+              <a href="#article-comments" class="article-comment-count" title="{{t 'go_to_comments'}}">
+                <span class="visibility-hidden">
+                  {{t 'comments_count' count=article.comment_count}}
+                </span>
+                <span aria-hidden="true">
+                  <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" focusable="false" viewBox="0 0 12 12" class="article-comment-count-icon">
+                    <path fill="none" stroke="currentColor" d="M1 .5h10c.3 0 .5.2.5.5v7c0 .3-.2.5-.5.5H6l-2.6 2.6c-.3.3-.9.1-.9-.4V8.5H1C.7 8.5.5 8.3.5 8V1C.5.7.7.5 1 .5z"/>
+                  </svg>
+                  {{article.comment_count}}
+                </span>
               </a>
             {{/if}}
           {{/if}}


### PR DESCRIPTION
Depends on https://github.com/zendesk/help_center/pull/19739 to be merged.

Adds the icon as SVG instead of pseudo-element, and adds a title to the link to explain what the link actually does. I'm a bit conflicted on the latter, since the link's functionality isn't very apparent to seeing users. Maybe it just shouldn't be a link 🤷‍♂ 