### PR TITLE
fix: Adding topic ID to the bottom New post button

### DIFF
--- a/templates/community_topic_page.hbs
+++ b/templates/community_topic_page.hbs
@@ -120,5 +120,5 @@
 
 <section class="container community-footer">
   <h2 class="community-footer-title">{{t 'suggest_new_post'}}</h2>
-  {{link 'new_post' class='button button-large'}}
+  {{link 'new_post' topic_id=topic.id class='button button-large'}}
 </section>


### PR DESCRIPTION
## Description

This resolves COMM-219 which highlights that the two "New post" buttons on the topic page have different behaviours but they should both prefill the topic ID of the New post form.

## Screenshots

![image](https://user-images.githubusercontent.com/291450/134663908-7cd0e289-5dae-496e-ae7d-0a0215135c54.png)

## Checklist

- [x] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [x] :nail_care: SASS files are compiled
- [x] :arrow_left: changes are compatible with RTL direction
- [x] :wheelchair: changes are accessible
- [x] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [x] :iphone: changes are responsive and tested in mobile
- [x] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->