### PR TITLE
chore(release): set checkout step to not persist credentials

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          persist-credentials: false
       - name: Setup Node.js
         uses: actions/setup-node@v1
         with:


### PR DESCRIPTION
## Description

According to https://github.com/actions/checkout/tree/master#checkout-v2:

> The auth token is persisted in the local git config. This enables your scripts to run authenticated git commands. The token is removed during post-job cleanup. Set persist-credentials: false to opt-out.

https://github.com/semantic-release/git/issues/196 also hints that the `semantic-release` step may be using the auth token set in the checkout step.

This PR sets `persist-credentials: false` in the checkout step so the `semantic-release` step can use the token from its configuration.

## Checklist

- [x] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [x] :nail_care: SASS files are compiled
- [x] :arrow_left: changes are compatible with RTL direction
- [x] :wheelchair: changes are accessible
- [x] :memo: changes are tested in Chrome, Firefox, Safari, Edge, and IE11
- [x] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->