### PR TITLE
Add `button` class name to `button-large` elements

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Copenhagen",
   "author": "Zendesk",
-  "version": "2.0.0-alpha.12",
+  "version": "2.0.0-alpha.13",
   "api_version": 2,
   "default_locale": "en-us",
   "settings": [{

--- a/templates/community_post_list_page.hbs
+++ b/templates/community_post_list_page.hbs
@@ -36,7 +36,7 @@
         </span>
       </span>
     <span class="post-to-community">
-      {{link 'new_post' role='button' class='button-large'}}
+      {{link 'new_post' role='button' class='button button-large'}}
     </span>
   </header>
 
@@ -152,6 +152,6 @@
 
   <section class="container community-footer">
     <h2 class="community-footer-title">{{t 'suggest_new_post'}}</h2>
-    {{link 'new_post' role='button' class='button-large'}}
+    {{link 'new_post' role='button' class='button button-large'}}
   </section>
 </div>

--- a/templates/community_post_list_page.hbs
+++ b/templates/community_post_list_page.hbs
@@ -36,7 +36,7 @@
         </span>
       </span>
     <span class="post-to-community">
-      {{link 'new_post' role='button' class='button button-large'}}
+      {{link 'new_post' class='button button-large'}}
     </span>
   </header>
 
@@ -152,6 +152,6 @@
 
   <section class="container community-footer">
     <h2 class="community-footer-title">{{t 'suggest_new_post'}}</h2>
-    {{link 'new_post' role='button' class='button button-large'}}
+    {{link 'new_post' class='button button-large'}}
   </section>
 </div>

--- a/templates/community_post_page.hbs
+++ b/templates/community_post_page.hbs
@@ -258,7 +258,7 @@
     <section class="post-sidebar">
       <h2 class="post-sidebar-title">{{t 'suggest_new_post'}}</h2>
       <span class="post-to-community">
-        {{link 'new_post' role='button' class='button-large'}}
+        {{link 'new_post' role='button' class='button button-large'}}
       </span>
     </section>
   </div>

--- a/templates/community_post_page.hbs
+++ b/templates/community_post_page.hbs
@@ -258,7 +258,7 @@
     <section class="post-sidebar">
       <h2 class="post-sidebar-title">{{t 'suggest_new_post'}}</h2>
       <span class="post-to-community">
-        {{link 'new_post' role='button' class='button button-large'}}
+        {{link 'new_post' class='button button-large'}}
       </span>
     </section>
   </div>

--- a/templates/community_topic_list_page.hbs
+++ b/templates/community_topic_list_page.hbs
@@ -36,7 +36,7 @@
         </span>
       </span>
     <span class="post-to-community">
-      {{link 'new_post' role='button' class='button button-large'}}
+      {{link 'new_post' class='button button-large'}}
     </span>
   </header>
 
@@ -95,6 +95,6 @@
 
   <section class="container community-footer">
     <h2 class="community-footer-title">{{t 'suggest_new_post'}}</h2>
-    {{link 'new_post' role='button' class='button button-large'}}
+    {{link 'new_post' class='button button-large'}}
   </section>
 </div>

--- a/templates/community_topic_list_page.hbs
+++ b/templates/community_topic_list_page.hbs
@@ -36,7 +36,7 @@
         </span>
       </span>
     <span class="post-to-community">
-      {{link 'new_post' role='button' class='button-large'}}
+      {{link 'new_post' role='button' class='button button-large'}}
     </span>
   </header>
 
@@ -95,6 +95,6 @@
 
   <section class="container community-footer">
     <h2 class="community-footer-title">{{t 'suggest_new_post'}}</h2>
-    {{link 'new_post' role='button' class='button-large'}}
+    {{link 'new_post' role='button' class='button button-large'}}
   </section>
 </div>

--- a/templates/community_topic_page.hbs
+++ b/templates/community_topic_page.hbs
@@ -22,7 +22,7 @@
       {{/if}}
     </h1>
     <span class="post-to-community">
-      {{link 'new_post' role='button' topic_id=topic.id class='button button-large'}}
+      {{link 'new_post' topic_id=topic.id class='button button-large'}}
     </span>
   </header>
   <div class="community-header">
@@ -120,5 +120,5 @@
 
 <section class="container community-footer">
   <h2 class="community-footer-title">{{t 'suggest_new_post'}}</h2>
-  {{link 'new_post' role='button' class='button button-large'}}
+  {{link 'new_post' class='button button-large'}}
 </section>

--- a/templates/community_topic_page.hbs
+++ b/templates/community_topic_page.hbs
@@ -120,5 +120,5 @@
 
 <section class="container community-footer">
   <h2 class="community-footer-title">{{t 'suggest_new_post'}}</h2>
-  {{link 'new_post' role='button' class='button-large'}}
+  {{link 'new_post' role='button' class='button button-large'}}
 </section>


### PR DESCRIPTION
These button relied on `[role="button"]` styling before, which are no
longer in v2.