### PR TITLE
[GG-1001] Don't disable focus outline for checkboxes

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Copenhagen",
   "author": "Zendesk",
-  "version": "2.0.0-alpha.10",
+  "version": "2.0.0-alpha.11",
   "api_version": 2,
   "default_locale": "en-us",
   "settings": [{

--- a/style.css
+++ b/style.css
@@ -244,11 +244,14 @@ input {
   font-weight: 300;
   max-width: 100%;
   box-sizing: border-box;
-  outline: none;
   transition: border .12s ease-in-out;
 }
 
-input:focus {
+input:not([type="checkbox"]) {
+  outline: none;
+}
+
+input:not([type="checkbox"]):focus {
   border: 1px solid $brand_color;
 }
 

--- a/styles/_base.scss
+++ b/styles/_base.scss
@@ -55,11 +55,14 @@ input {
   font-weight: $font-weight-light;
   max-width: 100%;
   box-sizing: border-box;
-  outline: none;
   transition: border .12s ease-in-out;
 
-  &:focus {
-    border: 1px solid $brand_color;
+  &:not([type="checkbox"]) {
+    outline: none;
+    
+    &:focus {
+      border: 1px solid $brand_color;
+    }
   }
 }
 


### PR DESCRIPTION
Since `border` won't really affect checkboxes, we'll keep focus outlines
around for these.