### PR TITLE
[COMM-721] Fix flipped vote buttons

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Copenhagen",
   "author": "Zendesk",
-  "version": "1.14.1",
+  "version": "1.14.2",
   "api_version": 1,
   "default_locale": "en-us",
   "settings": [{

--- a/style.css
+++ b/style.css
@@ -1972,6 +1972,10 @@ ul {
   unicode-bidi: bidi-override;
 }
 
+.vote-up svg {
+  transform: scale(1, -1);
+}
+
 .vote-up:hover,
 .vote-down:hover {
   color: $brand_color;

--- a/styles/_vote.scss
+++ b/styles/_vote.scss
@@ -24,6 +24,10 @@
   }
 }
 
+.vote-up svg {
+  transform: scale(1, -1);
+}
+
 .vote-up:hover,
 .vote-down:hover {
   color: $brand_color;

--- a/templates/article_page.hbs
+++ b/templates/article_page.hbs
@@ -208,7 +208,7 @@
                     <div class="comment-actions-container">
                       <div class="comment-vote vote" role='radiogroup'>
                         {{#vote 'up' role='radio' class='vote-up' selected_class='vote-voted'}}
-                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" focusable="false" viewBox="0 0 16 16" transform="scale(1,-1)">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" focusable="false" viewBox="0 0 16 16">
                           <path fill="none" stroke="currentColor" stroke-linecap="round" stroke-width="2" d="M4 6.5l3.6 3.6c.2.2.5.2.7 0L12 6.5"/>
                         </svg>
                         {{/vote}}

--- a/templates/community_post_page.hbs
+++ b/templates/community_post_page.hbs
@@ -81,7 +81,7 @@
             <div class="post-vote vote" role='radiogroup'>
               {{#with post}}
                 {{#vote 'up' role='radio' class='vote-up' selected_class='vote-voted'}}
-                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" focusable="false" viewBox="0 0 16 16" transform="scale(1,-1)">
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" focusable="false" viewBox="0 0 16 16">
                   <path fill="none" stroke="currentColor" stroke-linecap="round" stroke-width="2" d="M4 6.5l3.6 3.6c.2.2.5.2.7 0L12 6.5"/>
                 </svg>
                 {{/vote}}
@@ -183,7 +183,7 @@
                 {{#unless official}}
                   <div class="comment-vote vote" role='radiogroup'>
                     {{#vote 'up' role='radio' class='vote-up' selected_class='vote-voted'}}
-                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" focusable="false" viewBox="0 0 16 16" transform="scale(1,-1)">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" focusable="false" viewBox="0 0 16 16">
                       <path fill="none" stroke="currentColor" stroke-linecap="round" stroke-width="2" d="M4 6.5l3.6 3.6c.2.2.5.2.7 0L12 6.5"/>
                     </svg>
                     {{/vote}}


### PR DESCRIPTION
# [COMM-721]

Use a CSS declaration rather than `svg[transform]` for rotating the
up-vote.  Fixes an issue where the transformation was not applied in
non-compliant browsers (e.g. IE and Safari).

# Risk
None - simple style change

[COMM-721]: https://zendesk.atlassian.net/browse/COMM-721