### PR TITLE
feat(requests): [COMM-1283] Check for "emptiness" when using WYSIWYG

### DIFF
--- a/script.js
+++ b/script.js
@@ -92,9 +92,23 @@ document.addEventListener('DOMContentLoaded', function() {
   // Change Mark as solved text according to whether comment is filled
   var requestCommentTextarea = document.querySelector('.request-container .comment-container textarea');
 
+  var usesWysiwyg = requestCommentTextarea.dataset.helper === "wysiwyg";
+
+  function isEmptyPlaintext(s) {
+    return s.trim() === '';
+  }
+
+  function isEmptyHtml(xml) {
+    var doc = new DOMParser().parseFromString(`<_>${xml}</_>`, "text/xml");
+    var img = doc.querySelector("img");
+    return img === null && isEmptyPlaintext(doc.children[0].textContent);
+  };
+
+  var isEmpty = usesWysiwyg ? isEmptyHtml : isEmptyPlaintext;
+
   if (requestCommentTextarea) {
     requestCommentTextarea.addEventListener('input', function() {
-      if (requestCommentTextarea.value === '') {
+      if (isEmpty(requestCommentTextarea.value)) {
         if (requestMarkAsSolvedButton) {
           requestMarkAsSolvedButton.innerText = requestMarkAsSolvedButton.getAttribute('data-solve-translation');
         }


### PR DESCRIPTION
# [COMM-1283]

## Description

The "reply to request" page may now contain a WYSIWYG editor in stead
of a textarea. The existing mechanism for checking whether that input
field is "empty" is therefore no longer valid. Consider e.g.:

    <p></p>

This string is not "empty" if interpreted as `text/plain`, however it
*is* "empty" if interpreted as `text/xml` (HTML).

We switch between the two empty-checking mechanism by looking at the
data-attribute "helper" which may have the value "wysiwyg" in which
case the new mechanism is used.

## Checklist

- [x] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [x] :nail_care: SASS files are compiled
- [x] :arrow_left: changes are compatible with RTL direction
- [x] :wheelchair: changes are accessible
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [x] :iphone: changes are responsive and tested in mobile
- [x] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->

[COMM-1283]: https://zendesk.atlassian.net/browse/COMM-1283