### PR TITLE
chore: remove IE from the PR template checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,7 +12,7 @@
 - [ ] :nail_care: SASS files are compiled
 - [ ] :arrow_left: changes are compatible with RTL direction
 - [ ] :wheelchair: changes are accessible
-- [ ] :memo: changes are tested in Chrome, Firefox, Safari, Edge, and IE11
+- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
 - [ ] :+1: PR is approved by @zendesk/vikings
 
 <!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->


### PR DESCRIPTION
## Description

IE is no longer supported for endusers: https://support.zendesk.com/hc/en-us/articles/115001505447

## Checklist

- [x] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [x] :nail_care: SASS files are compiled
- [x] :arrow_left: changes are compatible with RTL direction
- [x] :wheelchair: changes are accessible
- [x] :memo: changes are tested in Chrome, Firefox, Safari, Edge, and IE11
- [x] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->