### PR TITLE
[GG-1009] Use proper ARIA attribute for top links

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Copenhagen",
   "author": "Zendesk",
-  "version": "2.0.0-alpha.14",
+  "version": "2.0.0-alpha.15",
   "api_version": 2,
   "default_locale": "en-us",
   "settings": [{

--- a/templates/contributions_page.hbs
+++ b/templates/contributions_page.hbs
@@ -13,7 +13,9 @@
         {{#if help_center.request_management_enabled}}
           <li>{{link 'requests'}}</li>
         {{/if}}
-        <li aria-selected=true>{{t 'contributions'}}</li>
+        <li class="current">
+          <a href="{{page_path 'contributions'}}" aria-current="page">{{ t 'contributions' }}</a>
+        </li>
         <li>{{link 'subscriptions'}}</li>
       </ul>
     </nav>

--- a/templates/requests_page.hbs
+++ b/templates/requests_page.hbs
@@ -10,7 +10,9 @@
         </svg>
       </button>
       <ul class="collapsible-nav-list">
-        <li aria-selected=true>{{t 'requests'}}</li>
+        <li class="current">
+          <a href="{{page_path 'requests'}}" aria-current="page">{{ t 'requests' }}</a>
+        </li>
         <li>{{link 'contributions'}}</li>
         <li>{{link 'subscriptions'}}</li>
       </ul>

--- a/templates/subscriptions_page.hbs
+++ b/templates/subscriptions_page.hbs
@@ -14,7 +14,9 @@
           <li>{{link 'requests'}}</li>
         {{/if}}
         <li>{{link 'contributions'}}</li>
-        <li aria-selected=true>{{t 'following'}}</li>
+        <li class="current">
+          <a href="{{page_path 'following'}}" aria-current="page">{{ t 'following' }}</a>
+        </li>
       </ul>
     </nav>
   </div>


### PR DESCRIPTION
We already fixed this for the responsive menu, but overlooked it for desktop.