### PR TITLE
fix(header): remove size attributes from logo img

### DIFF
--- a/settings/logo.svg
+++ b/settings/logo.svg
@@ -1,4 +1,4 @@
-<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="37" height="37">
   <defs>
     <style>
       .cls-1{fill:none}.cls-1,.cls-2{stroke:#fff;stroke-miterlimit:10;stroke-width:5px}

--- a/templates/header.hbs
+++ b/templates/header.hbs
@@ -3,7 +3,7 @@
 <header class="header">
   <div class="logo">
     {{#link 'help_center'}}
-      <img width="37" height="37" src="{{settings.logo}}" alt="{{t 'home_page' name=help_center.name}}">
+      <img src="{{settings.logo}}" alt="{{t 'home_page' name=help_center.name}}">
     {{/link}}
   </div>
   <div class="nav-wrapper">


### PR DESCRIPTION
## Description

Explicit size properties on `img` tag for the logo forced bigger logos to be squished. Since logos are a setting, it should be modifiable without code changes. Sizing properties are moved to the SVG, as the logo image should decide its aspect ratio.

## Checklist

- [x] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] ~:nail_care: SASS files are compiled~
- [x] :arrow_left: changes are compatible with RTL direction
- [x] :wheelchair: changes are accessible
- [x] :memo: changes are tested in Chrome, Firefox, Safari, Edge, and IE11
- [x] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->