### PR TITLE
Added translations.yml entries for future theme setting

### DIFF
--- a/translations.yml
+++ b/translations.yml
@@ -345,3 +345,13 @@ parts:
       title: "Description for the follow topic setting"
       screenshot: "https://drive.google.com/open?id=1uZaNe12E-A_snTd_7AjcqirB4ROLF4bB"
       value: "Users can follow a specific topic"
+  - translation:
+      key: "txt.help_center_copenhagen_theme.show_brand_name_label"
+      title: "Label for the show brand name setting"
+      screenshot: "https://drive.google.com/file/d/16zQao3zk3uRScIUpkyc6bXAWwqHh3Zh-/view?usp=sharing"
+      value: "Show Help Center name"
+  - translation:
+      key: "txt.help_center_copenhagen_theme.show_brand_name_description"
+      title: "Description for the show brand name setting"
+      screenshot: "https://drive.google.com/file/d/16zQao3zk3uRScIUpkyc6bXAWwqHh3Zh-/view?usp=sharing"
+      value: "Display the Help Center name next to the logo"


### PR DESCRIPTION
## Description

Added translations.yml entries for future theme setting rel. to HC brand name. With the coming visual updates of the theme (staged in PR #248), there will be an option to show the brand name next to the logo. This PR adds the string keys for that.

See COMM-1372 and ROAD-8816.

## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :nail_care: SASS files are compiled
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: changes are accessible
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->