### PR TITLE
Added translation key for visited links

### DIFF
--- a/translations.yml
+++ b/translations.yml
@@ -59,6 +59,16 @@ parts:
       screenshot: "https://zendesk.box.com/s/ufzzcaedpey0zp92nozg2yzhytsrhd8f"
       value: "Link color"
   - translation:
+      key: "txt.help_center_copenhagen_theme.visited_link_color_description"
+      title: "Description for the visited link color setting"
+      screenshot: "https://drive.google.com/file/d/1ZOoBb6K_mpYtyd3ulkEKawmSj1dZPuFw/view?usp=sharing"
+      value: "Text color for visited link elements"
+  - translation:
+      key: "txt.help_center_copenhagen_theme.visited_link_color_label"
+      title: "Label for the visited link color setting"
+      screenshot: "https://drive.google.com/file/d/1ZOoBb6K_mpYtyd3ulkEKawmSj1dZPuFw/view?usp=sharing"
+      value: "Visited link color"
+  - translation:
       key: "txt.help_center_copenhagen_theme.background_color_description"
       title: "Description for the background color setting"
       screenshot: "https://zendesk.box.com/s/ufzzcaedpey0zp92nozg2yzhytsrhd8f"


### PR DESCRIPTION
## Description

Added a translation key for a future setting which allows the user to select the link color for "visited" links.

## Checklist

- [x] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [x] :nail_care: SASS files are compiled
- [x] :arrow_left: changes are compatible with RTL direction
- [x] :wheelchair: changes are accessible
- [x] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [x] :iphone: changes are responsive and tested in mobile
- [x] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->