### PR TITLE
fix: Add rtl styling for Skip Navigation link

### DIFF
--- a/style.css
+++ b/style.css
@@ -721,6 +721,11 @@ ul {
   z-index: -999;
 }
 
+[dir="rtl"] .skip-navigation {
+  left: initial;
+  right: -999px;
+}
+
 .skip-navigation:focus, .skip-navigation:active {
   left: auto;
   overflow: auto;
@@ -728,6 +733,11 @@ ul {
   text-decoration: none;
   top: auto;
   z-index: 999;
+}
+
+[dir="rtl"] .skip-navigation:focus, [dir="rtl"] .skip-navigation:active {
+  left: initial;
+  right: auto;
 }
 
 /***** User info in header *****/

--- a/styles/_header.scss
+++ b/styles/_header.scss
@@ -107,6 +107,12 @@ $header-height: 71px;
   top: auto;
   z-index: -999;
 
+
+  [dir="rtl"] & {
+    left: initial;
+    right: -999px;
+  }
+
   &:focus,
   &:active {
     left: auto;
@@ -115,5 +121,11 @@ $header-height: 71px;
     text-decoration: none;
     top: auto;
     z-index: 999;
+
+
+  [dir="rtl"] & {
+    left: initial;
+    right: auto;
+  }
   }
 }


### PR DESCRIPTION
Without this styling, RTL languages will overflow to the left, rather
than hiding the link.

## Description

<!-- a summary of the changes introduced by this PR and the motivation behind them -->

## Screenshots

<!-- (optional) when applicable, please include some screenshots or gifs that illustrate the changes -->

## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :nail_care: SASS files are compiled
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: changes are accessible
- [ ] :memo: changes are tested in Chrome, Firefox, Safari, Edge, and IE11
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->