### PR TITLE
[COMM-748] Use `img` for including SVGs

### DIFF
--- a/assets/chevron-down-stroke.svg
+++ b/assets/chevron-down-stroke.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" focusable="false" viewBox="0 0 16 16">
+  <path fill="none" stroke="currentColor" stroke-linecap="round" d="M4 6.5l3.6 3.6c.2.2.5.2.7 0L12 6.5"/>
+</svg>

--- a/style.css
+++ b/style.css
@@ -1972,6 +1972,10 @@ ul {
   unicode-bidi: bidi-override;
 }
 
+.vote-up svg {
+  transform: scale(1, -1);
+}
+
 .vote-up:hover,
 .vote-down:hover {
   color: $brand_color;

--- a/style.css
+++ b/style.css
@@ -1972,7 +1972,7 @@ ul {
   unicode-bidi: bidi-override;
 }
 
-.vote-up svg {
+.vote-up img {
   transform: scale(1, -1);
 }
 

--- a/styles/_vote.scss
+++ b/styles/_vote.scss
@@ -24,6 +24,10 @@
   }
 }
 
+.vote-up svg {
+  transform: scale(1, -1);
+}
+
 .vote-up:hover,
 .vote-down:hover {
   color: $brand_color;

--- a/styles/_vote.scss
+++ b/styles/_vote.scss
@@ -24,7 +24,7 @@
   }
 }
 
-.vote-up svg {
+.vote-up img {
   transform: scale(1, -1);
 }
 

--- a/templates/article_page.hbs
+++ b/templates/article_page.hbs
@@ -208,7 +208,7 @@
                     <div class="comment-actions-container">
                       <div class="comment-vote vote" role='radiogroup'>
                         {{#vote 'up' role='radio' class='vote-up' selected_class='vote-voted'}}
-                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" focusable="false" viewBox="0 0 16 16" transform="scale(1,-1)">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" focusable="false" viewBox="0 0 16 16">
                           <path fill="none" stroke="currentColor" stroke-linecap="round" stroke-width="2" d="M4 6.5l3.6 3.6c.2.2.5.2.7 0L12 6.5"/>
                         </svg>
                         {{/vote}}

--- a/templates/article_page.hbs
+++ b/templates/article_page.hbs
@@ -208,15 +208,11 @@
                     <div class="comment-actions-container">
                       <div class="comment-vote vote" role='radiogroup'>
                         {{#vote 'up' role='radio' class='vote-up' selected_class='vote-voted'}}
-                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" focusable="false" viewBox="0 0 16 16">
-                          <path fill="none" stroke="currentColor" stroke-linecap="round" stroke-width="2" d="M4 6.5l3.6 3.6c.2.2.5.2.7 0L12 6.5"/>
-                        </svg>
+                        <img src="{{asset 'chevron-down-stroke.svg'}}" />
                         {{/vote}}
                         {{vote 'sum' class='vote-sum'}}
                         {{#vote 'down' role='radio' class='vote-down' selected_class='vote-voted'}}
-                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" focusable="false" viewBox="0 0 16 16">
-                          <path fill="none" stroke="currentColor" stroke-linecap="round" stroke-width="2" d="M4 6.5l3.6 3.6c.2.2.5.2.7 0L12 6.5"/>
-                        </svg>
+                        <img src="{{asset 'chevron-down-stroke.svg'}}" />
                         {{/vote}}
                       </div>
                       <div class="comment-actions actions">

--- a/templates/community_post_page.hbs
+++ b/templates/community_post_page.hbs
@@ -81,7 +81,7 @@
             <div class="post-vote vote" role='radiogroup'>
               {{#with post}}
                 {{#vote 'up' role='radio' class='vote-up' selected_class='vote-voted'}}
-                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" focusable="false" viewBox="0 0 16 16" transform="scale(1,-1)">
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" focusable="false" viewBox="0 0 16 16">
                   <path fill="none" stroke="currentColor" stroke-linecap="round" stroke-width="2" d="M4 6.5l3.6 3.6c.2.2.5.2.7 0L12 6.5"/>
                 </svg>
                 {{/vote}}
@@ -183,7 +183,7 @@
                 {{#unless official}}
                   <div class="comment-vote vote" role='radiogroup'>
                     {{#vote 'up' role='radio' class='vote-up' selected_class='vote-voted'}}
-                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" focusable="false" viewBox="0 0 16 16" transform="scale(1,-1)">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" focusable="false" viewBox="0 0 16 16">
                       <path fill="none" stroke="currentColor" stroke-linecap="round" stroke-width="2" d="M4 6.5l3.6 3.6c.2.2.5.2.7 0L12 6.5"/>
                     </svg>
                     {{/vote}}

--- a/templates/community_post_page.hbs
+++ b/templates/community_post_page.hbs
@@ -80,16 +80,12 @@
           <div class="post-actions-wrapper">
             <div class="post-vote vote" role='radiogroup'>
               {{#with post}}
-                {{#vote 'up' role='radio' class='vote-up' selected_class='vote-voted'}}
-                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" focusable="false" viewBox="0 0 16 16">
-                  <path fill="none" stroke="currentColor" stroke-linecap="round" stroke-width="2" d="M4 6.5l3.6 3.6c.2.2.5.2.7 0L12 6.5"/>
-                </svg>
-                {{/vote}}
+              {{#vote 'up' role='radio' class='vote-up' selected_class='vote-voted'}}
+              <img src="{{asset 'chevron-down-stroke.svg'}}" />
+              {{/vote}}
                 {{vote 'sum' class='vote-sum'}}
                 {{#vote 'down' role='radio' class='vote-down' selected_class='vote-voted'}}
-                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" focusable="false" viewBox="0 0 16 16">
-                  <path fill="none" stroke="currentColor" stroke-linecap="round" stroke-width="2" d="M4 6.5l3.6 3.6c.2.2.5.2.7 0L12 6.5"/>
-                </svg>
+                <img src="{{asset 'chevron-down-stroke.svg'}}" />
                 {{/vote}}
               {{/with}}
             </div>


### PR DESCRIPTION
# [COMM-748]

Should follow https://github.com/zendesk/copenhagen_theme/pull/151

# Risk
None

[COMM-748]: https://zendesk.atlassian.net/browse/COMM-748