### PR TITLE
[COMM-90] & [COMM-628] Remove arrows from vote buttons

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Copenhagen",
   "author": "Zendesk",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "api_version": 1,
   "default_locale": "en-us",
   "settings": [{

--- a/style.css
+++ b/style.css
@@ -1931,13 +1931,9 @@ ul {
 /***** Vote *****/
 /* Used in article comments, post comments and post */
 .vote {
-  display: inline-block;
+  display: flex;
+  flex-direction: column;
   text-align: center;
-  width: 35px;
-}
-
-.vote a {
-  outline: none;
 }
 
 .vote a:active, .vote a:hover, .vote a:focus {
@@ -1955,29 +1951,25 @@ ul {
   unicode-bidi: bidi-override;
 }
 
-.vote-up:hover::before,
-.vote-down:hover::before {
+.vote-up:hover,
+.vote-down:hover {
   color: $brand_color;
 }
 
-.vote-up::before, .vote-down::before {
+.vote-up, .vote-down {
   color: lighten($text_color, 20%);
-  font-size: 24px;
+  min-height: 44px;
+  min-width: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
-.vote-up::before {
-  content: "\2B06";
-}
-
-.vote-down::before {
-  content: "\2B07";
-}
-
-.vote-voted::before {
+.vote-voted {
   color: $brand_color;
 }
 
-.vote-voted:hover::before {
+.vote-voted:hover {
   color: darken($brand_color, 20%);
 }
 
@@ -3384,8 +3376,6 @@ ul {
 .article-vote::before,
 .attachments .attachment-item::before,
 .share a::before,
-.vote-up::before,
-.vote-down::before,
 .actions .dropdown-toggle::before,
 .collapsible-nav-toggle::after,
 .collapsible-sidebar-toggle::after {

--- a/style.css
+++ b/style.css
@@ -1514,12 +1514,8 @@ ul {
   color: $brand_text_color;
 }
 
-.article-vote-up::before {
-  content: "\2713";
-}
-
-.article-vote-down::before {
-  content: "\2715";
+.article-vote > * {
+  vertical-align: middle;
 }
 
 .article-more-questions {

--- a/style.css
+++ b/style.css
@@ -1514,7 +1514,7 @@ ul {
   color: $brand_text_color;
 }
 
-.article-vote > * {
+.article-vote .icon, .article-vote .search::before, .article-vote .recent-activity-item-comment span::before, .recent-activity-item-comment .article-vote span::before, .article-vote .article-vote::before, .article-vote .attachments .attachment-item::before, .attachments .article-vote .attachment-item::before, .article-vote .share a::before, .share .article-vote a::before, .article-vote .actions .dropdown-toggle::before, .actions .article-vote .dropdown-toggle::before, .article-vote .collapsible-nav-toggle::after, .article-vote .collapsible-sidebar-toggle::after {
   vertical-align: middle;
 }
 

--- a/styles/_article.scss
+++ b/styles/_article.scss
@@ -192,7 +192,7 @@
       color: $brand_text_color;
     }
 
-    > * {
+    .icon {
       vertical-align: middle;
     }
   }

--- a/styles/_article.scss
+++ b/styles/_article.scss
@@ -191,14 +191,10 @@
     &[aria-selected="true"]::after {
       color: $brand_text_color;
     }
-  }
 
-  &-vote-up::before {
-    content: "\2713";
-  }
-
-  &-vote-down::before {
-    content: "\2715";
+    > * {
+      vertical-align: middle;
+    }
   }
 
   &-more-questions {

--- a/styles/_vote.scss
+++ b/styles/_vote.scss
@@ -1,12 +1,10 @@
 /***** Vote *****/
 /* Used in article comments, post comments and post */
 .vote {
-  display: inline-block;
+  display: flex;
+  flex-direction: column;
   text-align: center;
-  width: 35px;
   a {
-    outline: none;
-
     &:active,
     &:hover,
     &:focus {
@@ -26,29 +24,24 @@
   }
 }
 
-.vote-up:hover::before,
-.vote-down:hover::before {
+.vote-up:hover,
+.vote-down:hover {
   color: $brand_color;
 }
 
-.vote-up::before, .vote-down::before {
-  @extend .icon;
+.vote-up, .vote-down {
   color: $secondary-text-color;
-  font-size: 24px;
+  min-height: 44px;
+  min-width: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
-.vote-up::before {
-  content: "\2B06";
-}
-
-.vote-down::before {
-  content: "\2B07";
-}
-
-.vote-voted::before {
+.vote-voted {
   color: $brand_color;
 }
 
-.vote-voted:hover::before {
+.vote-voted:hover {
   color: $hover-button-color;
 }

--- a/templates/article_page.hbs
+++ b/templates/article_page.hbs
@@ -115,8 +115,16 @@
           <div class="article-votes">
             <span class="article-votes-question">{{t 'was_this_article_helpful'}}</span>
             <div class="article-votes-controls" role='radiogroup'>
-              {{vote 'up' role='radio' class='button article-vote article-vote-up'}}
-              {{vote 'down' role='radio' class='button article-vote article-vote-down'}}
+              {{#vote 'up' role='radio' class='button article-vote article-vote-up'}}
+              <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" focusable="false" viewBox="0 0 16 16" transform="scale(1,-1)">
+                <path fill="none" stroke="currentColor" stroke-linecap="round" stroke-width="2" d="M4 6.5l3.6 3.6c.2.2.5.2.7 0L12 6.5"/>
+              </svg>
+              {{/vote}}
+              {{#vote 'down' role='radio' class='button article-vote article-vote-down'}}
+              <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" focusable="false" viewBox="0 0 16 16">
+                <path fill="none" stroke="currentColor" stroke-linecap="round" stroke-width="2" d="M4 6.5l3.6 3.6c.2.2.5.2.7 0L12 6.5"/>
+              </svg>
+              {{/vote}}
             </div>
             <small class="article-votes-count">
               {{vote 'label' class='article-vote-label'}}
@@ -207,9 +215,17 @@
 
                     <div class="comment-actions-container">
                       <div class="comment-vote vote" role='radiogroup'>
-                        {{vote 'up' role='radio' class='vote-up' selected_class='vote-voted'}}
+                        {{#vote 'up' role='radio' class='vote-up' selected_class='vote-voted'}}
+                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" focusable="false" viewBox="0 0 16 16" transform="scale(1,-1)">
+                          <path fill="none" stroke="currentColor" stroke-linecap="round" stroke-width="2" d="M4 6.5l3.6 3.6c.2.2.5.2.7 0L12 6.5"/>
+                        </svg>
+                        {{/vote}}
                         {{vote 'sum' class='vote-sum'}}
-                        {{vote 'down' role='radio' class='vote-down' selected_class='vote-voted'}}
+                        {{#vote 'down' role='radio' class='vote-down' selected_class='vote-voted'}}
+                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" focusable="false" viewBox="0 0 16 16">
+                          <path fill="none" stroke="currentColor" stroke-linecap="round" stroke-width="2" d="M4 6.5l3.6 3.6c.2.2.5.2.7 0L12 6.5"/>
+                        </svg>
+                        {{/vote}}
                       </div>
                       <div class="comment-actions actions">
                         {{actions}}

--- a/templates/article_page.hbs
+++ b/templates/article_page.hbs
@@ -116,13 +116,13 @@
             <span class="article-votes-question">{{t 'was_this_article_helpful'}}</span>
             <div class="article-votes-controls" role='radiogroup'>
               {{#vote 'up' role='radio' class='button article-vote article-vote-up'}}
-              <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" focusable="false" viewBox="0 0 16 16" transform="scale(1,-1)">
-                <path fill="none" stroke="currentColor" stroke-linecap="round" stroke-width="2" d="M4 6.5l3.6 3.6c.2.2.5.2.7 0L12 6.5"/>
+              <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" focusable="false" viewBox="0 0 16 16">
+                <path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M1 9l4 4L15 3"/>
               </svg>
               {{/vote}}
               {{#vote 'down' role='radio' class='button article-vote article-vote-down'}}
               <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" focusable="false" viewBox="0 0 16 16">
-                <path fill="none" stroke="currentColor" stroke-linecap="round" stroke-width="2" d="M4 6.5l3.6 3.6c.2.2.5.2.7 0L12 6.5"/>
+                <path stroke="currentColor" stroke-linecap="round" stroke-width="2" d="M3 13L13 3m0 10L3 3"/>
               </svg>
               {{/vote}}
             </div>

--- a/templates/article_page.hbs
+++ b/templates/article_page.hbs
@@ -116,12 +116,12 @@
             <span class="article-votes-question">{{t 'was_this_article_helpful'}}</span>
             <div class="article-votes-controls" role='radiogroup'>
               {{#vote 'up' role='radio' class='button article-vote article-vote-up'}}
-              <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" focusable="false" viewBox="0 0 16 16">
+              <svg class="icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" focusable="false" viewBox="0 0 16 16">
                 <path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M1 9l4 4L15 3"/>
               </svg>
               {{/vote}}
               {{#vote 'down' role='radio' class='button article-vote article-vote-down'}}
-              <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" focusable="false" viewBox="0 0 16 16">
+              <svg class="icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" focusable="false" viewBox="0 0 16 16">
                 <path stroke="currentColor" stroke-linecap="round" stroke-width="2" d="M3 13L13 3m0 10L3 3"/>
               </svg>
               {{/vote}}

--- a/templates/community_post_page.hbs
+++ b/templates/community_post_page.hbs
@@ -80,9 +80,17 @@
           <div class="post-actions-wrapper">
             <div class="post-vote vote" role='radiogroup'>
               {{#with post}}
-                {{vote 'up' role='radio' class='vote-up' selected_class='vote-voted'}}
+                {{#vote 'up' role='radio' class='vote-up' selected_class='vote-voted'}}
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" focusable="false" viewBox="0 0 16 16" transform="scale(1,-1)">
+                  <path fill="none" stroke="currentColor" stroke-linecap="round" stroke-width="2" d="M4 6.5l3.6 3.6c.2.2.5.2.7 0L12 6.5"/>
+                </svg>
+                {{/vote}}
                 {{vote 'sum' class='vote-sum'}}
-                {{vote 'down' role='radio' class='vote-down' selected_class='vote-voted'}}
+                {{#vote 'down' role='radio' class='vote-down' selected_class='vote-voted'}}
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" focusable="false" viewBox="0 0 16 16">
+                  <path fill="none" stroke="currentColor" stroke-linecap="round" stroke-width="2" d="M4 6.5l3.6 3.6c.2.2.5.2.7 0L12 6.5"/>
+                </svg>
+                {{/vote}}
               {{/with}}
             </div>
 
@@ -174,9 +182,17 @@
               <div class="comment-actions-container">
                 {{#unless official}}
                   <div class="comment-vote vote" role='radiogroup'>
-                    {{vote 'up' role='radio' class='vote-up' selected_class='vote-voted'}}
+                    {{#vote 'up' role='radio' class='vote-up' selected_class='vote-voted'}}
+                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" focusable="false" viewBox="0 0 16 16" transform="scale(1,-1)">
+                      <path fill="none" stroke="currentColor" stroke-linecap="round" stroke-width="2" d="M4 6.5l3.6 3.6c.2.2.5.2.7 0L12 6.5"/>
+                    </svg>
+                    {{/vote}}
                     {{vote 'sum' class='vote-sum'}}
-                    {{vote 'down' role='radio' class='vote-down' selected_class='vote-voted'}}
+                    {{#vote 'down' role='radio' class='vote-down' selected_class='vote-voted'}}
+                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" focusable="false" viewBox="0 0 16 16">
+                      <path fill="none" stroke="currentColor" stroke-linecap="round" stroke-width="2" d="M4 6.5l3.6 3.6c.2.2.5.2.7 0L12 6.5"/>
+                    </svg>
+                    {{/vote}}
                   </div>
                 {{/unless}}
                 <div class="comment-actions actions">


### PR DESCRIPTION
This changes should follow the following change in Help Center: https://github.com/zendesk/help_center/pull/19781

### [COMM-628]

Rather than adding

* Unicode Character 'UPWARDS BLACK ARROW' (U+2B06)
* Unicode Character 'DOWNWARDS BLACK ARROW' (U+2B07)

to the vote buttons using `::before` and a font to go with those
symbols we want to use SVG to display those arrows.  To style those
icons I'm also removing the `::before` selectors for the remaining
rules that deal with styling (hover highlight etc) for these elements.

The modification of the `font-size`, `display` and `flex-direction`
was to fix a centering/alignment issue with this new approach.

I've copied over / inlined this file:

https://github.com/zendeskgarden/svg-icons/blob/master/src/16/chevron-down-fill.svg

From zendeskgarden.  For the upwards pointing caret I've added an SVG
transformation to the root `<svg>` element to mirror it along the
horizontal axis.  Otherwise the two elements are the same.

### [COMM-90]
I've removed the `outline: none` rule. The visual clue is consistent with the other keyboard-navigatable elements and the chevron is aligned within the outline. This is what it looks like:

![image](https://user-images.githubusercontent.com/4547733/70427616-5bb05500-1a75-11ea-9f51-5ba8351ea835.png)


[COMM-628]: https://zendesk.atlassian.net/browse/COMM-628

[COMM-90]: https://zendesk.atlassian.net/browse/COMM-90