### PR TITLE
Add .zat file to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .sass-cache/
 style.css.map
 node_modules/
+.zat


### PR DESCRIPTION
ZAT supports a local `.zat` with auth credentials (https://developer.zendesk.com/apps/docs/developer-guide/zat#authentication), but it shouldn't be checked in