### PR TITLE
fix(split-button): correct button height and hover-color

### DIFF
--- a/style.css
+++ b/style.css
@@ -376,7 +376,7 @@ ul {
   text-decoration: none;
 }
 
-.button.button-primary:hover, .split-button button.button-primary:hover, .section-subscribe button.button-primary:hover, .section-subscribe button[data-selected="true"]:hover, .article-subscribe button.button-primary:hover, .article-subscribe button[data-selected="true"]:hover, .community-follow button.button-primary:hover, .requests-table-toolbar .organization-subscribe button.button-primary:hover, .requests-table-toolbar .organization-subscribe button[data-selected="true"]:hover, .subscriptions-subscribe button.button-primary:hover, .subscriptions-subscribe button[data-selected="true"]:hover, .button-primary.pagination-next-link:hover, .button-primary.pagination-prev-link:hover, .button-primary.pagination-first-link:hover, .button-primary.pagination-last-link:hover, .button.button-primary:focus, .split-button button.button-primary:focus, .section-subscribe button.button-primary:focus, .section-subscribe button[data-selected="true"]:focus, .article-subscribe button.button-primary:focus, .article-subscribe button[data-selected="true"]:focus, .community-follow button.button-primary:focus, .requests-table-toolbar .organization-subscribe button.button-primary:focus, .requests-table-toolbar .organization-subscribe button[data-selected="true"]:focus, .subscriptions-subscribe button.button-primary:focus, .subscriptions-subscribe button[data-selected="true"]:focus, .button-primary.pagination-next-link:focus, .button-primary.pagination-prev-link:focus, .button-primary.pagination-first-link:focus, .button-primary.pagination-last-link:focus, .button.button-primary:active, .split-button button.button-primary:active, .section-subscribe button.button-primary:active, .section-subscribe button[data-selected="true"]:active, .article-subscribe button.button-primary:active, .article-subscribe button[data-selected="true"]:active, .community-follow button.button-primary:active, .requests-table-toolbar .organization-subscribe button.button-primary:active, .requests-table-toolbar .organization-subscribe button[data-selected="true"]:active, .subscriptions-subscribe button.button-primary:active, .subscriptions-subscribe button[data-selected="true"]:active, .button-primary.pagination-next-link:active, .button-primary.pagination-prev-link:active, .button-primary.pagination-first-link:active, .button-primary.pagination-last-link:active {
+.button.button-primary:hover, .split-button button:hover, .section-subscribe button.button-primary:hover, .section-subscribe button[data-selected="true"]:hover, .article-subscribe button.button-primary:hover, .article-subscribe button[data-selected="true"]:hover, .community-follow button.button-primary:hover, .requests-table-toolbar .organization-subscribe button.button-primary:hover, .requests-table-toolbar .organization-subscribe button[data-selected="true"]:hover, .subscriptions-subscribe button.button-primary:hover, .subscriptions-subscribe button[data-selected="true"]:hover, .button-primary.pagination-next-link:hover, .button-primary.pagination-prev-link:hover, .button-primary.pagination-first-link:hover, .button-primary.pagination-last-link:hover, .button.button-primary:focus, .split-button button.button-primary:focus, .section-subscribe button.button-primary:focus, .section-subscribe button[data-selected="true"]:focus, .article-subscribe button.button-primary:focus, .article-subscribe button[data-selected="true"]:focus, .community-follow button.button-primary:focus, .requests-table-toolbar .organization-subscribe button.button-primary:focus, .requests-table-toolbar .organization-subscribe button[data-selected="true"]:focus, .subscriptions-subscribe button.button-primary:focus, .subscriptions-subscribe button[data-selected="true"]:focus, .button-primary.pagination-next-link:focus, .button-primary.pagination-prev-link:focus, .button-primary.pagination-first-link:focus, .button-primary.pagination-last-link:focus, .button.button-primary:active, .split-button button.button-primary:active, .section-subscribe button.button-primary:active, .section-subscribe button[data-selected="true"]:active, .article-subscribe button.button-primary:active, .article-subscribe button[data-selected="true"]:active, .community-follow button.button-primary:active, .requests-table-toolbar .organization-subscribe button.button-primary:active, .requests-table-toolbar .organization-subscribe button[data-selected="true"]:active, .subscriptions-subscribe button.button-primary:active, .subscriptions-subscribe button[data-selected="true"]:active, .button-primary.pagination-next-link:active, .button-primary.pagination-prev-link:active, .button-primary.pagination-first-link:active, .button-primary.pagination-last-link:active {
   background-color: darken($brand_color, 20%);
   border-color: darken($brand_color, 20%);
 }
@@ -434,9 +434,9 @@ ul {
   background-color: $brand_color;
   border: 0;
   color: $brand_text_color;
-  line-height: normal;
+  height: 32px;
+  line-height: 16px;
   outline-color: $brand_color;
-  padding: 8px 20px;
 }
 
 [dir="rtl"] .split-button button:not(:only-child):first-child {
@@ -452,6 +452,9 @@ ul {
 }
 
 .split-button button:not(:only-child):last-child {
+  display: flex;
+  justify-content: center;
+  align-items: center;
   width: 26px;
   min-width: 26px;
   max-width: 26px;

--- a/styles/_split_button.scss
+++ b/styles/_split_button.scss
@@ -3,14 +3,18 @@
   display: flex;
 }
 
+.split-button button:hover {
+  @extend .button-primary:hover;
+}
+
 .split-button button {
   @extend .button;
   background-color: $brand_color;
   border: 0;
   color: $brand_text_color;
-  line-height: normal;
+  height: 32px;
+  line-height: 16px;
   outline-color: $brand_color;
-  padding: 8px 20px;
 }
 
 .split-button button:not(:only-child) {
@@ -29,6 +33,9 @@
   }
 
   &:last-child {
+    display: flex;
+    justify-content: center;
+    align-items: center;
     width: 26px;
     min-width: 26px;
     max-width: 26px;


### PR DESCRIPTION
## Description

The newly added split button does not match in height with other buttons used in the theme, and this shows especially on the user profile page when it is placed next to the follow/unfollow button. This PR makes sure that the button is exactly 32px tall, matching the follow/unfollow button.

Also, when hovered, the two buttons within the split button do not highlight with the darker blue, like other buttons do, so this part was added as well.

## Screenshots

Before
<img width="348" alt="Screenshot 2020-07-13 at 14 34 09" src="https://user-images.githubusercontent.com/6997051/87310773-b4b9fd00-c51e-11ea-8880-39a57a812868.png">

After
<img width="326" alt="Screenshot 2020-07-13 at 14 50 51" src="https://user-images.githubusercontent.com/6997051/87310795-be436500-c51e-11ea-94d5-21c65aecb749.png">

## Checklist

- [x] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [x] :nail_care: SASS files are compiled
- [x] :arrow_left: changes are compatible with RTL direction
- [x] :wheelchair: changes are accessible
- [x] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->