### PR TITLE
fix: Remove refs to AppleGothic

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -79,7 +79,7 @@
             },
             {
               "label": "Century Gothic",
-              "value": "'Century Gothic', AppleGothic, sans-serif"
+              "value": "'Century Gothic', sans-serif"
             },
             {
               "label": "Copperplate Light",
@@ -91,7 +91,7 @@
             },
             {
               "label": "Futura",
-              "value": "Futura, 'Century Gothic', AppleGothic, sans-serif"
+              "value": "Futura, 'Century Gothic', sans-serif"
             },
             {
               "label": "Garamond",
@@ -152,7 +152,7 @@
             },
             {
               "label": "Century Gothic",
-              "value": "'Century Gothic', AppleGothic, sans-serif"
+              "value": "'Century Gothic', sans-serif"
             },
             {
               "label": "Copperplate Light",
@@ -164,7 +164,7 @@
             },
             {
               "label": "Futura",
-              "value": "Futura, 'Century Gothic', AppleGothic, sans-serif"
+              "value": "Futura, 'Century Gothic', sans-serif"
             },
             {
               "label": "Garamond",


### PR DESCRIPTION
## Description

Removes fallback font `AppleGothic` which is causing issues for our Japanese users

Ref https://support.zendesk.com/agent/tickets/9679482

## Screenshots

![inline514956496](https://user-images.githubusercontent.com/5488576/140752308-b3fd165e-1240-43d9-a5c7-63892a9404a5.png)


<!-- (optional) when applicable, please include some screenshots or gifs that illustrate the changes -->

## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :nail_care: SASS files are compiled
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: changes are accessible
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->