### PR TITLE
[COMM-350] Change topic and post list items to be sections

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Copenhagen",
   "author": "Zendesk",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "api_version": 1,
   "default_locale": "en-us",
   "settings": [{

--- a/templates/community_post_list_page.hbs
+++ b/templates/community_post_list_page.hbs
@@ -59,17 +59,17 @@
     </span>
   </div>
 
-  <ul class="posts-list striped-list">
+  <div class="posts-list striped-list">
     {{#unless posts}}
       <div class="no-posts-with-filter">
         {{t 'no_posts_with_filter'}}
       </div>
     {{/unless}}
     {{#each posts}}
-      <li>
+      <section role="region" aria-labelledby="title-{{id}}">
         <div class="striped-list-item {{#if featured}}post-featured{{/if}}">
           <span class="striped-list-info">
-            <a href="{{url}}" title="{{title}}" class="striped-list-title">{{title}}</a>
+            <a href="{{url}}" id="title-{{id}}" class="striped-list-title">{{title}}</a>
             <span class="post-overview-item">
               {{#if pinned}}
                 <span class="status-label status-label-pinned">{{t 'pinned'}}</span>
@@ -107,9 +107,9 @@
             </span>
           </div>
         </div>
-      </li>
+      </section>
     {{/each}}
-  </ul>
+  </div>
 
   {{pagination}}
 

--- a/templates/community_topic_page.hbs
+++ b/templates/community_topic_page.hbs
@@ -54,12 +54,12 @@
     </span>
   </div>
 
-  <ul class="posts-list striped-list">
+  <div class="posts-list striped-list">
     {{#each posts}}
-      <li>
+      <section role="region" aria-labelledby="title-{{id}}">
         <div class="striped-list-item {{#if featured}}post-featured{{/if}}">
           <span class="striped-list-info">
-            <a href="{{url}}" title="{{title}}" class="striped-list-title">{{title}}</a>
+            <a href="{{url}}" id="title-{{id}}" class="striped-list-title">{{title}}</a>
             <span class="post-overview-item">
               {{#if pinned}}
                 <span class="status-label status-label-pinned">{{t 'pinned'}}</span>
@@ -97,9 +97,9 @@
             </span>
           </div>
         </div>
-      </li>
+      </section>
     {{/each}}
-  </ul>
+  </div>
   {{pagination}}
 </div>
 


### PR DESCRIPTION
The ticket only mentions the Topics List page, but since Post List is the same markup, I've made the change there as-well.

Recent Activities should be aligned with this change.

JIRA: https://zendesk.atlassian.net/browse/COMM-350