### PR TITLE
More verbose errors for github workflow

### DIFF
--- a/.github/workflows/theme_upload.rb
+++ b/.github/workflows/theme_upload.rb
@@ -50,11 +50,16 @@ loop do
   raise "timeout" if retries < 1
 
   job_status_response = zendesk_connection.get("jobs/#{job_id}")
-  status = job_status_response.body['job']['status']
+  body = job_status_response.body
+  status = body['job']['status']
 
-  raise 'Import failed' if status == "failed"
+  if status == "failed"
+    warn(body)
 
-  break if job_status_response.body['job']['status'] == 'completed'
+    raise 'Import failed'
+  end
+
+  break if status == 'completed'
 
   retries -= 1
 


### PR DESCRIPTION
On build failure, the output will now contain a line like:
```
{"job"=>{"id"=>"43e7c3e5bc1f30c8407bcf43f4a914e8", "status"=>"failed", "errors"=>[{"message"=>"Template(s) with syntax error(s)", "code"=>"InvalidTemplates", "meta"=>{"templates/user_profile_page.hbs"=>[{"description"=>"'badges' does not exist", "line"=>253, "column"=>18, "length"=>6}]}}], "data"=>nil}}
```