### PR TITLE
[GG-1121] fix(header): Make sign in link visible on mobile

### DIFF
--- a/style.css
+++ b/style.css
@@ -673,6 +673,22 @@ ul {
   display: inline-block;
 }
 
+@media (max-width: 768px) {
+  .nav-wrapper .hide-on-mobile {
+    border: 0;
+    clip: rect(0 0 0 0);
+    -webkit-clip-path: inset(50%);
+    clip-path: inset(50%);
+    height: 1px;
+    margin: -1px;
+    overflow: hidden;
+    padding: 0;
+    position: absolute;
+    width: 1px;
+    white-space: nowrap;
+  }
+}
+
 .nav-wrapper .menu-button {
   background: none;
   border: 0;

--- a/style.css
+++ b/style.css
@@ -330,7 +330,7 @@ ul {
   }
 }
 
-.visibility-hidden, .recent-activity-accessibility-label, .pagination-first-text, .pagination-last-text {
+.visibility-hidden {
   border: 0;
   clip: rect(0 0 0 0);
   -webkit-clip-path: inset(50%);
@@ -1298,6 +1298,20 @@ ul {
 
 .recent-activity-controls {
   padding-top: 15px;
+}
+
+.recent-activity-accessibility-label {
+  border: 0;
+  clip: rect(0 0 0 0);
+  -webkit-clip-path: inset(50%);
+  clip-path: inset(50%);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+  white-space: nowrap;
 }
 
 .recent-activity-comment-icon svg {
@@ -3386,6 +3400,20 @@ ul {
 
 .pagination-first-link, .pagination-last-link {
   padding: 0 10px;
+}
+
+.pagination-first-text, .pagination-last-text {
+  border: 0;
+  clip: rect(0 0 0 0);
+  -webkit-clip-path: inset(50%);
+  clip-path: inset(50%);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+  white-space: nowrap;
 }
 
 .pagination-next-link {

--- a/style.css
+++ b/style.css
@@ -669,7 +669,7 @@ ul {
   text-decoration: underline;
 }
 
-.nav-wrapper a.login {
+.nav-wrapper a.sign-in {
   display: inline-block;
 }
 

--- a/styles/_base.scss
+++ b/styles/_base.scss
@@ -124,15 +124,5 @@ ul {
 }
 
 .visibility-hidden {
-  border: 0;
-  clip: rect(0 0 0 0);
-  -webkit-clip-path: inset(50%);
-  clip-path: inset(50%);
-  height: 1px;
-  margin: -1px;
-  overflow: hidden;
-  padding: 0;
-  position: absolute;
-  width: 1px;
-  white-space: nowrap;
+  @include visually-hidden;
 }

--- a/styles/_header.scss
+++ b/styles/_header.scss
@@ -62,6 +62,12 @@ $header-height: 71px;
     &.sign-in { display: inline-block; }
   }
 
+  .hide-on-mobile {
+    @include mobile {
+      @include visually-hidden;
+    }
+  }
+
   .menu-button {
     @include tablet { display: none; }
     background: none;

--- a/styles/_header.scss
+++ b/styles/_header.scss
@@ -59,7 +59,7 @@ $header-height: 71px;
       text-decoration: underline;
     }
 
-    &.login { display: inline-block; }
+    &.sign-in { display: inline-block; }
   }
 
   .menu-button {

--- a/styles/_mixins.scss
+++ b/styles/_mixins.scss
@@ -11,6 +11,12 @@
   }
 }
 
+@mixin mobile {
+  @media (max-width: #{$tablet-width}) {
+    @content;
+  }
+}
+
 @mixin max-width-container {
   @media (min-width: #{$max-width-container}) {
     padding: 0;
@@ -94,4 +100,18 @@
     font-style: italic;
     padding: 0 15px;
   }
+}
+
+@mixin visually-hidden {
+  border: 0;
+  clip: rect(0 0 0 0);
+  -webkit-clip-path: inset(50%);
+  clip-path: inset(50%);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+  white-space: nowrap;
 }

--- a/styles/_pagination.scss
+++ b/styles/_pagination.scss
@@ -17,7 +17,7 @@
     }
 
     &-text {
-      @extend .visibility-hidden;
+     @include visually-hidden;
     }
   }
 

--- a/styles/_recent-activity.scss
+++ b/styles/_recent-activity.scss
@@ -72,7 +72,7 @@
   }
 
   &-accessibility-label {
-    @extend .visibility-hidden
+    @include visually-hidden;
   }
 
   &-comment-icon {

--- a/templates/header.hbs
+++ b/templates/header.hbs
@@ -20,10 +20,12 @@
       <div class="user-info dropdown">
         <button class="dropdown-toggle" aria-haspopup="true">
           {{user_avatar class="user-avatar"}}
-          {{user_name}}
-          <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" focusable="false" viewBox="0 0 12 12" class="dropdown-chevron-icon" aria-hidden="true">
-            <path fill="none" stroke="currentColor" stroke-linecap="round" d="M3 4.5l2.6 2.6c.2.2.5.2.7 0L9 4.5"/>
-          </svg>
+          <span class="hide-on-mobile">
+            {{user_name}}
+            <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" focusable="false" viewBox="0 0 12 12" class="dropdown-chevron-icon" aria-hidden="true">
+              <path fill="none" stroke="currentColor" stroke-linecap="round" d="M3 4.5l2.6 2.6c.2.2.5.2.7 0L9 4.5"/>
+            </svg>
+          </span>
         </button>
         <div class="dropdown-menu" role="menu">
           {{link "my_activities" role="menuitem"}}

--- a/templates/header.hbs
+++ b/templates/header.hbs
@@ -33,7 +33,7 @@
         </div>
       </div>
     {{else}}
-      {{#link "sign_in"}}
+      {{#link "sign_in" class="sign-in"}}
         {{t 'sign_in'}}
       {{/link}}
     {{/if}}


### PR DESCRIPTION
## Description

Currently, the sign in link is not visible on mobile, since we went away from `{{user_info}}`. This re-aligns the old styling rules.

## Screenshots

<!-- (optional) when applicable, please include some screenshots or gifs that illustrate the changes -->

## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :nail_care: SASS files are compiled
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: changes are accessible
- [ ] :memo: changes are tested in Chrome, Firefox, Safari, Edge, and IE11
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->