### PR TITLE
Update if statement to check for type filters instead of community

### DIFF
--- a/templates/search_results.hbs
+++ b/templates/search_results.hbs
@@ -41,7 +41,7 @@
           </ul>
         </section>
       {{/if}}
-      {{#if help_center.community_enabled}}
+      {{#if type_filters}}
         <section class="filters-in-section collapsible-sidebar" aria-expanded="false">
           <button type="button" class="collapsible-sidebar-toggle" aria-expanded="false">
             <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" focusable="false" viewBox="0 0 12 12" aria-hidden="true" class="collapsible-sidebar-toggle-icon chevron-icon">


### PR DESCRIPTION
## Description

- Fixes bug where `type_filters` are nested in a check for community, meaning that those without communities but with external record types wouldn't see the results properly. 

## Checklist

- [x] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [x] :nail_care: SASS files are compiled
- [x] :arrow_left: changes are compatible with RTL direction
- [x] :wheelchair: changes are accessible
- [x] :memo: changes are tested in Chrome, Firefox, Safari, Edge, and IE11
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->