### PR TITLE
Community badges feature support

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-  "name": "Copenhagen",
+  "name": "Badges example theme (based on Copenhagen)",
   "author": "Zendesk",
   "version": "2.3.1",
   "api_version": 2,

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-  "name": "Badges example theme (based on Copenhagen)",
+  "name": "Copenhagen",
   "author": "Zendesk",
   "version": "2.3.1",
   "api_version": 2,

--- a/style.css
+++ b/style.css
@@ -2754,6 +2754,49 @@ ul {
   }
 }
 
+/***** Community Badges *****/
+/* Styles labels used next to the authors of article comments, community posts, and community comments */
+.community-badge-titles {
+  background-color: #04444D;
+  border-radius: 4px;
+  color: #fff;
+  font-size: 12px;
+  font-weight: 600;
+  margin-right: 2px;
+  padding: 2px 8px;
+  vertical-align: middle;
+  white-space: nowrap;
+  display: inline-block;
+  margin-left: 10px;
+}
+
+.community-badge-container-achievements {
+  margin-top: 0.4em;
+}
+
+.community-badge-achievements {
+  display: inline-block;
+  margin-right: 0.5em;
+}
+
+.community-badge-achievements img {
+  width: 22px;
+  height: 22px;
+}
+
+.community-badge-titles img {
+  width: 1.6em;
+  height: 1.6em;
+  margin-top: -0.2em;
+  margin-bottom: -0.2em;
+  vertical-align: text-bottom;
+}
+
+.profile-info .community-badge-achievements img {
+  width: 40px;
+  height: 40px;
+}
+
 /* Navigation element that collapses on mobile */
 .collapsible-nav {
   flex-direction: column;
@@ -3515,6 +3558,14 @@ ul {
   display: block;
 }
 
+.meta-group-opposite {
+  float: right;
+}
+
+[dir="rtl"] .meta-group-opposite {
+  float: left;
+}
+
 .meta-group * {
   display: inline;
 }
@@ -3567,8 +3618,8 @@ ul {
 }
 
 .profile-avatar .user-avatar {
-  width: 65px;
-  height: 65px;
+  width: 80px;
+  height: 80px;
 }
 
 .profile-avatar .icon-agent {
@@ -3865,6 +3916,60 @@ ul {
     margin-left: 0;
     margin-right: 20px;
   }
+}
+
+.profile-badges-items {
+  margin-top: 25px;
+}
+
+.profile-badges-item {
+  border-top: 1px solid #ddd;
+  display: flex;
+  flex: 1;
+  flex-direction: row;
+  justify-content: flex-start;
+  padding: 27px 12px;
+}
+
+.profile-badges-item > div {
+  padding-right: 12px;
+  padding-left: 12px;
+}
+
+.profile-badges-item-image {
+  height: 40px;
+  width: 40px;
+  margin-right: 12px;
+}
+
+.profile-badges-item-image img {
+  max-height: 40px;
+}
+
+.profile-badges-item-title, .profile-badges-item-metadata-title {
+  font-size: 15px;
+  margin-bottom: 10px;
+}
+
+.profile-badges-item-title {
+  font-weight: 600;
+}
+
+.profile-badges-item-description, .profile-badges-item-metadata-description {
+  color: lighten($text_color, 20%);
+  font-size: 13px;
+  margin: 0;
+}
+
+.profile-badges-item-metadata {
+  margin-left: auto;
+  text-align: right;
+}
+
+[dir="rtl"] .profile-badges-item-metadata {
+  margin-left: 0;
+  margin-right: auto;
+  text-align: left;
 }
 
 .profile-contribution {

--- a/style.css
+++ b/style.css
@@ -2765,29 +2765,22 @@ ul {
   padding: 2px 8px;
   vertical-align: middle;
   white-space: nowrap;
-  display: inline-block;
-  margin-left: 10px;
-  margin-right: 2px;
-}
-
-[dir="rtl"] .community-badge-titles {
-  margin-right: 10px;
-  margin-left: 2px;
+  display: inline-flex;
+  line-height: 20px;
+  margin: 0 2px;
 }
 
 .community-badge-container-achievements {
-  margin-top: 5px;
+  padding-top: 5px;
 }
 
 .community-badge-achievements {
   display: inline-block;
-  margin-left: 0px;
-  margin-right: 5px;
+  margin: 0 3px 0 0;
 }
 
 [dir="rtl"] .community-badge-achievements {
-  margin-right: 0px;
-  margin-left: 0px;
+  margin: 0 0 0 3px;
 }
 
 .community-badge-achievements img {
@@ -2796,11 +2789,8 @@ ul {
 }
 
 .community-badge-titles img {
-  width: 1.6em;
-  height: 1.6em;
-  margin-top: -0.2em;
-  margin-bottom: -0.2em;
-  vertical-align: text-bottom;
+  width: 20px;
+  height: 20px;
 }
 
 .profile-info .community-badge-achievements img {
@@ -3654,6 +3644,7 @@ ul {
 
 .profile-header .basic-info .name {
   margin: 0;
+  line-height: 25px;
 }
 
 .profile-header .options {
@@ -3955,6 +3946,11 @@ ul {
 
 .profile-badges-item-image img {
   max-height: 40px;
+}
+
+[dir="rtl"] .profile-badges-item-image {
+  margin-left: 12px;
+  margin-right: 0;
 }
 
 .profile-badges-item-title, .profile-badges-item-metadata-title {

--- a/style.css
+++ b/style.css
@@ -2757,26 +2757,37 @@ ul {
 /***** Community Badges *****/
 /* Styles labels used next to the authors of article comments, community posts, and community comments */
 .community-badge-titles {
-  background-color: #04444D;
+  background-color: #04444d;
   border-radius: 4px;
   color: #fff;
   font-size: 12px;
   font-weight: 600;
-  margin-right: 2px;
   padding: 2px 8px;
   vertical-align: middle;
   white-space: nowrap;
   display: inline-block;
   margin-left: 10px;
+  margin-right: 2px;
+}
+
+[dir="rtl"] .community-badge-titles {
+  margin-right: 10px;
+  margin-left: 2px;
 }
 
 .community-badge-container-achievements {
-  margin-top: 0.4em;
+  margin-top: 5px;
 }
 
 .community-badge-achievements {
   display: inline-block;
-  margin-right: 0.5em;
+  margin-left: 0px;
+  margin-right: 5px;
+}
+
+[dir="rtl"] .community-badge-achievements {
+  margin-right: 0px;
+  margin-left: 0px;
 }
 
 .community-badge-achievements img {

--- a/styles/_community_badge.scss
+++ b/styles/_community_badge.scss
@@ -1,0 +1,42 @@
+/***** Community Badges *****/
+/* Styles labels used next to the authors of article comments, community posts, and community comments */
+.community-badge-titles {
+  background-color: #04444D;
+  border-radius: 4px;
+  color: #fff;
+  font-size: 12px;
+  font-weight: $font-weight-semibold;
+  margin-right: 2px;
+  padding: 2px 8px;
+  vertical-align: middle;
+  white-space: nowrap;
+  display: inline-block;
+  margin-left: 10px;
+}
+
+.community-badge-container-achievements {
+  margin-top: 0.4em;
+}
+
+.community-badge-achievements {
+  display: inline-block;
+  margin-right: 0.5em;
+}
+
+.community-badge-achievements img {
+  width: 22px;
+  height: 22px;
+}
+
+.community-badge-titles img {
+  width: 1.6em;
+  height: 1.6em;
+  margin-top: -0.2em;
+  margin-bottom: -0.2em;
+  vertical-align: text-bottom;
+}
+
+.profile-info .community-badge-achievements img {
+  width: 40px;
+  height: 40px;
+}

--- a/styles/_community_badge.scss
+++ b/styles/_community_badge.scss
@@ -9,29 +9,22 @@
   padding: 2px 8px;
   vertical-align: middle;
   white-space: nowrap;
-  display: inline-block;
-  margin-left: 10px;
-  margin-right: 2px;
-}
-
-[dir="rtl"] .community-badge-titles {
-  margin-right: 10px;
-  margin-left: 2px;
+  display: inline-flex;
+  line-height: 20px;
+  margin: 0 2px;
 }
 
 .community-badge-container-achievements {
-  margin-top: 5px;
+  padding-top: 5px;
 }
 
 .community-badge-achievements {
   display: inline-block;
-  margin-left: 0px;
-  margin-right: 5px;
+  margin: 0 3px 0 0;
 }
 
 [dir="rtl"] .community-badge-achievements {
-  margin-right: 0px;
-  margin-left: 0px;
+  margin: 0 0 0 3px;
 }
 
 .community-badge-achievements img {
@@ -40,11 +33,8 @@
 }
 
 .community-badge-titles img {
-  width: 1.6em;
-  height: 1.6em;
-  margin-top: -0.2em;
-  margin-bottom: -0.2em;
-  vertical-align: text-bottom;
+  width: 20px;
+  height: 20px;
 }
 
 .profile-info .community-badge-achievements img {

--- a/styles/_community_badge.scss
+++ b/styles/_community_badge.scss
@@ -1,26 +1,37 @@
 /***** Community Badges *****/
 /* Styles labels used next to the authors of article comments, community posts, and community comments */
 .community-badge-titles {
-  background-color: #04444D;
+  background-color: #04444d;
   border-radius: 4px;
   color: #fff;
   font-size: 12px;
   font-weight: $font-weight-semibold;
-  margin-right: 2px;
   padding: 2px 8px;
   vertical-align: middle;
   white-space: nowrap;
   display: inline-block;
   margin-left: 10px;
+  margin-right: 2px;
+}
+
+[dir="rtl"] .community-badge-titles {
+  margin-right: 10px;
+  margin-left: 2px;
 }
 
 .community-badge-container-achievements {
-  margin-top: 0.4em;
+  margin-top: 5px;
 }
 
 .community-badge-achievements {
   display: inline-block;
-  margin-right: 0.5em;
+  margin-left: 0px;
+  margin-right: 5px;
+}
+
+[dir="rtl"] .community-badge-achievements {
+  margin-right: 0px;
+  margin-left: 0px;
 }
 
 .community-badge-achievements img {

--- a/styles/_metadata.scss
+++ b/styles/_metadata.scss
@@ -3,6 +3,14 @@
   display: block;
 }
 
+.meta-group-opposite {
+  float: right;
+}
+
+[dir="rtl"] .meta-group-opposite {
+  float: left;
+}
+
 .meta-group * {
   display: inline;
 }

--- a/styles/_user-profiles.scss
+++ b/styles/_user-profiles.scss
@@ -36,8 +36,8 @@
 }
 
 .profile-avatar .user-avatar {
-  width: 65px;
-  height: 65px;
+  width: 80px;
+  height: 80px;
 }
 
 .profile-avatar .icon-agent {
@@ -313,6 +313,64 @@
     [dir="rtl"] & {
       margin-left: 0;
       margin-right: 20px;
+    }
+  }
+}
+
+// Profile badges
+
+.profile-badges {
+  &-items {
+    margin-top: 25px;
+  }
+
+  &-item {
+    border-top: 1px solid $border-color;
+    display: flex;
+    flex: 1;
+    flex-direction: row;
+    justify-content: flex-start;
+    padding: 27px 12px;
+
+    & > div {
+      padding-right: 12px;
+      padding-left: 12px;
+    }
+
+    &-image {
+      height: 40px;
+      width: 40px;
+      margin-right: 12px;
+
+      img {
+        max-height: 40px;
+      }
+    }
+
+    &-title, &-metadata-title {
+      font-size: $font-size-base;
+      margin-bottom: 10px;
+    }
+
+    &-title {
+      font-weight: $font-weight-semibold;
+    }
+
+    &-description, &-metadata-description {
+      color: $secondary-text-color;
+      font-size: $font-size-small;
+      margin: 0;
+    }
+
+    &-metadata {
+      margin-left: auto;
+      text-align: right;
+
+      [dir="rtl"] & {
+        margin-left: 0;
+        margin-right: auto;
+        text-align: left;
+      }
     }
   }
 }

--- a/styles/_user-profiles.scss
+++ b/styles/_user-profiles.scss
@@ -56,6 +56,7 @@
 
   .name {
     margin: 0;
+    line-height: 25px;
   }
 }
 
@@ -345,9 +346,15 @@
       img {
         max-height: 40px;
       }
+
+      [dir="rtl"] & {
+        margin-left: 12px;
+        margin-right: 0;
+      }
     }
 
-    &-title, &-metadata-title {
+    &-title,
+    &-metadata-title {
       font-size: $font-size-base;
       margin-bottom: 10px;
     }
@@ -356,7 +363,8 @@
       font-weight: $font-weight-semibold;
     }
 
-    &-description, &-metadata-description {
+    &-description,
+    &-metadata-description {
       color: $secondary-text-color;
       font-size: $font-size-small;
       margin: 0;

--- a/styles/index.scss
+++ b/styles/index.scss
@@ -29,6 +29,7 @@
 @import "striped_list";
 @import "status-label";
 @import "post";
+@import "community_badge";
 @import "collapsible-nav";
 @import "collapsible-sidebar";
 @import "my-activities";

--- a/templates/article_page.hbs
+++ b/templates/article_page.hbs
@@ -210,9 +210,19 @@
                             {{#link 'user_profile' id=author.id}}
                               {{author.name}}
                             {{/link}}
+                            {{#each author.badges}}
+                              {{#is category_slug "titles"}}
+                                <span class="community-badge community-badge-{{category_slug}}" title="{{description}}">
+                                  {{#if icon_url}}
+                                    <img src="{{icon_url}}" alt="" />
+                                  {{/if}}
+                                  {{name}}
+                                </span>
+                              {{/is}}
+                            {{/each}}
                           </span>
 
-                          <ul class="meta-group">
+                          <ul class="meta-group meta-group-opposite">
                             {{#if editor}}
                               <li class="meta-data">{{date edited_at timeago=true}}</li>
                               <li class="meta-data">{{t 'edited'}}</li>
@@ -220,6 +230,18 @@
                               <li class="meta-data">{{date created_at timeago=true}}</li>
                             {{/if}}
                           </ul>
+
+                          <div class="community-badge-container-achievements">
+                            {{#each author.badges}}
+                              {{#is category_slug "achievements"}}
+                                {{#if icon_url}}
+                                  <div class="community-badge community-badge-{{category_slug}}">
+                                    <img src="{{icon_url}}" alt="{{name}}" title="{{name}} | {{description}}" />
+                                  </div>
+                                {{/if}}
+                              {{/is}}
+                            {{/each}}
+                          </div>
                         </div>
                         <div class="comment-labels">
                           {{#with ticket}}

--- a/templates/article_page.hbs
+++ b/templates/article_page.hbs
@@ -212,7 +212,7 @@
                             {{/link}}
                             {{#each author.badges}}
                               {{#is category_slug "titles"}}
-                                <span class="community-badge community-badge-{{category_slug}}" title="{{description}}">
+                                <span class="community-badge community-badge-titles" title="{{description}}" aria-label="{{name}}">
                                   {{#if icon_url}}
                                     <img src="{{icon_url}}" alt="" />
                                   {{/if}}
@@ -235,8 +235,8 @@
                             {{#each author.badges}}
                               {{#is category_slug "achievements"}}
                                 {{#if icon_url}}
-                                  <div class="community-badge community-badge-{{category_slug}}">
-                                    <img src="{{icon_url}}" alt="{{name}}" title="{{name}} | {{description}}" />
+                                  <div class="community-badge community-badge-achievements">
+                                    <img src="{{icon_url}}" alt="{{name}}" title="{{name}} | {{description}}" aria-label="{{name}}" />
                                   </div>
                                 {{/if}}
                               {{/is}}

--- a/templates/community_post_page.hbs
+++ b/templates/community_post_page.hbs
@@ -61,9 +61,18 @@
                   {{#link 'user_profile' id=post.author.id}}
                     {{post.author.name}}
                   {{/link}}
+                  {{#each post.author.badges}}
+                    {{#is category_slug "titles"}}
+                      <span class="community-badge community-badge-{{category_slug}}" title="{{description}}">
+                        {{#if icon_url}}
+                          <img src="{{icon_url}}" alt="" />
+                        {{/if}}
+                        {{name}}
+                      </span>
+                    {{/is}}
+                  {{/each}}
                 </span>
-
-                <ul class="meta-group">
+                <ul class="meta-group meta-group-opposite">
                   {{#if post.editor}}
                     <li class="meta-data">{{date post.edited_at timeago=true}}</li>
                     <li class="meta-data">{{t 'edited'}}</li>
@@ -71,6 +80,17 @@
                     <li class="meta-data">{{date post.created_at timeago=true}}</li>
                   {{/if}}
                 </ul>
+                <div class="community-badge-container-achievements">
+                  {{#each post.author.badges}}
+                    {{#is category_slug "achievements"}}
+                      {{#if icon_url}}
+                        <div class="community-badge community-badge-{{category_slug}}">
+                          <img src="{{icon_url}}" alt="{{name}}" title="{{name}} | {{description}}" />
+                        </div>
+                      {{/if}}
+                    {{/is}}
+                  {{/each}}
+                </div>
               </div>
 
               {{#if post.pending}}
@@ -178,9 +198,19 @@
                       {{#link 'user_profile' id=author.id}}
                         {{author.name}}
                       {{/link}}
+                      {{#each author.badges}}
+                        {{#is category_slug "titles"}}
+                          <span class="community-badge community-badge-{{category_slug}}" title="{{description}}">
+                            {{#if icon_url}}
+                              <img src="{{icon_url}}" alt="" />
+                            {{/if}}
+                            {{name}}
+                          </span>
+                        {{/is}}
+                      {{/each}}
                     </span>
 
-                    <ul class="meta-group">
+                    <ul class="meta-group meta-group-opposite">
                       {{#if editor}}
                         <li class="meta-data">{{date edited_at timeago=true}}</li>
                         <li class="meta-data">{{t 'edited'}}</li>
@@ -188,6 +218,19 @@
                         <li class="meta-data">{{date created_at timeago=true}}</li>
                       {{/if}}
                     </ul>
+
+                    <div class="community-badge-container-achievements">
+                      {{#each author.badges}}
+                        {{#is category_slug "achievements"}}
+                          {{#if icon_url}}
+                            <div class="community-badge community-badge-{{category_slug}}">
+                              <img src="{{icon_url}}" alt="{{name}}" title="{{name}} | {{description}}" />
+                            </div>
+                          {{/if}}
+                        {{/is}}
+                      {{/each}}
+                    </div>
+
                   </div>
                   <div class="comment-labels">
                     {{#with ticket}}

--- a/templates/community_post_page.hbs
+++ b/templates/community_post_page.hbs
@@ -63,7 +63,7 @@
                   {{/link}}
                   {{#each post.author.badges}}
                     {{#is category_slug "titles"}}
-                      <span class="community-badge community-badge-{{category_slug}}" title="{{description}}">
+                      <span class="community-badge community-badge-titles" title="{{description}}" aria-label="{{name}}">
                         {{#if icon_url}}
                           <img src="{{icon_url}}" alt="" />
                         {{/if}}
@@ -84,8 +84,8 @@
                   {{#each post.author.badges}}
                     {{#is category_slug "achievements"}}
                       {{#if icon_url}}
-                        <div class="community-badge community-badge-{{category_slug}}">
-                          <img src="{{icon_url}}" alt="{{name}}" title="{{name}} | {{description}}" />
+                        <div class="community-badge community-badge-achievements">
+                          <img src="{{icon_url}}" alt="{{name}}" title="{{name}} | {{description}}" aria-label="{{name}}" />
                         </div>
                       {{/if}}
                     {{/is}}
@@ -200,7 +200,7 @@
                       {{/link}}
                       {{#each author.badges}}
                         {{#is category_slug "titles"}}
-                          <span class="community-badge community-badge-{{category_slug}}" title="{{description}}">
+                          <span class="community-badge community-badge-titles" title="{{description}}" aria-label="{{name}}">
                             {{#if icon_url}}
                               <img src="{{icon_url}}" alt="" />
                             {{/if}}
@@ -223,8 +223,8 @@
                       {{#each author.badges}}
                         {{#is category_slug "achievements"}}
                           {{#if icon_url}}
-                            <div class="community-badge community-badge-{{category_slug}}">
-                              <img src="{{icon_url}}" alt="{{name}}" title="{{name}} | {{description}}" />
+                            <div class="community-badge community-badge-achievements">
+                              <img src="{{icon_url}}" alt="{{name}}" title="{{name}} | {{description}}" aria-label="{{name}}" />
                             </div>
                           {{/if}}
                         {{/is}}

--- a/templates/user_profile_page.hbs
+++ b/templates/user_profile_page.hbs
@@ -240,51 +240,52 @@
       </div>
     {{/is}}
 
+    {{#is current_filter.identifier 'badges'}}
+      <div class="container">
+        <section class="profile-section">
+
+          {{#if user.badges}}
+            <header class="profile-section-header">
+              <h2 class="profile-section-title">{{t 'badges'}}</h2>
+              <span class="profile-section-description">{{t 'badges_description' name=user.name}}</span>
+            </header>
+
+            <div class="profile-badges-items">
+              {{#each user.badges}}
+                <section role="region" class="profile-badges-item" aria-labelledby="title-{{id}}" aria-describedby="desc-{{id}}">
+                  <div class="profile-badges-item-image">
+                    {{#if icon_url}}
+                      <img class="badge" src="{{icon_url}}" alt="">
+                    {{/if}}
+                  </div>
+                  <div>
+                    <div id="title-{{id}}" class="profile-badges-item-title">
+                      {{name}}
+                    </div>
+                    <p id="desc-{{id}}" class="profile-badges-item-description">
+                      {{description}}
+                    </p>
+                  </div>
+                  <div class="profile-badges-item-metadata">
+                    <div class="profile-badges-item-metadata-title">
+                      {{t 'badges_awarded'}}
+                    </div>
+                    <p class="profile-badges-item-metadata-description">
+                      {{date assigned_at format='medium'}}
+                    </p>
+                  </div>
+                </section>
+              {{/each}}
+            </div>
+          {{else}}
+            <span class="no-activity">{{t 'no_badges'}}</span>
+          {{/if}}
+        </section>
+      </div>
+
+    {{/is}}
+
     {{#isnt current_filter.identifier 'activities'}}
-      {{#is current_filter.identifier 'badges'}}
-        <div class="container">
-          <section class="profile-section">
-
-            {{#if user.badges}}
-              <header class="profile-section-header">
-                <h2 class="profile-section-title">{{t 'badges'}}</h2>
-                <span class="profile-section-description">{{t 'badges_description' name=user.name}}</span>
-              </header>
-
-              <div class="profile-badges-items">
-                {{#each user.badges}}
-                  <section role="region" class="profile-badges-item" aria-labelledby="title-{{id}}" aria-describedby="desc-{{id}}">
-                    <div class="profile-badges-item-image">
-                      {{#if icon_url}}
-                        <img class="badge" src="{{icon_url}}" alt="">
-                      {{/if}}
-                    </div>
-                    <div>
-                      <div id="title-{{id}}" class="profile-badges-item-title">
-                        {{name}}
-                      </div>
-                      <p id="desc-{{id}}" class="profile-badges-item-description">
-                        {{description}}
-                      </p>
-                    </div>
-                    <div class="profile-badges-item-metadata">
-                      <div class="profile-badges-item-metadata-title">
-                        {{t 'badges_awarded'}}
-                      </div>
-                      <p class="profile-badges-item-metadata-description">
-                        {{date assigned_at format='medium'}}
-                      </p>
-                    </div>
-                  </section>
-                {{/each}}
-              </div>
-            {{else}}
-              <span class="no-activity">{{t 'no_badges'}}</span>
-            {{/if}}
-          </section>
-        </div>
-
-      {{/is}}
       {{#isnt current_filter.identifier 'badges'}}
         <div class="container">
           <section class="profile-section">

--- a/templates/user_profile_page.hbs
+++ b/templates/user_profile_page.hbs
@@ -16,7 +16,28 @@
           {{else}}
             {{user.name}}
           {{/if}}
+          {{#each user.badges}}
+            {{#is category_slug "titles"}}
+              <span class="community-badge community-badge-{{category_slug}}" title="{{description}}">
+                {{#if icon_url}}
+                	<img src="{{icon_url}}" alt="" />
+                {{/if}}
+                {{name}}
+              </span>
+            {{/is}}
+          {{/each}}
         </h1>
+        <div class="community-badge-container-achievements">
+          {{#each user.badges}}
+            {{#is category_slug "achievements"}}
+              {{#if icon_url}}
+                <div class="community-badge community-badge-{{category_slug}}">
+                  <img src="{{icon_url}}" alt="{{name}}" title="{{name}} | {{description}}" />
+                </div>
+              {{/if}}
+            {{/is}}
+          {{/each}}
+        </div>
       </div>
       <div class="options">
         {{#if private_profile}}
@@ -220,119 +241,164 @@
     {{/is}}
 
     {{#isnt current_filter.identifier 'activities'}}
-      <div class="container">
-        <section class="profile-section">
+      {{#is current_filter.identifier 'badges'}}
+        <div class="container">
+          <section class="profile-section">
 
-          {{#if contributions}}
+            {{#if user.badges}}
+              <header class="profile-section-header">
+                <h2 class="profile-section-title">{{t 'badges'}}</h2>
+                <span class="profile-section-description">{{t 'badges_description' name=user.name}}</span>
+              </header>
 
-            <header class="profile-section-header">
-              <h2 class="profile-section-title">{{t current_filter.identifier}}</h2>
-              {{#if sorters}}
-                <span class="profile-section-description">{{sorter_description}}</span>
-                <span class="profile-section-sorter dropdown">
-                  <button class="dropdown-toggle" aria-haspopup="true">
-                    {{current_sorter.label}}
-                    <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" focusable="false" viewBox="0 0 12 12" class="dropdown-chevron-icon">
-                      <path fill="none" stroke="currentColor" stroke-linecap="round" d="M3 4.5l2.6 2.6c.2.2.5.2.7 0L9 4.5"/>
-                    </svg>
-                  </button>
-                  <span class="dropdown-menu" role="menu">
-                    {{#each sorters}}
-                      <a href="{{url}}" aria-selected="{{selected}}" role="menuitem">
+              <div class="profile-badges-items">
+                {{#each user.badges}}
+                  <section role="region" class="profile-badges-item" aria-labelledby="title-{{id}}" aria-describedby="desc-{{id}}">
+                    <div class="profile-badges-item-image">
+                      {{#if icon_url}}
+                        <img class="badge" src="{{icon_url}}" alt="">
+                      {{/if}}
+                    </div>
+                    <div>
+                      <div id="title-{{id}}" class="profile-badges-item-title">
                         {{name}}
-                      </a>
-                    {{/each}}
+                      </div>
+                      <p id="desc-{{id}}" class="profile-badges-item-description">
+                        {{description}}
+                      </p>
+                    </div>
+                    <div class="profile-badges-item-metadata">
+                      <div class="profile-badges-item-metadata-title">
+                        {{t 'badges_awarded'}}
+                      </div>
+                      <p class="profile-badges-item-metadata-description">
+                        {{date assigned_at format='medium'}}
+                      </p>
+                    </div>
+                  </section>
+                {{/each}}
+              </div>
+            {{else}}
+              <span class="no-activity">{{t 'no_badges'}}</span>
+            {{/if}}
+          </section>
+        </div>
+
+      {{/is}}
+      {{#isnt current_filter.identifier 'badges'}}
+        <div class="container">
+          <section class="profile-section">
+
+            {{#if contributions}}
+
+              <header class="profile-section-header">
+                <h2 class="profile-section-title">{{t current_filter.identifier}}</h2>
+                {{#if sorters}}
+                  <span class="profile-section-description">{{sorter_description}}</span>
+                  <span class="profile-section-sorter dropdown">
+                    <button class="dropdown-toggle" aria-haspopup="true">
+                      {{current_sorter.label}}
+                      <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" focusable="false" viewBox="0 0 12 12" class="dropdown-chevron-icon">
+                        <path fill="none" stroke="currentColor" stroke-linecap="round" d="M3 4.5l2.6 2.6c.2.2.5.2.7 0L9 4.5"/>
+                      </svg>
+                    </button>
+                    <span class="dropdown-menu" role="menu">
+                      {{#each sorters}}
+                        <a href="{{url}}" aria-selected="{{selected}}" role="menuitem">
+                          {{name}}
+                        </a>
+                      {{/each}}
+                    </span>
                   </span>
-                </span>
-              {{/if}}
-            </header>
+                {{/if}}
+              </header>
 
-            <ul class="profile-contribution-list profile-{{current_filter.identifier}}">
-              {{#each contributions}}
+              <ul class="profile-contribution-list profile-{{current_filter.identifier}}">
+                {{#each contributions}}
 
-                <li class="profile-contribution">
-                  <span class="profile-contribution-icon" aria-hidden="true">
-                    {{#is object_type "article"}}
-                      <svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" focusable="false" viewBox="0 0 12 12">
-                        <path fill="none" stroke="currentColor" stroke-linecap="round" d="M3.5 5.5h5m-5 2h5m-5 2h5m2-6.29V11c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h5.79c.13 0 .26.05.35.15l2.21 2.21c.1.09.15.21.15.35zM7.5.5V3c0 .28.22.5.5.5h2.5"/>
-                      </svg>
-                    {{/is}}
-                    {{#is object_type "post"}}
-                      <svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" focusable="false" viewBox="0 0 12 12">
-                        <path fill="none" stroke="currentColor" stroke-linecap="round" d="M1.5 6.5H1C.7 6.5.5 6.3.5 6V1C.5.7.7.5 1 .5h7c.3 0 .5.2.5.5v2.5m-6-1h4m-1 5h4m-4 2h4M4 5.5h7c.3 0 .5.2.5.5v5c0 .3-.2.5-.5.5H4c-.3 0-.5-.2-.5-.5V6c0-.3.2-.5.5-.5z"/>
-                      </svg>
-                    {{/is}}
-                    {{#is object_type "comment"}}
-                      <svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" focusable="false" viewBox="0 0 12 12">
-                        <path fill="none" stroke="currentColor" d="M1 .5h10c.3 0 .5.2.5.5v7c0 .3-.2.5-.5.5H6l-2.6 2.6c-.3.3-.9.1-.9-.4V8.5H1C.7 8.5.5 8.3.5 8V1C.5.7.7.5 1 .5z"/>
-                      </svg>
-                    {{/is}}
-                  </span>
-                  <header class="profile-contribution-header">
-                    {{#isnt object_type 'comment'}}
-                      <h3 class="profile-contribution-title"><a href="{{url}}">{{title}}</a></h3>
-                    {{/isnt}}
+                  <li class="profile-contribu tion">
+                    <span class="profile-contribution-icon" aria-hidden="true">
+                      {{#is object_type "article"}}
+                        <svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" focusable="false" viewBox="0 0 12 12">
+                          <path fill="none" stroke="currentColor" stroke-linecap="round" d="M3.5 5.5h5m-5 2h5m-5 2h5m2-6.29V11c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h5.79c.13 0 .26.05.35.15l2.21 2.21c.1.09.15.21.15.35zM7.5.5V3c0 .28.22.5.5.5h2.5"/>
+                        </svg>
+                      {{/is}}
+                      {{#is object_type "post"}}
+                        <svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" focusable="false" viewBox="0 0 12 12">
+                          <path fill="none" stroke="currentColor" stroke-linecap="round" d="M1.5 6.5H1C.7 6.5.5 6.3.5 6V1C.5.7.7.5 1 .5h7c.3 0 .5.2.5.5v2.5m-6-1h4m-1 5h4m-4 2h4M4 5.5h7c.3 0 .5.2.5.5v5c0 .3-.2.5-.5.5H4c-.3 0-.5-.2-.5-.5V6c0-.3.2-.5.5-.5z"/>
+                        </svg>
+                      {{/is}}
+                      {{#is object_type "comment"}}
+                        <svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" focusable="false" viewBox="0 0 12 12">
+                          <path fill="none" stroke="currentColor" d="M1 .5h10c.3 0 .5.2.5.5v7c0 .3-.2.5-.5.5H6l-2.6 2.6c-.3.3-.9.1-.9-.4V8.5H1C.7 8.5.5 8.3.5 8V1C.5.7.7.5 1 .5z"/>
+                        </svg>
+                      {{/is}}
+                    </span>
+                    <header class="profile-contribution-header">
+                      {{#isnt object_type 'comment'}}
+                        <h3 class="profile-contribution-title"><a href="{{url}}">{{title}}</a></h3>
+                      {{/isnt}}
 
-                    {{#isnt status 'none'}}
-                        <span class="status-label status-label-{{status_dasherized}}">{{status_name}}</span>
-                    {{/isnt}}
+                      {{#isnt status 'none'}}
+                          <span class="status-label status-label-{{status_dasherized}}">{{status_name}}</span>
+                      {{/isnt}}
 
-                    {{#if pending}}
-                      <span class="status-label status-label-pending-moderation">{{t 'pending_approval'}}</span>
-                    {{/if}}
+                      {{#if pending}}
+                        <span class="status-label status-label-pending-moderation">{{t 'pending_approval'}}</span>
+                      {{/if}}
 
-                    {{#if official}}
-                      <span class="status-label status-label-official">{{t 'official_comment'}}</span>
-                    {{/if}}
-                  </header>
+                      {{#if official}}
+                        <span class="status-label status-label-official">{{t 'official_comment'}}</span>
+                      {{/if}}
+                    </header>
 
-                  <ol class="breadcrumbs profile-contribution-breadcrumbs">
-                    {{#each path_steps}}
-                      <li title="{{name}}"><a href="{{url}}">{{name}}</a></li>
-                    {{/each}}
-                  </ol>
+                    <ol class="breadcrumbs profile-contribution-breadcrumbs">
+                      {{#each path_steps}}
+                        <li title="{{name}}"><a href="{{url}}">{{name}}</a></li>
+                      {{/each}}
+                    </ol>
 
-                  <p class="profile-contribution-body">{{excerpt body characters=200}}</p>
+                    <p class="profile-contribution-body">{{excerpt body characters=200}}</p>
 
-                  <ul class="meta-group">
-                    {{#is object_type 'comment'}}
-                      <li class="meta-data">
-                        <a class="comment-link" href={{url}}>{{t 'view_comment'}}</a>
-                      </li>
-                    {{/is}}
-                    <li class="meta-data">{{author.name}}</li>
-                    {{#if editor}}
-                      <li class="meta-data">{{date edited_at timeago=true}}</li>
-                      <li class="meta-data">
-                        {{#is object_type 'article'}}
-                          {{t 'updated'}}
-                        {{else}}
-                          {{t 'edited'}}
-                        {{/is}}
-                      </li>
-                    {{else}}
-                      <li class="meta-data">{{date created_at timeago=true}}</li>
-                    {{/if}}
-                    {{#each stats}}
-                      <li class="meta-data">{{label}}</li>
-                    {{/each}}
-                  </ul>
-                </li>
+                    <ul class="meta-group">
+                      {{#is object_type 'comment'}}
+                        <li class="meta-data">
+                          <a class="comment-link" href={{url}}>{{t 'view_comment'}}</a>
+                        </li>
+                      {{/is}}
+                      <li class="meta-data">{{author.name}}</li>
+                      {{#if editor}}
+                        <li class="meta-data">{{date edited_at timeago=true}}</li>
+                        <li class="meta-data">
+                          {{#is object_type 'article'}}
+                            {{t 'updated'}}
+                          {{else}}
+                            {{t 'edited'}}
+                          {{/is}}
+                        </li>
+                      {{else}}
+                        <li class="meta-data">{{date created_at timeago=true}}</li>
+                      {{/if}}
+                      {{#each stats}}
+                        <li class="meta-data">{{label}}</li>
+                      {{/each}}
+                    </ul>
+                  </li>
 
-              {{/each}}
-            </ul>
+                {{/each}}
+              </ul>
 
-            {{pagination}}
+              {{pagination}}
 
-          {{/if}}
+            {{/if}}
 
-          {{#unless contributions}}
-            <span class="no-activity">{{t 'no_contributions'}}</span>
-          {{/unless}}
+            {{#unless contributions}}
+              <span class="no-activity">{{t 'no_contributions'}}</span>
+            {{/unless}}
 
-        </section>
-      </div>
-
+          </section>
+        </div>
+      {{/isnt}}
     {{/isnt}}
 
   {{/if}}

--- a/templates/user_profile_page.hbs
+++ b/templates/user_profile_page.hbs
@@ -20,7 +20,7 @@
             {{#is category_slug "titles"}}
               <span class="community-badge community-badge-{{category_slug}}" title="{{description}}">
                 {{#if icon_url}}
-                	<img src="{{icon_url}}" alt="" />
+                  <img src="{{icon_url}}" alt="" />
                 {{/if}}
                 {{name}}
               </span>
@@ -316,7 +316,7 @@
               <ul class="profile-contribution-list profile-{{current_filter.identifier}}">
                 {{#each contributions}}
 
-                  <li class="profile-contribu tion">
+                  <li class="profile-contribution">
                     <span class="profile-contribution-icon" aria-hidden="true">
                       {{#is object_type "article"}}
                         <svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" focusable="false" viewBox="0 0 12 12">

--- a/templates/user_profile_page.hbs
+++ b/templates/user_profile_page.hbs
@@ -18,7 +18,7 @@
           {{/if}}
           {{#each user.badges}}
             {{#is category_slug "titles"}}
-              <span class="community-badge community-badge-{{category_slug}}" title="{{description}}">
+              <span class="community-badge community-badge-titles" title="{{description}}" aria-label="{{name}}">
                 {{#if icon_url}}
                   <img src="{{icon_url}}" alt="" />
                 {{/if}}
@@ -31,8 +31,8 @@
           {{#each user.badges}}
             {{#is category_slug "achievements"}}
               {{#if icon_url}}
-                <div class="community-badge community-badge-{{category_slug}}">
-                  <img src="{{icon_url}}" alt="{{name}}" title="{{name}} | {{description}}" />
+                <div class="community-badge community-badge-achievements">
+                  <img src="{{icon_url}}" alt="{{name}}" title="{{name}} | {{description}}" aria-label="{{name}}" />
                 </div>
               {{/if}}
             {{/is}}
@@ -250,9 +250,9 @@
               <span class="profile-section-description">{{t 'badges_description' name=user.name}}</span>
             </header>
 
-            <div class="profile-badges-items">
+            <ul class="profile-badges-items">
               {{#each user.badges}}
-                <section role="region" class="profile-badges-item" aria-labelledby="title-{{id}}" aria-describedby="desc-{{id}}">
+                <li role="region" class="profile-badges-item" aria-labelledby="title-{{id}}" aria-describedby="desc-{{id}}">
                   <div class="profile-badges-item-image">
                     {{#if icon_url}}
                       <img class="badge" src="{{icon_url}}" alt="">
@@ -274,9 +274,9 @@
                       {{date assigned_at format='medium'}}
                     </p>
                   </div>
-                </section>
+                </li>
               {{/each}}
-            </div>
+            </ul>
           {{else}}
             <span class="no-activity">{{t 'no_badges'}}</span>
           {{/if}}


### PR DESCRIPTION
## Description

Heavily inspired by @zdrve's work in #203, I have done some more adjustments to make it appear more like the design abstract.

This should not be merged yet since the feature is only in EAP, and I'm also not sure if there are conventions wrt. CSS class names and attributes etc. that needs to be revised.

## Screenshots

Post page:
<img width="1031" alt="Screenshot 2020-05-20 at 10 28 40" src="https://user-images.githubusercontent.com/291450/82424415-6f7cd000-9a85-11ea-960e-bc51eb6e379e.png">

User profile:
![image](https://user-images.githubusercontent.com/291450/82424453-802d4600-9a85-11ea-8eb0-36cb5a910bad.png)

Topic page:
![image](https://user-images.githubusercontent.com/291450/82424497-92a77f80-9a85-11ea-80a2-a76072399ac2.png)

## Checklist

- [x] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [x] :nail_care: SASS files are compiled
- [x] :arrow_left: changes are compatible with RTL direction
- [x] :wheelchair: changes are accessible
- [x] :memo: changes are tested in Chrome, Firefox, Safari, Edge, and IE11
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->