### PR TITLE
Remove red `*` for required fields

### DIFF
--- a/style.css
+++ b/style.css
@@ -384,12 +384,6 @@ ul {
   margin: 0 0 0 10px;
 }
 
-.form-field.required > label::after {
-  content: "*";
-  color: #f00;
-  margin-left: 2px;
-}
-
 .form-field .optional {
   color: lighten($text_color, 20%);
   margin-left: 4px;

--- a/styles/_forms.scss
+++ b/styles/_forms.scss
@@ -62,12 +62,6 @@
   margin: 0 0 0 10px;
 }
 
-.form-field.required > label::after {
-  content: "*";
-  color: #f00;
-  margin-left: 2px;
-}
-
 .form-field .optional {
   color: $secondary-text-color;
   margin-left: 4px;


### PR DESCRIPTION
For accessibility reasons we want to stop indicating that the form field is required by appending `*` via css, which is ignored by the screen readers. 

Initial idea was to inline the marker into the label, but to keep it consistent with other parts of the product and general guidelines for the forms - we should instead mark optional fields with `(optional)` and not mark the required fields.

Therefore, this PR removes the style responsible for adding the `*` and coloring it. 
 