### PR TITLE
COMM-1183: Refined how title badges are presented

### DIFF
--- a/style.css
+++ b/style.css
@@ -2766,12 +2766,6 @@ ul {
   margin-left: 10px;
 }
 
-.posts-list .community-badge-titles {
-  background-color: #f0f0f0;
-  color: #04444D;
-  font-size: 10px;
-}
-
 .community-badge-container-achievements {
   margin-top: 0.4em;
 }

--- a/styles/_community_badge.scss
+++ b/styles/_community_badge.scss
@@ -14,12 +14,6 @@
   margin-left: 10px;
 }
 
-.posts-list .community-badge-titles {
-  background-color: #f0f0f0;
-  color: #04444D;
-  font-size: 10px;
-}
-
 .community-badge-container-achievements {
   margin-top: 0.4em;
 }

--- a/templates/article_page.hbs
+++ b/templates/article_page.hbs
@@ -212,7 +212,12 @@
                             {{/link}}
                             {{#each author.badges}}
                               {{#is category_slug "titles"}}
-                                <span class="community-badge community-badge-{{category_slug}}" title="{{description}}">{{name}}</span>
+                                <span class="community-badge community-badge-{{category_slug}}" title="{{description}}">
+                                  {{#if icon_url}}
+                                    <img src="{{icon_url}}" alt="" />
+                                  {{/if}}
+                                  {{name}}
+                                </span>
                               {{/is}}
                             {{/each}}
                           </span>

--- a/templates/community_post_page.hbs
+++ b/templates/community_post_page.hbs
@@ -200,7 +200,12 @@
                       {{/link}}
                       {{#each author.badges}}
                         {{#is category_slug "titles"}}
-                          <span class="community-badge community-badge-{{category_slug}}" title="{{description}}">{{name}}</span>
+                          <span class="community-badge community-badge-{{category_slug}}" title="{{description}}">
+                            {{#if icon_url}}
+                              <img src="{{icon_url}}" alt="" />
+                            {{/if}}
+                            {{name}}
+                          </span>
                         {{/is}}
                       {{/each}}
                     </span>

--- a/templates/community_topic_page.hbs
+++ b/templates/community_topic_page.hbs
@@ -92,13 +92,6 @@
 
             <ul class="meta-group">
               <li class="meta-data">{{author.name}}</li>
-              {{#each author.badges}}
-                {{#is category_slug "titles"}}
-                  <li class="meta-data">
-                    <span class="community-badge community-badge-{{category_slug}}" title="{{description}}">{{name}}</span>
-                  </li>
-                {{/is}}
-              {{/each}}
               {{#if editor}}
                 <li class="meta-data">{{date edited_at timeago=true}}</li>
                 <li class="meta-data">{{t 'edited'}}</li>


### PR DESCRIPTION
## Description

Adds title badge icons (if available) to the various places where we show title badges.

Also removed title badges from the post listings - that was not designed by product design and just my bad idea that we should remove.

## Screenshots

Can be seen live on https://z3n-kaspersor.zendesk.com/hc/en-us/profiles/377841432074

Post comment:

![image](https://user-images.githubusercontent.com/291450/90634310-c9796700-e227-11ea-972d-6991c23461e3.png)

Article comment:

![image](https://user-images.githubusercontent.com/291450/90634377-ddbd6400-e227-11ea-94c2-0e079c63d2b1.png)


## Checklist

Omitted because this PR only merges into the non-main branch `badges-example`.