### PR TITLE
Do not lower case 'answered' post status

### DIFF
--- a/style.css
+++ b/style.css
@@ -2414,7 +2414,7 @@ ul {
   color: lighten($text_color, 20%);
 }
 
-.status-label-pending {
+.status-label-pending, .status-label-pending-moderation {
   background-color: #1f73b7;
   text-align: center;
 }
@@ -2436,7 +2436,7 @@ ul {
   background-color: #000;
 }
 
-.status-label-open, .status-label-closed, .status-label-solved, .status-label-new, .status-label-hold {
+.status-label-open, .status-label-closed, .status-label-solved, .status-label-new, .status-label-hold, .status-label-pending {
   text-transform: lowercase;
 }
 

--- a/style.css
+++ b/style.css
@@ -2436,7 +2436,7 @@ ul {
   background-color: #000;
 }
 
-.status-label-open, .status-label-closed, .status-label-solved, .status-label-new, .status-label-hold, .status-label-answered {
+.status-label-open, .status-label-closed, .status-label-solved, .status-label-new, .status-label-hold {
   text-transform: lowercase;
 }
 

--- a/styles/_status-label.scss
+++ b/styles/_status-label.scss
@@ -51,7 +51,8 @@
     color: $secondary-text-color;
   }
 
-  &-pending {
+  &-pending,
+  &-pending-moderation {
     background-color: #1f73b7;
     text-align: center;
   }
@@ -77,7 +78,8 @@
   &-closed,
   &-solved,
   &-new,
-  &-hold {
+  &-hold,
+  &-pending {
     text-transform: lowercase; // To be consistent with Lotus
   }
 }

--- a/styles/_status-label.scss
+++ b/styles/_status-label.scss
@@ -77,8 +77,7 @@
   &-closed,
   &-solved,
   &-new,
-  &-hold,
-  &-answered {
+  &-hold {
     text-transform: lowercase; // To be consistent with Lotus
   }
 }

--- a/templates/article_page.hbs
+++ b/templates/article_page.hbs
@@ -150,7 +150,7 @@
         </div>
         <div class="article-return-to-top">
           <a href="#article-container">
-            {{t 'return_to_top'}} 
+            {{t 'return_to_top'}}
             <svg xmlns="http://www.w3.org/2000/svg" class="article-return-to-top-icon" width="20" height="20" focusable="false" viewBox="0 0 12 12" aria-hidden="true">
               <path fill="none" stroke="currentColor" stroke-linecap="round" d="M3 4.5l2.6 2.6c.2.2.5.2.7 0L9 4.5"/>
             </svg>
@@ -228,7 +228,7 @@
                             </a>
                           {{/with}}
                           {{#if pending}}
-                            <span class="comment-pending status-label status-label-pending">{{t 'pending_approval'}}</span>
+                            <span class="comment-pending status-label status-label-pending-moderation">{{t 'pending_approval'}}</span>
                           {{/if}}
                         </div>
                       </div>

--- a/templates/community_post_page.hbs
+++ b/templates/community_post_page.hbs
@@ -74,7 +74,7 @@
               </div>
 
               {{#if post.pending}}
-                <span class="status-label status-label-pending">{{t 'pending_approval'}}</span>
+                <span class="status-label status-label-pending-moderation">{{t 'pending_approval'}}</span>
               {{/if}}
 
               {{#with post.ticket}}
@@ -196,7 +196,7 @@
                       </a>
                     {{/with}}
                     {{#if pending}}
-                      <span class="comment-pending status-label status-label-pending">{{t 'pending_approval'}}</span>
+                      <span class="comment-pending status-label status-label-pending-moderation">{{t 'pending_approval'}}</span>
                     {{/if}}
                   </div>
                 </div>

--- a/templates/user_profile_page.hbs
+++ b/templates/user_profile_page.hbs
@@ -165,7 +165,7 @@
                         {{/isnt}}
 
                         {{#if pending}}
-                          <span class="status-label status-label-pending">{{t 'pending_approval'}}</span>
+                          <span class="status-label status-label-pending-moderation">{{t 'pending_approval'}}</span>
                         {{/if}}
 
                         {{#if official}}
@@ -280,7 +280,7 @@
                     {{/isnt}}
 
                     {{#if pending}}
-                      <span class="status-label status-label-pending">{{t 'pending_approval'}}</span>
+                      <span class="status-label status-label-pending-moderation">{{t 'pending_approval'}}</span>
                     {{/if}}
 
                     {{#if official}}


### PR DESCRIPTION
https://zendesk.atlassian.net/browse/COMM-346

 * Do not lower case the "answered" status of Community Posts
 * *Do* lower case the "pending" status of Classic Requests (like we do for all other statuses of such requests); *do not* lower case the "pending" for Community Content moderation
