### PR TITLE
Add transparent background to actions button

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Copenhagen",
   "author": "Zendesk",
-  "version": "2.0.0-alpha.27",
+  "version": "2.0.0-alpha.28",
   "api_version": 2,
   "default_locale": "en-us",
   "settings": [{

--- a/style.css
+++ b/style.css
@@ -2155,6 +2155,7 @@ ul {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
+  background-color: transparent;
   border: none;
   cursor: pointer;
   padding: 0;

--- a/styles/_actions.scss
+++ b/styles/_actions.scss
@@ -8,6 +8,7 @@
     -webkit-appearance: none;
     -moz-appearance: none;
     appearance: none;
+    background-color: transparent;
     border: none;
     cursor: pointer;
     padding: 0;


### PR DESCRIPTION
Actions button in Firefox looks like this:

<img width="31" alt="Screenshot 2020-02-20 at 11 29 44" src="https://user-images.githubusercontent.com/25344971/74925578-bac70a00-53d4-11ea-8f8b-952f3146575c.png">

