### PR TITLE
fix: [GG-2204] A11y - mark nav as a list

### DIFF
--- a/style.css
+++ b/style.css
@@ -699,6 +699,15 @@ ul {
   margin: 20px;
 }
 
+.user-nav-list {
+  display: block;
+  list-style: none;
+}
+
+.user-nav-list > li {
+  display: inline-block;
+}
+
 .nav-wrapper a {
   border: 0;
   color: $link_color;

--- a/style.css
+++ b/style.css
@@ -699,6 +699,15 @@ ul {
   margin: 20px;
 }
 
+.user-nav[aria-expanded="true"] > .user-nav-list li {
+  display: block;
+}
+
+.user-nav[aria-expanded="true"] > .user-nav-list a {
+  display: block;
+  margin: 20px;
+}
+
 .user-nav-list {
   display: block;
   list-style: none;
@@ -731,10 +740,6 @@ ul {
   background-color: transparent;
   color: $link_color;
   text-decoration: underline;
-}
-
-.nav-wrapper a.sign-in {
-  display: inline-block;
 }
 
 @media (max-width: 768px) {

--- a/styles/_header.scss
+++ b/styles/_header.scss
@@ -50,6 +50,15 @@ $header-height: 71px;
   }
 }
 
+.user-nav-list {
+  display: block;
+  list-style: none;
+
+  > li {
+    display: inline-block;
+  }
+}
+
 .nav-wrapper {
   a {
     @include tablet {

--- a/styles/_header.scss
+++ b/styles/_header.scss
@@ -47,6 +47,17 @@ $header-height: 71px;
       display: block;
       margin: 20px;
     }
+
+    > .user-nav-list {
+      li {
+        display: block;
+      }
+
+      a {
+        display: block;
+        margin: 20px;
+      }
+    }
   }
 }
 
@@ -81,8 +92,6 @@ $header-height: 71px;
       color: $link_color;
       text-decoration: underline;
     }
-
-    &.sign-in { display: inline-block; }
   }
 
   .hide-on-mobile {

--- a/templates/header.hbs
+++ b/templates/header.hbs
@@ -16,8 +16,17 @@
       </svg>
     </button>
     <nav class="user-nav" id="user-nav">
-      {{link 'community'}}
-      {{link 'new_request' class='submit-a-request'}}
+      <ul class="user-nav-list">
+        <li>{{link 'community'}}</li>
+        <li>{{link 'new_request' class='submit-a-request'}}</li>
+        {{#unless signed_in}}
+          <li>
+            {{#link "sign_in" class="sign-in"}}
+              {{t 'sign_in'}}
+            {{/link}}
+          </li>
+        {{/unless}}
+      </ul>
     </nav>
     {{#if signed_in}}
       <div class="user-info dropdown">
@@ -37,10 +46,6 @@
           {{link "sign_out" role="menuitem"}}
         </div>
       </div>
-    {{else}}
-      {{#link "sign_in" class="sign-in"}}
-        {{t 'sign_in'}}
-      {{/link}}
     {{/if}}
   </div>
 </header>


### PR DESCRIPTION
## Description


## Screenshots
**The appearance SHOULD NOT change, only the underlying HTML elements**

Before:
<img width="1789" alt="cph_v1_elements" src="https://user-images.githubusercontent.com/12835055/138880012-fd1f6e10-d98f-44a3-9629-8b8ccc7208db.png">

After:
<img width="1791" alt="cph_v2_elements" src="https://user-images.githubusercontent.com/12835055/138880045-fb08a3f8-7542-4b55-9633-4b35de92b2cf.png">

## Checklist

- [x] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [x] :nail_care: SASS files are compiled
- [x] :arrow_left: changes are compatible with RTL direction
- [x] :wheelchair: changes are accessible
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->