### PR TITLE
Update lighthouse rules 

### DIFF
--- a/.github/workflows/lighthouserc.json
+++ b/.github/workflows/lighthouserc.json
@@ -7,108 +7,40 @@
       }
     },
     "assert": {
-      "assertMatrix": [
-        {
-          "matchingUrlPattern": "hc/en-us$",
-          "assertions": {
-            "link-name": ["error", {}]
-          }
-        },
-        {
-          "matchingUrlPattern": ".+categories.+",
-          "assertions": {
-            "link-name": ["error", {}]
-          }
-        },
-        {
-          "matchingUrlPattern": ".+sections.+",
-          "assertions": {
-            "link-name": ["error", {}]
-          }
-        },
-        {
-          "matchingUrlPattern": ".+articles.+",
-          "assertions": {
-            "link-name": ["warn", {}]
-          }
-        },
-        {
-          "matchingUrlPattern": "requests/new$",
-          "assertions": {
-            "link-name": ["error", {}]
-          }
-        },
-        {
-          "matchingUrlPattern": ".+search.+",
-          "assertions": {
-            "link-name": ["warn", {}]
-          }
-        },
-        {
-          "matchingUrlPattern": "community/topics$",
-          "assertions": {
-            "link-name": ["error", {}]
-          }
-        },
-        {
-          "matchingUrlPattern": ".+community/topics.+",
-          "assertions": {
-            "link-name": ["error", {}]
-          }
-        },
-        {
-          "matchingUrlPattern": "community/posts$",
-          "assertions": {
-            "link-name": ["error", {}]
-          }
-        },
-        {
-          "matchingUrlPattern": ".+community/posts.+",
-          "assertions": {
-            "link-name": ["warn", {}]
-          }
-        },
-        {
-          "matchingUrlPattern": ".+profiles.+",
-          "assertions": {
-            "link-name": ["error", {}]
-          }
-        },
-        {"assertions": {
-            "accesskeys": ["error", {}],
-            "aria-allowed-attr": ["error", {}],
-            "aria-required-attr": ["error", {}],
-            "aria-required-children": ["error", {}],
-            "aria-required-parent": ["error", {}],
-            "aria-roles": ["error", {}],
-            "aria-valid-attr-value": ["error", {}],
-            "aria-valid-attr": ["error", {}],
-            "audio-caption": ["error", {}],
-            "button-name": ["error", {}],
-            "bypass": ["error", {}],
-            "definition-list": ["error", {}],
-            "dlitem": ["error", {}],
-            "document-title": ["error", {}],
-            "html-has-lang": ["error", {}],
-            "html-lang-valid": ["error", {}],
-            "image-alt": ["error", {}],
-            "input-image-alt": ["error", {}],
-            "label": ["error", {}],
-            "layout-table": ["error", {}],
-            "list": ["error", {}],
-            "listitem": ["error", {}],
-            "meta-refresh": ["error", {}],
-            "meta-viewport": ["error", {}],
-            "object-alt": ["error", {}],
-            "tabindex": ["warn", {}],
-            "td-headers-attr": ["error", {}],
-            "th-has-data-cells": ["error", {}],
-            "valid-lang": ["error", {}],
-            "video-caption": ["error", {}],
-            "video-description": ["error", {}]
+      "assertions": {
+        "accesskeys": ["error", {}],
+        "aria-allowed-attr": ["error", {}],
+        "aria-required-attr": ["error", {}],
+        "aria-required-children": ["error", {}],
+        "aria-required-parent": ["error", {}],
+        "aria-roles": ["error", {}],
+        "aria-valid-attr-value": ["error", {}],
+        "aria-valid-attr": ["error", {}],
+        "audio-caption": ["error", {}],
+        "button-name": ["error", {}],
+        "bypass": ["error", {}],
+        "definition-list": ["error", {}],
+        "dlitem": ["error", {}],
+        "document-title": ["error", {}],
+        "html-has-lang": ["error", {}],
+        "html-lang-valid": ["error", {}],
+        "image-alt": ["error", {}],
+        "input-image-alt": ["error", {}],
+        "label": ["error", {}],
+        "layout-table": ["error", {}],
+        "link-name": ["error", {}],
+        "list": ["error", {}],
+        "listitem": ["error", {}],
+        "meta-refresh": ["error", {}],
+        "meta-viewport": ["error", {}],
+        "object-alt": ["error", {}],
+        "tabindex": ["warn", {}],
+        "td-headers-attr": ["error", {}],
+        "th-has-data-cells": ["error", {}],
+        "valid-lang": ["error", {}],
+        "video-caption": ["error", {}],
+        "video-description": ["error", {}]
         }
-        }
-      ]
     }
   }
 }

--- a/.github/workflows/lighthouserc.json
+++ b/.github/workflows/lighthouserc.json
@@ -11,82 +11,72 @@
         {
           "matchingUrlPattern": "hc/en-us$",
           "assertions": {
-            "aria-allowed-attr": ["error", {}],
             "link-name": ["error", {}]
           }
         },
         {
           "matchingUrlPattern": ".+categories.+",
           "assertions": {
-            "aria-allowed-attr": ["error", {}],
             "link-name": ["error", {}]
           }
         },
         {
           "matchingUrlPattern": ".+sections.+",
           "assertions": {
-            "aria-allowed-attr": ["warn", {}],
             "link-name": ["error", {}]
           }
         },
         {
           "matchingUrlPattern": ".+articles.+",
           "assertions": {
-            "aria-allowed-attr": ["warn", {}],
             "link-name": ["warn", {}]
           }
         },
         {
           "matchingUrlPattern": "requests/new$",
           "assertions": {
-            "aria-allowed-attr": ["error", {}],
             "link-name": ["error", {}]
           }
         },
         {
           "matchingUrlPattern": ".+search.+",
           "assertions": {
-            "aria-allowed-attr": ["warn", {}],
             "link-name": ["warn", {}]
           }
         },
         {
           "matchingUrlPattern": "community/topics$",
           "assertions": {
-            "aria-allowed-attr": ["error", {}],
             "link-name": ["error", {}]
           }
         },
         {
           "matchingUrlPattern": ".+community/topics.+",
           "assertions": {
-            "aria-allowed-attr": ["warn", {}],
             "link-name": ["error", {}]
           }
         },
         {
           "matchingUrlPattern": "community/posts$",
           "assertions": {
-            "aria-allowed-attr": ["error", {}],
             "link-name": ["error", {}]
           }
         },
         {
           "matchingUrlPattern": ".+community/posts.+",
           "assertions": {
-            "aria-allowed-attr": ["warn", {}],
             "link-name": ["warn", {}]
           }
         },
         {
           "matchingUrlPattern": ".+profiles.+",
           "assertions": {
-            "aria-allowed-attr": ["warn", {}],
             "link-name": ["error", {}]
           }
         },
         {"assertions": {
             "accesskeys": ["error", {}],
+            "aria-allowed-attr": ["error", {}],
             "aria-required-attr": ["error", {}],
             "aria-required-children": ["error", {}],
             "aria-required-parent": ["error", {}],


### PR DESCRIPTION
## Description

- Moving aria-allowed-attr to hard assertion

## Checklist

- [x] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [x] :nail_care: SASS files are compiled
- [x] :arrow_left: changes are compatible with RTL direction
- [x] :wheelchair: changes are accessible
- [x] :memo: changes are tested in Chrome, Firefox, Safari, Edge, and IE11
- [ ] :+1: PR is approved by @zendesk/vikings