### PR TITLE
[COMM-352] Fix the heading structure on Community list page

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Copenhagen",
   "author": "Zendesk",
-  "version": "1.12.2",
+  "version": "1.13.0",
   "api_version": 1,
   "default_locale": "en-us",
   "settings": [{

--- a/style.css
+++ b/style.css
@@ -2013,6 +2013,11 @@ ul {
   margin-bottom: 20px;
 }
 
+.community-featured-posts .title {
+  font-size: 18px;
+  font-weight: 600;
+}
+
 .community-featured-posts, .community-activity {
   padding-top: 40px;
   width: 100%;
@@ -2022,7 +2027,7 @@ ul {
   margin-bottom: 30px;
 }
 
-.community-header h1 {
+.community-header .title {
   margin-bottom: 0;
   font-size: 16px;
 }

--- a/styles/_community.scss
+++ b/styles/_community.scss
@@ -15,6 +15,11 @@
     }
   }
 
+  &-featured-posts .title {
+    font-size: 18px;
+    font-weight: 600;
+  }
+
   &-featured-posts,
   &-activity {
     padding-top: 40px;
@@ -24,7 +29,7 @@
   &-header {
     margin-bottom: 30px;
 
-    h1 {
+    .title {
       margin-bottom: 0;
       font-size: 16px;
     }

--- a/templates/community_post_list_page.hbs
+++ b/templates/community_post_list_page.hbs
@@ -1,3 +1,5 @@
+<h1 class="visibility-hidden">{{ t 'community'}}</h1>
+
 <section class="section hero community-hero">
   <div class="hero-inner">
     {{search submit=false class='search search-full' scoped=settings.scoped_community_search}}
@@ -10,10 +12,11 @@
   </nav>
 
   <header class="page-header community-header">
-    <h1>
       <span class="dropdown">
         <button class="dropdown-toggle" aria-haspopup="true">
-          {{t 'all_posts'}}
+          <h2 class="title">
+            {{t 'all_posts'}}
+          </h2>
         </button>
         <span class="dropdown-menu" role="menu">
           {{#link 'topics' role='menuitem'}}
@@ -24,7 +27,6 @@
           {{/link}}
         </span>
       </span>
-    </h1>
     <span class="post-to-community">
       {{link 'new_post' role='button' class='button-large'}}
     </span>
@@ -115,7 +117,7 @@
 
   {{#if featured_posts}}
     <section class="section community-featured-posts">
-      <h3>{{t 'featured_posts'}}</h3>
+      <h2 class="title">{{t 'featured_posts'}}</h2>
       <ul class="promoted-articles">
         {{#each featured_posts}}
           <li class="promoted-articles-item">

--- a/templates/community_topic_list_page.hbs
+++ b/templates/community_topic_list_page.hbs
@@ -1,4 +1,7 @@
+<h1 class="visibility-hidden">{{ t 'community'}}</h1>
+
 <section class="section hero community-hero">
+  <h2 class="visibility-hidden">{{ t 'search'}}</h2>
   <div class="hero-inner">
     {{search submit=false class='search search-full' scoped=settings.scoped_community_search}}
   </div>
@@ -10,11 +13,12 @@
   </nav>
 
   <header class="page-header community-header">
-    <h1>
       <span class="dropdown">
-        <button class="dropdown-toggle" aria-haspopup="true">
-          {{t 'community_topics'}}
-        </button>
+          <button class="dropdown-toggle" aria-haspopup="true">
+            <h2 class="title">
+              {{t 'community_topics'}}
+            </h2>
+          </button>
         <span class="dropdown-menu" role="menu">
           {{#link 'topics' role='menuitem' selected='true'}}
             {{t 'show_topics'}}
@@ -24,7 +28,6 @@
           {{/link}}
         </span>
       </span>
-    </h1>
     <span class="post-to-community">
       {{link 'new_post' role='button' class='button-large'}}
     </span>
@@ -61,7 +64,7 @@
 
   {{#if featured_posts}}
     <section class="section community-featured-posts">
-      <h3>{{t 'featured_posts'}}</h3>
+      <h2 class="title">{{t 'featured_posts'}}</h2>
       <ul class="promoted-articles">
         {{#each featured_posts}}
           <li class="promoted-articles-item">


### PR DESCRIPTION
I think the heading within a popup button is strange, and that part should probably change, but this is the quickest solution without redesigning the interactions so much, while still addressing the issue.

Don't merge before the strings are translated (same as #117)

JIRA: https://zendesk.atlassian.net/browse/COMM-352