### PR TITLE
Set the `show_brand_name` setting default to true

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -217,7 +217,7 @@
           "type": "checkbox",
           "description": "show_brand_name_description",
           "label": "show_brand_name_label",
-          "value": false
+          "value": true
         },
         {
           "identifier": "favicon",


### PR DESCRIPTION
## Description

Makes the new setting "Show brand name" default to `true`. This should be done once we have backfilled the latest version of Copenhagen, introducing the setting with it's safer-for-backwards-compatibility `false` setting.

## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :nail_care: SASS files are compiled
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: changes are accessible
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->