### PR TITLE
Use `sign_in` string for header link

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Copenhagen",
   "author": "Zendesk",
-  "version": "2.0.0-alpha.15",
+  "version": "2.0.0-alpha.16",
   "api_version": 2,
   "default_locale": "en-us",
   "settings": [{

--- a/templates/header.hbs
+++ b/templates/header.hbs
@@ -33,7 +33,9 @@
         </div>
       </div>
     {{else}}
-      {{link "sign_in"}}
+      {{#link "sign_in"}}
+        {{t 'sign_in'}}
+      {{/link}}
     {{/if}}
   </div>
 </header>


### PR DESCRIPTION
`{{link 'sign_in'}}` will output a long string for unauthenticated users, and that's not what we want.