### PR TITLE
fix (styles): [GG-1634] Remove unnecessary font weights

### DIFF
--- a/style.css
+++ b/style.css
@@ -191,7 +191,6 @@ body {
   color: $text_color;
   font-family: $text_font;
   font-size: 15px;
-  font-weight: 400;
   line-height: 1.5;
   -webkit-font-smoothing: antialiased;
 }
@@ -204,7 +203,6 @@ body {
 
 h1, h2, h3, h4, h5, h6 {
   font-family: $heading_font;
-  font-weight: 400;
   margin-top: 0;
 }
 
@@ -241,7 +239,6 @@ textarea {
 }
 
 input {
-  font-weight: 300;
   max-width: 100%;
   box-sizing: border-box;
   transition: border .12s ease-in-out;
@@ -392,7 +389,6 @@ ul {
   border-radius: 4px;
   color: $brand_text_color;
   font-size: 14px;
-  font-weight: 400;
   line-height: 2.72;
   min-width: 190px;
   padding: 0 1.9286em;
@@ -489,7 +485,6 @@ ul {
 .table th a {
   color: lighten($text_color, 20%);
   font-size: 13px;
-  font-weight: 300;
   text-align: left;
 }
 
@@ -932,7 +927,6 @@ ul {
 .footer-language-selector button {
   color: lighten($text_color, 20%);
   display: inline-block;
-  font-weight: 300;
 }
 
 /***** Breadcrumbs *****/
@@ -950,7 +944,6 @@ ul {
 .breadcrumbs li {
   color: lighten($text_color, 20%);
   display: inline;
-  font-weight: 300;
   font-size: 13px;
   max-width: 450px;
   overflow: hidden;
@@ -1071,7 +1064,6 @@ ul {
 
 .page-header-description {
   font-style: italic;
-  font-weight: 300;
   margin: 0 0 30px 0;
   word-break: break-word;
 }
@@ -1201,7 +1193,6 @@ ul {
 }
 
 .blocks-item-description {
-  font-weight: 300;
   margin: 0;
 }
 
@@ -1336,7 +1327,6 @@ ul {
 
 .recent-activity-item-link {
   font-size: 14px;
-  font-weight: 300;
 }
 
 .recent-activity-item-meta {
@@ -1358,7 +1348,6 @@ ul {
   color: lighten($text_color, 20%);
   display: inline-block;
   font-size: 13px;
-  font-weight: 300;
 }
 
 .recent-activity-item-comment {
@@ -1687,7 +1676,6 @@ ul {
 
 .article-comment-count {
   color: lighten($text_color, 20%);
-  font-weight: 300;
 }
 
 .article-comment-count:hover {
@@ -1798,7 +1786,6 @@ ul {
   border-radius: 4px;
   color: $text_color;
   display: block;
-  font-weight: 300;
   margin-bottom: 10px;
   padding: 10px;
 }
@@ -1905,7 +1892,6 @@ ul {
 .comment-callout {
   color: lighten($text_color, 20%);
   display: inline-block;
-  font-weight: 300;
   font-size: 13px;
   margin-bottom: 0;
 }
@@ -1921,7 +1907,6 @@ ul {
 
 .comment-sorter .dropdown-toggle {
   color: lighten($text_color, 20%);
-  font-weight: 300;
   font-size: 13px;
 }
 
@@ -2417,7 +2402,6 @@ ul {
 
 .striped-list-count {
   color: lighten($text_color, 20%);
-  font-weight: 300;
   font-size: 13px;
   justify-content: flex-start;
   text-transform: capitalize;
@@ -2448,7 +2432,6 @@ ul {
 }
 
 .striped-list-number {
-  font-weight: 300;
   text-align: center;
 }
 
@@ -2456,7 +2439,6 @@ ul {
   .striped-list-number {
     color: $text_color;
     display: block;
-    font-weight: 400;
   }
 }
 
@@ -2711,7 +2693,6 @@ ul {
 
 .post-comment-count {
   color: lighten($text_color, 20%);
-  font-weight: 300;
 }
 
 .post-comment-count:hover {
@@ -3284,7 +3265,6 @@ ul {
 .contributions-table td:last-child {
   color: lighten($text_color, 20%);
   font-size: 13px;
-  font-weight: 300;
 }
 
 @media (min-width: 768px) {
@@ -3477,7 +3457,6 @@ ul {
 
 .request-details dt {
   color: lighten($text_color, 20%);
-  font-weight: 300;
   width: 40%;
 }
 
@@ -3581,7 +3560,6 @@ ul {
 .meta-data {
   color: lighten($text_color, 20%);
   font-size: 13px;
-  font-weight: 300;
 }
 
 .meta-data:not(:last-child)::after {
@@ -3712,7 +3690,6 @@ ul {
 
 .profile-stats .stat-label {
   color: lighten($text_color, 20%);
-  font-weight: 300;
   flex: 0 0 100px;
   margin-right: 10px;
 }
@@ -3873,7 +3850,6 @@ ul {
   flex-basis: 100%;
   padding: 10px 0;
   color: lighten($text_color, 20%);
-  font-weight: 300;
   font-size: 13px;
   white-space: nowrap;
   overflow: hidden;
@@ -4410,7 +4386,6 @@ ul {
   color: lighten($text_color, 20%);
   display: inline-block;
   font-size: 13px;
-  font-weight: 300;
   padding: 4px 5px;
   position: relative;
 }

--- a/styles/_article.scss
+++ b/styles/_article.scss
@@ -93,7 +93,6 @@
 
   &-comment-count {
     color: $secondary-text-color;
-    font-weight: $font-weight-light;
 
     &:hover {
       text-decoration: none;
@@ -201,7 +200,6 @@
     border-radius: 4px;
     color: $text_color;
     display: block;
-    font-weight: $font-weight-light;
     margin-bottom: 10px;
     padding: 10px;
 

--- a/styles/_base.scss
+++ b/styles/_base.scss
@@ -8,7 +8,6 @@ body {
   color: $text_color;
   font-family: $text_font;
   font-size: $font-size-base;
-  font-weight: $font-weight-base;
   line-height: 1.5;
   -webkit-font-smoothing: antialiased;
 
@@ -21,7 +20,6 @@ body {
 
 h1, h2, h3, h4, h5, h6 {
   font-family: $heading_font;
-  font-weight: $font-weight-base;
   margin-top: 0;
 }
 
@@ -52,7 +50,6 @@ textarea {
 }
 
 input {
-  font-weight: $font-weight-light;
   max-width: 100%;
   box-sizing: border-box;
   transition: border .12s ease-in-out;

--- a/styles/_blocks.scss
+++ b/styles/_blocks.scss
@@ -80,7 +80,6 @@
   }
 
   &-item-description {
-    font-weight: $font-weight-light;
     margin: 0;
   }
 

--- a/styles/_breadcrumbs.scss
+++ b/styles/_breadcrumbs.scss
@@ -10,7 +10,6 @@
   li {
     color: $secondary-text-color;
     display: inline;
-    font-weight: $font-weight-light;
     font-size: $font-size-small;
     max-width: 450px;
     overflow: hidden;

--- a/styles/_buttons.scss
+++ b/styles/_buttons.scss
@@ -53,7 +53,6 @@
   border-radius: 4px;
   color: $brand_text_color;
   font-size: 14px;
-  font-weight: $font-weight-base;
   line-height: 2.72;
   min-width: 190px;
   padding: 0 1.9286em;

--- a/styles/_comments.scss
+++ b/styles/_comments.scss
@@ -22,7 +22,6 @@
   &-callout {
     color: $secondary-text-color;
     display: inline-block;
-    font-weight: $font-weight-light;
     font-size: $font-size-small;
     margin-bottom: 0;
 
@@ -36,7 +35,6 @@
 
     .dropdown-toggle {
       color: $secondary-text-color;
-      font-weight: $font-weight-light;
       font-size: $font-size-small;
     }
 

--- a/styles/_footer.scss
+++ b/styles/_footer.scss
@@ -15,6 +15,5 @@
   &-language-selector button {
     color: $secondary-text-color;
     display: inline-block;
-    font-weight: $font-weight-light;
   }
 }

--- a/styles/_metadata.scss
+++ b/styles/_metadata.scss
@@ -18,7 +18,6 @@
 .meta-data {
   color: $secondary-text-color;
   font-size: $font-size-small;
-  font-weight: $font-weight-light;
 
   &:not(:last-child)::after {
     content: "\00B7";

--- a/styles/_my-activities.scss
+++ b/styles/_my-activities.scss
@@ -224,7 +224,6 @@
 
     color: $secondary-text-color;
     font-size: $font-size-small;
-    font-weight: $font-weight-light;
   }
 }
 

--- a/styles/_page_header.scss
+++ b/styles/_page_header.scss
@@ -32,7 +32,6 @@
       flex-basis: 100%;
     }
     font-style: italic;
-    font-weight: $font-weight-light;
     margin: 0 0 30px 0;
     word-break: break-word;
   }

--- a/styles/_post.scss
+++ b/styles/_post.scss
@@ -109,7 +109,6 @@
 
   &-comment-count {
     color: $secondary-text-color;
-    font-weight: $font-weight-light;
 
     &:hover {
       text-decoration: none;

--- a/styles/_recent-activity.scss
+++ b/styles/_recent-activity.scss
@@ -33,7 +33,6 @@
 
   &-item-link {
     font-size: 14px;
-    font-weight: $font-weight-light;
   }
 
   &-item-meta {
@@ -54,7 +53,6 @@
     color: $secondary-text-color;
     display: inline-block;
     font-size: $font-size-small;
-    font-weight: $font-weight-light;
   }
 
   &-item-comment {

--- a/styles/_request.scss
+++ b/styles/_request.scss
@@ -151,7 +151,6 @@
 
     dt {
       color: $secondary-text-color;
-      font-weight: $font-weight-light;
       width: 40%;
     }
 

--- a/styles/_search_results.scss
+++ b/styles/_search_results.scss
@@ -166,7 +166,6 @@
     color: $secondary-text-color;
     display: inline-block;
     font-size: $font-size-small;
-    font-weight: $font-weight-light;
     padding: 4px 5px;
     position: relative;
 

--- a/styles/_striped_list.scss
+++ b/styles/_striped_list.scss
@@ -47,12 +47,10 @@
     }
 
     color: $secondary-text-color;
-    font-weight: $font-weight-light;
     font-size: $font-size-small;
     justify-content: flex-start;
     text-transform: capitalize;
   }
-
   &-count-item {
     &::after {
       @include tablet { display: none; }
@@ -69,10 +67,7 @@
     @include tablet {
       color: $text_color;
       display: block;
-      font-weight: $font-weight-base;
     }
-
-    font-weight: $font-weight-light;
     text-align: center;
   }
 }

--- a/styles/_tables.scss
+++ b/styles/_tables.scss
@@ -11,7 +11,6 @@
   th a {
     color: $secondary-text-color;
     font-size: $font-size-small;
-    font-weight: $font-weight-light;
     text-align: left;
 
     [dir="rtl"] & { text-align: right; }

--- a/styles/_user-profiles.scss
+++ b/styles/_user-profiles.scss
@@ -117,7 +117,6 @@
 
 .profile-stats .stat-label {
   color: $secondary-text-color;
-  font-weight: $font-weight-light;
   flex: 0 0 100px;
   margin-right: 10px;
 
@@ -269,7 +268,6 @@
   flex-basis: 100%;
   padding: 10px 0;
   color: $secondary-text-color;
-  font-weight: $font-weight-light;
   font-size: $font-size-small;
   white-space: nowrap;
   overflow: hidden;

--- a/styles/_variables.scss
+++ b/styles/_variables.scss
@@ -35,6 +35,4 @@ $max-width-container: 1160px;
 // Fonts
 $heading_font: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif !default;
 $text_font: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif !default;
-$font-weight-base: 400;
-$font-weight-light: 300;
 $font-weight-semibold: 600;


### PR DESCRIPTION
## Description

We only need two font weight rules, default and semi-bold, so the others are removed.
https://zendesk.atlassian.net/browse/GG-1634

## Checklist

- [x] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [x] :nail_care: SASS files are compiled
- [x] :arrow_left: changes are compatible with RTL direction
- [x] :wheelchair: changes are accessible
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->