### PR TITLE
!fixup [COMM-1046] Achievement widget

### DIFF
--- a/script.js
+++ b/script.js
@@ -397,4 +397,43 @@ document.addEventListener('DOMContentLoaded', function() {
       }
     });
   });
+
+  const splitAt = (n, xs) => [xs.slice(0, n), xs.slice(n)];
+
+  const makePlaceholder = () => "data:image/gif;base64,R0lGODlhEAAQAMQAAORHHOVSKudfOulrSOp3WOyDZu6QdvCchPGolfO0o/XBs/fNwfjZ0frl3/zy7////wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACH5BAkAABAALAAAAAAQABAAAAVVICSOZGlCQAosJ6mu7fiyZeKqNKToQGDsM8hBADgUXoGAiqhSvp5QAnQKGIgUhwFUYLCVDFCrKUE1lBavAViFIDlTImbKC5Gm2hB0SlBCBMQiB0UjIQA7";
+
+  const makeTruncateElement = (achievements) => {
+    const txt = achievements.map(({description}) => description).join("\n");
+    const span = document.createElement("span");
+    const img = document.createElement("img");
+    img.setAttribute("src", makePlaceholder(achievements.length));
+    span.setAttribute("title", txt);
+    span.appendChild(img);
+    return span;
+  };
+
+  const recoverAchievement = (elt) => {
+    const img = elt.firstElementChild;
+    return {
+      badgeCategorySlug: elt.dataset.badgeCategorySlug,
+      description: img.getAttribute("alt"),
+      iconUrl: img.getAttribute("src")
+    };
+  };
+
+  const showAchievements = 5;
+  function truncateAchievement(container) {
+    const achievements = [...container.children];
+    if(achievements.length <= showAchievements) return;
+    const [show, hidden] = splitAt(showAchievements, achievements);
+    hidden.forEach((elt) => elt.remove());
+    const truncateElement = makeTruncateElement(hidden.map(recoverAchievement));
+    container.appendChild(truncateElement);
+  }
+
+  function truncateAchievements() {
+    Array.prototype.forEach.call(document.querySelectorAll(".achievements"), truncateAchievement);
+  }
+
+  truncateAchievements();
 });

--- a/templates/user_profile_page.hbs
+++ b/templates/user_profile_page.hbs
@@ -16,17 +16,22 @@
           {{else}}
             {{user.name}}
           {{/if}}
-          {{#each user.badges}}
-            {{#is category_slug "titles"}}
-              <span class="community-badge community-badge-{{category_slug}}" title="{{description}}">
-                {{#if icon_url}}
-                  <img src="{{icon_url}}" />
-                {{/if}}
-                {{name}}
-              </span>
-            {{/is}}
-          {{/each}}
         </h1>
+        <div class="achievements">
+          {{#each user.badges}}
+          <span data-badge-category-slug="{{category_slug}}"><img alt="{{description}}" src="{{icon_url}}" /></span>
+          {{/each}}
+        </div>
+        {{#each user.badges}}
+          {{#is category_slug "titles"}}
+            <span class="community-badge community-badge-{{category_slug}}" title="{{description}}">
+              {{#if icon_url}}
+                <img src="{{icon_url}}" />
+              {{/if}}
+              {{name}}
+            </span>
+          {{/is}}
+        {{/each}}
         <div class="community-badge-container-achievements">
           {{#each user.badges}}
             {{#is category_slug "achievements"}}


### PR DESCRIPTION
[COMM-1046]
===

TODO
===

* [ ] Only consider badges with `category == "achievements"`
* [ ] Do not show on user profile page
* [ ] Show in the correct places (which?)
* [ ] Dynamically generate the "+n" icon.
* [ ] Use compatible JS-syntax.
* [ ] Don't actually output the slug as part of the generated HTML.

[COMM-1046]: https://zendesk.atlassian.net/browse/COMM-1046