### PR TITLE
chore: Translations for "visited links" strings

### DIFF
--- a/translations/ar.json
+++ b/translations/ar.json
@@ -8,6 +8,8 @@
   "text_color_label": "لون النص",
   "link_color_description": "لون النص لعناصر الروابط",
   "link_color_label": "لون الروابط",
+  "visited_link_color_description": "لون النص لعناصر الروابط التي تمت زيارتها",
+  "visited_link_color_label": "لون الروابط التي تمت زيارتها",
   "background_color_description": "لون خلفية مركز المساعدة",
   "background_color_label": "لون الخلفية",
   "fonts_group_label": "الخطوط",

--- a/translations/bg.json
+++ b/translations/bg.json
@@ -8,6 +8,8 @@
   "text_color_label": "Цвят на текста",
   "link_color_description": "Цвят на текста за елементите-линкове",
   "link_color_label": "Цвят на линка",
+  "visited_link_color_description": "Цвят на текста за посетените линкове",
+  "visited_link_color_label": "Цвят на посетен линк",
   "background_color_description": "Цвят на фона на вашия Помощен център",
   "background_color_label": "Цвят на фона",
   "fonts_group_label": "Шрифтове",

--- a/translations/cs.json
+++ b/translations/cs.json
@@ -8,6 +8,8 @@
   "text_color_label": "Barva textu",
   "link_color_description": "Barva textu pro elementy odkazů",
   "link_color_label": "Barva odkazu",
+  "visited_link_color_description": "Barva textu pro navštívené elementy odkazů",
+  "visited_link_color_label": "Barva navštíveného odkazu",
   "background_color_description": "Barva pozadí vašeho Centra nápovědy",
   "background_color_label": "Barva pozadí",
   "fonts_group_label": "Písma",

--- a/translations/da.json
+++ b/translations/da.json
@@ -8,6 +8,8 @@
   "text_color_label": "Tekstfarve",
   "link_color_description": "Tekstfarve til link-elementer",
   "link_color_label": "Farve på link",
+  "visited_link_color_description": "Tekstfarve til besøgte link-elementer",
+  "visited_link_color_label": "Farve til besøgt link",
   "background_color_description": "Baggrundsfarve på dit Help Center",
   "background_color_label": "Baggrundsfarve",
   "fonts_group_label": "Skrifttyper",

--- a/translations/de.json
+++ b/translations/de.json
@@ -8,6 +8,8 @@
   "text_color_label": "Textfarbe",
   "link_color_description": "Textfarbe für Linkelemente",
   "link_color_label": "Linkfarbe",
+  "visited_link_color_description": "Textfarbe für besuchte Linkelemente",
+  "visited_link_color_label": "Farbe für besuchte Links",
   "background_color_description": "Hintergrundfarbe für Ihr Help Center",
   "background_color_label": "Hintergrundfarbe",
   "fonts_group_label": "Schriftarten",

--- a/translations/el.json
+++ b/translations/el.json
@@ -8,6 +8,8 @@
   "text_color_label": "Χρώμα κειμένου",
   "link_color_description": "Χρώμα κειμένου για στοιχεία συνδέσμων",
   "link_color_label": "Χρώμα συνδέσμων",
+  "visited_link_color_description": "Χρώμα κειμένου για στοιχεία συνδέσμων με επισκέψεις",
+  "visited_link_color_label": "Χρώμα συνδέσμων με επισκέψεις",
   "background_color_description": "Χρώμα φόντου του Κέντρου βοήθειας",
   "background_color_label": "Χρώμα φόντου",
   "fonts_group_label": "Γραμματοσειρές",

--- a/translations/en-ca.json
+++ b/translations/en-ca.json
@@ -8,6 +8,8 @@
   "text_color_label": "Text colour",
   "link_color_description": "Text colour for link elements",
   "link_color_label": "Link colour",
+  "visited_link_color_description": "Text colour for visited link elements",
+  "visited_link_color_label": "Visited link colour",
   "background_color_description": "Background colour of your Help Centre",
   "background_color_label": "Background colour",
   "fonts_group_label": "Fonts",

--- a/translations/en-gb.json
+++ b/translations/en-gb.json
@@ -8,6 +8,8 @@
   "text_color_label": "Text colour",
   "link_color_description": "Text colour for link elements",
   "link_color_label": "Link colour",
+  "visited_link_color_description": "Text colour for visited link elements",
+  "visited_link_color_label": "Visited link colour",
   "background_color_description": "Background colour of your Help Centre",
   "background_color_label": "Background colour",
   "fonts_group_label": "Fonts",

--- a/translations/en-us.json
+++ b/translations/en-us.json
@@ -8,6 +8,8 @@
   "text_color_label": "Text color",
   "link_color_description": "Text color for link elements",
   "link_color_label": "Link color",
+  "visited_link_color_description": "Text color for visited link elements",
+  "visited_link_color_label": "Visited link color",
   "background_color_description": "Background color of your Help Center",
   "background_color_label": "Background color",
   "fonts_group_label": "Fonts",

--- a/translations/es-419.json
+++ b/translations/es-419.json
@@ -8,6 +8,8 @@
   "text_color_label": "Color de texto",
   "link_color_description": "El color del texto para los elementos de vínculos",
   "link_color_label": "Color de vínculos",
+  "visited_link_color_description": "El color del texto para los elementos de los vínculos visitados",
+  "visited_link_color_label": "Color de vínculo visitado",
   "background_color_description": "El color de fondo del Centro de ayuda",
   "background_color_label": "Color de fondo",
   "fonts_group_label": "Fuentes",

--- a/translations/es-es.json
+++ b/translations/es-es.json
@@ -8,6 +8,8 @@
   "text_color_label": "Color de texto",
   "link_color_description": "El color del texto para los elementos de vínculos",
   "link_color_label": "Color de vínculos",
+  "visited_link_color_description": "El color del texto para los elementos de los vínculos visitados",
+  "visited_link_color_label": "Color de vínculo visitado",
   "background_color_description": "El color de fondo del Centro de ayuda",
   "background_color_label": "Color de fondo",
   "fonts_group_label": "Fuentes",

--- a/translations/es.json
+++ b/translations/es.json
@@ -8,6 +8,8 @@
   "text_color_label": "Color de texto",
   "link_color_description": "El color del texto para los elementos de vínculos",
   "link_color_label": "Color de vínculos",
+  "visited_link_color_description": "El color del texto para los elementos de los vínculos visitados",
+  "visited_link_color_label": "Color de vínculo visitado",
   "background_color_description": "El color de fondo del Centro de ayuda",
   "background_color_label": "Color de fondo",
   "fonts_group_label": "Fuentes",

--- a/translations/fi.json
+++ b/translations/fi.json
@@ -8,6 +8,8 @@
   "text_color_label": "Tekstin väri",
   "link_color_description": "Linkkielementtien tekstin väri",
   "link_color_label": "Linkin väri",
+  "visited_link_color_description": "Vierailtujen linkkielementtien tekstin väri",
+  "visited_link_color_label": "Vierailtujen linkkien väri",
   "background_color_description": "Tukiportaalin taustaväri",
   "background_color_label": "Taustaväri",
   "fonts_group_label": "Fontit",

--- a/translations/fr-ca.json
+++ b/translations/fr-ca.json
@@ -8,6 +8,8 @@
   "text_color_label": "Couleur du texte",
   "link_color_description": "Couleur du texte pour les liens",
   "link_color_label": "Couleur des liens",
+  "visited_link_color_description": "Couleur du texte pour les éléments de liens consultés",
+  "visited_link_color_label": "Couleur des liens consultés",
   "background_color_description": "Couleur d’arrière-plan de votre Centre d’aide",
   "background_color_label": "Couleur d’arrière-plan",
   "fonts_group_label": "Polices",

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -8,6 +8,8 @@
   "text_color_label": "Couleur du texte",
   "link_color_description": "Couleur du texte pour les liens",
   "link_color_label": "Couleur des liens",
+  "visited_link_color_description": "Couleur du texte pour les éléments de liens consultés",
+  "visited_link_color_label": "Couleur des liens consultés",
   "background_color_description": "Couleur d’arrière-plan de votre Centre d’aide",
   "background_color_label": "Couleur d’arrière-plan",
   "fonts_group_label": "Polices",

--- a/translations/he.json
+++ b/translations/he.json
@@ -8,6 +8,8 @@
   "text_color_label": "צבע טקסט",
   "link_color_description": "צבע הטקסט בשביל רכיבי קישור",
   "link_color_label": "צבע קישור",
+  "visited_link_color_description": "צבע הטקסט בשביל קישורים שנכנסו אליהם",
+  "visited_link_color_label": "צבע קישור שנכנסו אליו",
   "background_color_description": "צבע הרקע של מרכז התמיכה",
   "background_color_label": "צבע רקע",
   "fonts_group_label": "גופנים",

--- a/translations/hi.json
+++ b/translations/hi.json
@@ -8,6 +8,8 @@
   "text_color_label": "पाठ रंग",
   "link_color_description": "लिंक तत्वों के लिए पाठ रंग",
   "link_color_label": "लिंक रंग",
+  "visited_link_color_description": "विज़िट किए गए लिंक तत्वों के लिए पाठ रंग",
+  "visited_link_color_label": "विज़िट किए गए लिंक के रंग",
   "background_color_description": "आपके सहायता केंद्र की पृष्ठभूमि का रंग",
   "background_color_label": "पृष्ठभूमि का रंग",
   "fonts_group_label": "फॉन्ट",

--- a/translations/hu.json
+++ b/translations/hu.json
@@ -8,6 +8,8 @@
   "text_color_label": "Szöveg színe",
   "link_color_description": "Linkek szövegének színe",
   "link_color_label": "Link színe",
+  "visited_link_color_description": "Meglátogatott hivatkozások szövegének színe",
+  "visited_link_color_label": "Meglátogatott hivatkozás színe",
   "background_color_description": "A Súgóközpontja háttérszíne",
   "background_color_label": "Háttérszín",
   "fonts_group_label": "Betűtípusok",

--- a/translations/id.json
+++ b/translations/id.json
@@ -8,6 +8,8 @@
   "text_color_label": "Warna teks",
   "link_color_description": "Warna teks untuk elemen tautan",
   "link_color_label": "Warna tautan",
+  "visited_link_color_description": "Warna teks untuk elemen tautan yang dikunjungi",
+  "visited_link_color_label": "Warna tautan yang dikunjungi",
   "background_color_description": "Warna latar belakang Pusat Bantuan Anda",
   "background_color_label": "Warna latar belakang",
   "fonts_group_label": "Font",

--- a/translations/it.json
+++ b/translations/it.json
@@ -8,6 +8,8 @@
   "text_color_label": "Colore testo",
   "link_color_description": "Colore del testo per i link",
   "link_color_label": "Colore link",
+  "visited_link_color_description": "Colore del testo per i link selezionati",
+  "visited_link_color_label": "Colore link selezionati",
   "background_color_description": "Colore di sfondo del Centro assistenza",
   "background_color_label": "Colore di sfondo",
   "fonts_group_label": "Carattere",

--- a/translations/ja.json
+++ b/translations/ja.json
@@ -8,6 +8,8 @@
   "text_color_label": "テキストの色",
   "link_color_description": "リンク要素のテキストの色",
   "link_color_label": "リンクの色",
+  "visited_link_color_description": "訪問済みリンク要素のテキストの色",
+  "visited_link_color_label": "訪問済みリンクの色",
   "background_color_description": "ヘルプセンターの背景色",
   "background_color_label": "背景色",
   "fonts_group_label": "フォント",

--- a/translations/ko.json
+++ b/translations/ko.json
@@ -8,6 +8,8 @@
   "text_color_label": "텍스트 색",
   "link_color_description": "링크 요소의 텍스트 색",
   "link_color_label": "링크 색",
+  "visited_link_color_description": "방문한 링크 요소의 텍스트 색",
+  "visited_link_color_label": "방문한 링크 색",
   "background_color_description": "헬프 센터 배경 색",
   "background_color_label": "배경 색",
   "fonts_group_label": "글꼴",

--- a/translations/nl.json
+++ b/translations/nl.json
@@ -8,6 +8,8 @@
   "text_color_label": "Tekstkleur",
   "link_color_description": "Tekstkleur voor linkelementen",
   "link_color_label": "Kleur van link",
+  "visited_link_color_description": "Tekstkleur voor bezochte linkelementen",
+  "visited_link_color_label": "Kleur van bezochte link",
   "background_color_description": "Achtergrondkleur van uw Helpcenter",
   "background_color_label": "Achtergrondkleur",
   "fonts_group_label": "Lettertypen",

--- a/translations/no.json
+++ b/translations/no.json
@@ -8,6 +8,8 @@
   "text_color_label": "Tekstfarge",
   "link_color_description": "Tekstfarge for lenkeelementer",
   "link_color_label": "Lenkefarge",
+  "visited_link_color_description": "Tekstfarge for besøkte lenkeelementer",
+  "visited_link_color_label": "Farge på besøkt lenke",
   "background_color_description": "Bakgrunnsfarge i Kundesenter",
   "background_color_label": "Bakgrunnsfarge",
   "fonts_group_label": "Skrifter",

--- a/translations/pl.json
+++ b/translations/pl.json
@@ -8,6 +8,8 @@
   "text_color_label": "Kolor tekstu",
   "link_color_description": "Kolor tekstu elementów łączy",
   "link_color_label": "Kolor łączy",
+  "visited_link_color_description": "Kolor tekstu elementów użytych łączy",
+  "visited_link_color_label": "Kolor użytych łączy",
   "background_color_description": "Kolor tła Centrum pomocy",
   "background_color_label": "Kolor tła",
   "fonts_group_label": "Czcionki",

--- a/translations/pt-br.json
+++ b/translations/pt-br.json
@@ -8,6 +8,8 @@
   "text_color_label": "Cor do texto",
   "link_color_description": "Cor do texto para elementos de link",
   "link_color_label": "Cor do link",
+  "visited_link_color_description": "Cor do texto para elementos de links visitados",
+  "visited_link_color_label": "Cor de links visitados",
   "background_color_description": "Cor do plano de fundo da sua Central de Ajuda",
   "background_color_label": "Cor do plano de fundo",
   "fonts_group_label": "Fontes",

--- a/translations/pt.json
+++ b/translations/pt.json
@@ -8,6 +8,8 @@
   "text_color_label": "Cor do texto",
   "link_color_description": "Cor do texto para elementos de link",
   "link_color_label": "Cor do link",
+  "visited_link_color_description": "Cor do texto para elementos de links visitados",
+  "visited_link_color_label": "Cor de links visitados",
   "background_color_description": "Cor do plano de fundo da sua Central de Ajuda",
   "background_color_label": "Cor do plano de fundo",
   "fonts_group_label": "Fontes",

--- a/translations/ro.json
+++ b/translations/ro.json
@@ -8,6 +8,8 @@
   "text_color_label": "Culoare text",
   "link_color_description": "Culoarea textului pentru elementele tip link",
   "link_color_label": "Culoare link",
+  "visited_link_color_description": "Culoarea textului pentru elementele linkului vizitat",
+  "visited_link_color_label": "Culoarea linkului vizitat",
   "background_color_description": "Culoarea de fundal a Centrului de asistență",
   "background_color_label": "Culoare fundal",
   "fonts_group_label": "Fonturi",

--- a/translations/ru.json
+++ b/translations/ru.json
@@ -8,6 +8,8 @@
   "text_color_label": "Цвет текста",
   "link_color_description": "Цвет текста для элементов ссылок",
   "link_color_label": "Цвет ссылки",
+  "visited_link_color_description": "Цвет текста для элементов посещенных ссылок",
+  "visited_link_color_label": "Цвет посещенной ссылки",
   "background_color_description": "Цвет фона Справочного центра",
   "background_color_label": "Цвет фона",
   "fonts_group_label": "Шрифты",

--- a/translations/sv.json
+++ b/translations/sv.json
@@ -8,6 +8,8 @@
   "text_color_label": "Textfärg",
   "link_color_description": "Textfärg för länkelement",
   "link_color_label": "Länkfärg",
+  "visited_link_color_description": "Textfärg för besökta länkelement",
+  "visited_link_color_label": "Färg för besökt länk",
   "background_color_description": "Bakgrundsfärg för ditt Helpcenter",
   "background_color_label": "Bakgrundsfärg",
   "fonts_group_label": "Typsnitt",

--- a/translations/th.json
+++ b/translations/th.json
@@ -8,6 +8,8 @@
   "text_color_label": "สีข้อความ",
   "link_color_description": "สีข้อความสำหรับองค์ประกอบลิงก์",
   "link_color_label": "สีลิงก์",
+  "visited_link_color_description": "สีข้อความสำหรับองค์ประกอบลิงก์ที่เข้าชม",
+  "visited_link_color_label": "สีลิงก์ที่เข้าชม",
   "background_color_description": "สีพื้นหลังของศูนย์ความช่วยเหลือของคุณ",
   "background_color_label": "สีพื้นหลัง",
   "fonts_group_label": "ฟอนต์",

--- a/translations/tr.json
+++ b/translations/tr.json
@@ -8,6 +8,8 @@
   "text_color_label": "Metin rengi",
   "link_color_description": "Bağlantı öğeleri için metin rengi",
   "link_color_label": "Bağlantı rengi",
+  "visited_link_color_description": "Ziyaret edilmiş bağlantı öğeleri için metin rengi",
+  "visited_link_color_label": "Ziyaret edilmiş bağlantı rengi",
   "background_color_description": "Yardım Merkezi'nizin arka plan rengi",
   "background_color_label": "Arka plan rengi",
   "fonts_group_label": "Yazı tipleri",

--- a/translations/uk.json
+++ b/translations/uk.json
@@ -8,6 +8,8 @@
   "text_color_label": "Text color",
   "link_color_description": "Text color for link elements",
   "link_color_label": "Link color",
+  "visited_link_color_description": "Text color for visited link elements",
+  "visited_link_color_label": "Visited link color",
   "background_color_description": "Background color of your Help Center",
   "background_color_label": "Background color",
   "fonts_group_label": "Fonts",

--- a/translations/vi.json
+++ b/translations/vi.json
@@ -8,6 +8,8 @@
   "text_color_label": "Màu văn bản",
   "link_color_description": "Màu văn bản cho các thành phần liên kết",
   "link_color_label": "Màu liên kết",
+  "visited_link_color_description": "Màu văn bản cho các thành phần liên kết đã truy cập",
+  "visited_link_color_label": "Màu liên kết đã truy cập",
   "background_color_description": "Màu nền của Trung tâm Trợ giúp của bạn",
   "background_color_label": "Màu nền",
   "fonts_group_label": "Phông chữ",

--- a/translations/zh-cn.json
+++ b/translations/zh-cn.json
@@ -8,6 +8,8 @@
   "text_color_label": "文本颜色",
   "link_color_description": "链接元素的文本颜色",
   "link_color_label": "链接颜色",
+  "visited_link_color_description": "已访问链接元素的文本颜色",
+  "visited_link_color_label": "已访问链接颜色",
   "background_color_description": "您的帮助中心的背景颜色",
   "background_color_label": "背景颜色",
   "fonts_group_label": "字体",

--- a/translations/zh-tw.json
+++ b/translations/zh-tw.json
@@ -8,6 +8,8 @@
   "text_color_label": "文字色彩",
   "link_color_description": "連結元素文字色彩",
   "link_color_label": "連結色彩",
+  "visited_link_color_description": "已造訪連結元素文字色彩",
+  "visited_link_color_label": "已造訪連結色彩",
   "background_color_description": "客服中心背景色彩",
   "background_color_label": "背景色彩",
   "fonts_group_label": "字型",


### PR DESCRIPTION
## Description

Just ran `update-translations` script

## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :nail_care: SASS files are compiled
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: changes are accessible
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->