### PR TITLE
fix(script): prevent TypeError with null element

### DIFF
--- a/script.js
+++ b/script.js
@@ -90,9 +90,15 @@ document.addEventListener('DOMContentLoaded', function() {
   }
 
   // Change Mark as solved text according to whether comment is filled
-  var requestCommentTextarea = document.querySelector('.request-container .comment-container textarea');
+  var
+    requestCommentTextarea = document.querySelector(
+      ".request-container .comment-container textarea"
+    ),
+    usesWysiwyg = false;
 
-  var usesWysiwyg = requestCommentTextarea.dataset.helper === "wysiwyg";
+  if (requestCommentTextarea) {
+    usesWysiwyg = requestCommentTextarea.dataset.helper === "wysiwyg";
+  }
 
   function isEmptyPlaintext(s) {
     return s.trim() === '';


### PR DESCRIPTION
## Description

When there are no matching textarea element that the query selector is trying to get, the script would throw TypeError when accessing `dataset` property of a (null)`requestCommentTextarea`

## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :nail_care: SASS files are compiled
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: changes are accessible
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->