### PR TITLE
Navbar changes

### DIFF
--- a/script.js
+++ b/script.js
@@ -102,7 +102,7 @@ document.addEventListener('DOMContentLoaded', function() {
     var doc = new DOMParser().parseFromString(`<_>${xml}</_>`, "text/xml");
     var img = doc.querySelector("img");
     return img === null && isEmptyPlaintext(doc.children[0].textContent);
-  };
+  }
 
   var isEmpty = usesWysiwyg ? isEmptyHtml : isEmptyPlaintext;
 
@@ -158,25 +158,21 @@ document.addEventListener('DOMContentLoaded', function() {
     toggle.focus();
   }
 
-  var burgerMenu = document.querySelector('.header .menu-button');
-  var userMenu = document.querySelector('#user-nav');
+  var menuButton = document.querySelector('.header .menu-button-mobile');
+  var menuList = document.querySelector('#user-nav-mobile');
 
-  burgerMenu.addEventListener('click', function(e) {
+  menuButton.addEventListener('click', function(e) {
     e.stopPropagation();
-    toggleNavigation(this, userMenu);
+    toggleNavigation(this, menuList);
   });
 
 
-  userMenu.addEventListener('keyup', function(e) {
+  menuList.addEventListener('keyup', function(e) {
     if (e.keyCode === ESCAPE) {
       e.stopPropagation();
-      closeNavigation(burgerMenu, this);
+      closeNavigation(menuButton, this);
     }
   });
-
-  if (userMenu.children.length === 0) {
-    burgerMenu.style.display = 'none';
-  }
 
   // Toggles expanded aria to collapsible elements
   var collapsible = document.querySelectorAll('.collapsible-nav, .collapsible-sidebar');
@@ -245,7 +241,7 @@ document.addEventListener('DOMContentLoaded', function() {
     this.toggle.addEventListener("click", this.clickHandler.bind(this));
     this.toggle.addEventListener("keydown", this.toggleKeyHandler.bind(this));
     this.menu.addEventListener("keydown", this.menuKeyHandler.bind(this));
-  };
+  }
 
   Dropdown.prototype = {
 

--- a/style.css
+++ b/style.css
@@ -699,6 +699,15 @@ ul {
   margin: 20px;
 }
 
+.user-nav[aria-expanded="true"] > .user-nav-list li {
+  display: block;
+}
+
+.user-nav[aria-expanded="true"] > .user-nav-list a {
+  display: block;
+  margin: 20px;
+}
+
 .user-nav-list {
   display: block;
   list-style: none;
@@ -708,7 +717,25 @@ ul {
   display: inline-block;
 }
 
-.nav-wrapper a {
+@media (max-width: 768px) {
+  .nav-wrapper-desktop {
+    display: none;
+  }
+}
+
+@media (min-width: 768px) {
+  .nav-wrapper-desktop {
+    display: none;
+  }
+}
+
+@media (min-width: 1024px) {
+  .nav-wrapper-desktop {
+    display: inline-block;
+  }
+}
+
+.nav-wrapper-desktop a {
   border: 0;
   color: $link_color;
   display: none;
@@ -718,71 +745,134 @@ ul {
 }
 
 @media (min-width: 768px) {
-  .nav-wrapper a {
+  .nav-wrapper-desktop a {
     display: inline-block;
   }
 }
 
-[dir="rtl"] .nav-wrapper a {
+[dir="rtl"] .nav-wrapper-desktop a {
   padding: 0 0 0 20px;
 }
 
-.nav-wrapper a:hover, .nav-wrapper a:focus, .nav-wrapper a:active {
+.nav-wrapper-desktop a:hover, .nav-wrapper-desktop a:focus, .nav-wrapper-desktop a:active {
   background-color: transparent;
   color: $link_color;
   text-decoration: underline;
 }
 
-.nav-wrapper a.sign-in {
-  display: inline-block;
-}
-
-@media (max-width: 768px) {
-  .nav-wrapper .hide-on-mobile {
-    border: 0;
-    clip: rect(0 0 0 0);
-    -webkit-clip-path: inset(50%);
-    clip-path: inset(50%);
-    height: 1px;
-    margin: -1px;
-    overflow: hidden;
-    padding: 0;
-    position: absolute;
-    width: 1px;
-    white-space: nowrap;
-  }
-}
-
-.nav-wrapper .menu-button {
-  background: none;
-  border: 0;
-  color: $link_color;
-  display: inline-block;
-  margin-right: 10px;
-  padding: 0;
-  width: auto;
-}
-
-@media (min-width: 768px) {
-  .nav-wrapper .menu-button {
+@media (min-width: 1024px) {
+  .nav-wrapper-mobile {
     display: none;
   }
 }
 
-.nav-wrapper .menu-button .icon-menu {
+.nav-wrapper-mobile .menu-button-mobile {
+  background: none;
+  border: 0;
+  width: auto;
+  min-width: 71px;
+  cursor: pointer;
+}
+
+.nav-wrapper-mobile .menu-button-mobile .icon-menu {
+  padding: 7px;
   vertical-align: middle;
-  width: 13px;
-  height: 13px;
+  width: 30px;
+  height: 30px;
 }
 
-[dir="rtl"] .nav-wrapper .menu-button {
-  margin-left: 10px;
+.nav-wrapper-mobile .menu-button-mobile[aria-expanded="true"] .icon-menu {
+  background: rgba(31, 115, 183, 0.2);
+  border-radius: 50%;
+}
+
+.nav-wrapper-mobile .menu-list-mobile {
+  position: absolute;
+  background-color: #fff;
+  box-shadow: 0 10px 10px 0 rgba(0, 0, 0, 0.15);
+  border-top: solid 0.1px #ddd;
+  border-bottom: solid 1px #ddd;
+  right: 0;
+  left: 0;
+  top: 71px;
+  z-index: 2;
+}
+
+.nav-wrapper-mobile .menu-list-mobile[aria-expanded="false"] {
+  display: none;
+}
+
+.nav-wrapper-mobile .menu-list-mobile[aria-expanded="true"] {
+  display: block;
+}
+
+.nav-wrapper-mobile .menu-list-mobile-items .item {
+  margin: 4px 0;
+}
+
+.nav-wrapper-mobile .menu-list-mobile-items li:empty:not(.nav-divider) {
+  display: none;
+}
+
+.nav-wrapper-mobile .menu-list-mobile-items .nav-divider {
+  border-bottom: 0.1px solid #ddd;
+  padding: 0;
+}
+
+.nav-wrapper-mobile .menu-list-mobile-items .nav-divider:last-child {
+  display: none;
+}
+
+.nav-wrapper-mobile .menu-list-mobile-items button {
+  background: none;
+  border: none;
+  padding: 8px 24px;
+  width: 100%;
+  height: 100%;
+  color: $text_color;
+  cursor: pointer;
+  text-align: start;
+}
+
+.nav-wrapper-mobile .menu-list-mobile-items button:active, .nav-wrapper-mobile .menu-list-mobile-items button:focus, .nav-wrapper-mobile .menu-list-mobile-items button:hover {
+  background-color: rgba(31, 115, 183, 0.1);
+  text-decoration: underline;
+}
+
+.nav-wrapper-mobile .menu-list-mobile-items a {
+  display: block;
+  padding: 8px 24px;
+  width: 100%;
+  height: 100%;
+  color: $text_color;
+}
+
+.nav-wrapper-mobile .menu-list-mobile-items a:active, .nav-wrapper-mobile .menu-list-mobile-items a:focus, .nav-wrapper-mobile .menu-list-mobile-items a:hover {
+  background-color: rgba(31, 115, 183, 0.1);
+}
+
+.nav-wrapper-mobile .menu-list-mobile-items .my-profile {
+  display: flex;
+  line-height: 1.5;
+}
+
+.nav-wrapper-mobile .menu-list-mobile-items .my-profile .my-profile-tooltip {
+  font-size: 12px;
+  color: #68737D;
+}
+
+.nav-wrapper-mobile .menu-list-mobile-items .menu-profile-avatar {
+  height: 20px;
+  width: 20px;
+  border-radius: 50%;
+  display: inline-block;
+  margin-right: 8px;
+  margin-top: 1px;
+}
+
+[dir="rtl"] .nav-wrapper-mobile .menu-list-mobile-items .menu-profile-avatar {
   margin-right: 0;
-}
-
-.nav-wrapper .menu-button:hover, .nav-wrapper .menu-button:focus, .nav-wrapper .menu-button:active {
-  background-color: transparent;
-  color: $link_color;
+  margin-left: 8px;
 }
 
 .skip-navigation {

--- a/style.css
+++ b/style.css
@@ -699,6 +699,15 @@ ul {
   margin: 20px;
 }
 
+.user-nav-list {
+  display: block;
+  list-style: none;
+}
+
+.user-nav-list > li {
+  display: inline-block;
+}
+
 .nav-wrapper a {
   border: 0;
   color: $link_color;

--- a/styles/_header.scss
+++ b/styles/_header.scss
@@ -50,6 +50,15 @@ $header-height: 71px;
   }
 }
 
+.user-nav-list {
+  display: block;
+  list-style: none;
+
+  > li {
+    display: inline-block;
+  }
+}
+
 .nav-wrapper {
   a {
     @include tablet {

--- a/styles/_header.scss
+++ b/styles/_header.scss
@@ -47,6 +47,17 @@ $header-height: 71px;
       display: block;
       margin: 20px;
     }
+
+    > .user-nav-list {
+      li {
+        display: block;
+      }
+
+      a {
+        display: block;
+        margin: 20px;
+      }
+    }
   }
 }
 
@@ -59,7 +70,11 @@ $header-height: 71px;
   }
 }
 
-.nav-wrapper {
+.nav-wrapper-desktop {
+  @include mobile { display: none; }
+  @include tablet { display: none; }
+  @include desktop { display: inline-block; }
+
   a {
     @include tablet {
       display: inline-block;
@@ -81,42 +96,123 @@ $header-height: 71px;
       color: $link_color;
       text-decoration: underline;
     }
-
-    &.sign-in { display: inline-block; }
   }
+}
 
-  .hide-on-mobile {
-    @include mobile {
-      @include visually-hidden;
-    }
-  }
+.nav-wrapper-mobile {
+  @include desktop { display: none; }
 
-  .menu-button {
-    @include tablet { display: none; }
+  .menu-button-mobile {
     background: none;
     border: 0;
-    color: $link_color;
-    display: inline-block;
-    margin-right: 10px;
-    padding: 0;
     width: auto;
+    min-width: 71px;
+    cursor: pointer;
 
     .icon-menu {
+      padding: 7px;
       vertical-align: middle;
-      width: 13px;
-      height: 13px;
+      width: 30px;
+      height: 30px;
     }
 
-    [dir="rtl"] & {
-      margin-left: 10px;
-      margin-right: 0;
+    &[aria-expanded="true"] {
+      .icon-menu {
+        background: rgba(31, 115, 183, 0.2);
+        border-radius: 50%;
+      }
+    }
+  }
+
+  .menu-list-mobile {
+    position: absolute;
+    background-color: #fff;
+    box-shadow: 0 10px 10px 0 rgba(0, 0, 0, .15);
+    border-top: solid 0.1px #ddd;
+    border-bottom: solid 1px #ddd;
+    right: 0;
+    left: 0;
+    top: $header-height;
+    z-index: 2;
+
+    &[aria-expanded="false"] {
+      display: none;
     }
 
-    &:hover,
-    &:focus,
-    &:active {
-      background-color: transparent;
-      color: $link_color;
+    &[aria-expanded="true"] {
+      display: block;
+    }
+  }
+
+  .menu-list-mobile-items {
+    .item {
+      margin: 4px 0;
+    }
+
+    li:empty:not(.nav-divider){
+      display: none;
+    }
+
+    .nav-divider {
+      border-bottom: 0.1px solid #ddd;
+      padding: 0;
+
+      &:last-child {
+        display: none;
+      }
+    }
+
+    button {
+      background: none;
+      border: none;
+      padding: 8px 24px;
+
+      width: 100%;
+      height: 100%;
+      color: $text_color;
+      cursor: pointer;
+      text-align: start;
+
+      &:active, &:focus, &:hover {
+        background-color: rgba(31, 115, 183, 0.1);
+        text-decoration: underline;
+      }
+    }
+
+    a {
+      display: block;
+      padding: 8px 24px;
+      width: 100%;
+      height: 100%;
+      color: $text_color;
+
+      &:active, &:focus, &:hover {
+        background-color: rgba(31, 115, 183, 0.1);
+      }
+    }
+
+    .my-profile {
+      display: flex;
+      line-height: 1.5;
+
+      .my-profile-tooltip {
+        font-size: 12px;
+        color: #68737D;
+      }
+    }
+
+    .menu-profile-avatar {
+      height: 20px;
+      width: 20px;
+      border-radius: 50%;
+      display: inline-block;
+      margin-right: 8px;
+      margin-top: 1px;
+
+      [dir="rtl"] & {
+        margin-right: 0;
+        margin-left: 8px;
+      }
     }
   }
 }

--- a/templates/header.hbs
+++ b/templates/header.hbs
@@ -16,8 +16,17 @@
       </svg>
     </button>
     <nav class="user-nav" id="user-nav">
-      {{link 'community'}}
-      {{link 'new_request' class='submit-a-request'}}
+      <ul class="user-nav-list">
+        <li>{{link 'community'}}</li>
+        <li>{{link 'new_request' class='submit-a-request'}}</li>
+        {{#unless signed_in}}
+          <li>
+            {{#link "sign_in" class="sign-in"}}
+              {{t 'sign_in'}}
+            {{/link}}
+          </li>
+        {{/unless}}
+      </ul>
     </nav>
     {{#if signed_in}}
       <div class="user-info dropdown">
@@ -38,10 +47,6 @@
           {{link "sign_out" role="menuitem"}}
         </div>
       </div>
-    {{else}}
-      {{#link "sign_in" class="sign-in"}}
-        {{t 'sign_in'}}
-      {{/link}}
     {{/if}}
   </div>
 </header>

--- a/templates/header.hbs
+++ b/templates/header.hbs
@@ -9,12 +9,8 @@
       {{/if}}
     {{/link}}
   </div>
-  <div class="nav-wrapper">
-    <button class="menu-button" aria-controls="user-nav" aria-expanded="false" aria-label="{{t 'toggle_navigation'}}">
-      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" focusable="false" viewBox="0 0 16 16" class="icon-menu">
-        <path fill="none" stroke="currentColor" stroke-linecap="round" d="M1.5 3.5h13m-13 4h13m-13 4h13"/>
-      </svg>
-    </button>
+
+  <div class="nav-wrapper-desktop">
     <nav class="user-nav" id="user-nav">
       <ul class="user-nav-list">
         <li>{{link 'community'}}</li>
@@ -49,4 +45,51 @@
       </div>
     {{/if}}
   </div>
+
+  <div class="nav-wrapper-mobile">
+    <button class="menu-button-mobile" aria-controls="user-nav-mobile" aria-expanded="false" aria-label="{{t 'toggle_navigation'}}">
+      {{#if signed_in}}
+        {{user_avatar class="user-avatar"}}
+      {{/if}}
+      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" focusable="false" viewBox="0 0 16 16" class="icon-menu">
+        <path fill="none" stroke="currentColor" stroke-linecap="round" d="M1.5 3.5h13m-13 4h13m-13 4h13"/>
+      </svg>
+    </button>
+    <nav class="menu-list-mobile" id="user-nav-mobile" aria-expanded="false">
+      <ul class="menu-list-mobile-items">
+        {{#if signed_in}}
+          <li class="user-avatar-item item">
+            {{#my_profile role="menuitem" class="my-profile"}}
+              {{user_avatar class="menu-profile-avatar"}}
+              <div class="menu-profile-name">
+                <div>{{user_name}}</div>
+                <div class="my-profile-tooltip">{{t 'my_profile'}}</div>
+              </div>
+            {{/my_profile}}
+          </li>
+          <li class="item">{{link "my_activities" role="menuitem"}}</li>
+          <li class="item">{{contact_details role="menuitem"}}</li>
+          <li class="item">{{change_password role="menuitem" class='change-password'}}</li>
+          <li class="nav-divider"></li>
+        {{else}}
+          <li class="item">
+            {{#link "sign_in"}}
+              {{t 'sign_in'}}
+            {{/link}}
+          </li>
+          <li class="nav-divider"></li>
+        {{/if}}
+        <li class="item">{{link 'community'}}</li>
+        <li class="item">{{link 'new_request' class='submit-a-request'}}</li>
+        <li class="nav-divider"></li>
+        {{#if signed_in}}
+          <li class="item">
+            {{link "sign_out" role="menuitem"}}
+          </li>
+        {{/if}}
+        </li>
+      </ul>
+    </nav>
+  </div>
+
 </header>


### PR DESCRIPTION
## Description

1. Merges two navigations for mobile. Currently, we have a hamburger menu and a dropdown menu that's displayed when the user clicks on the avatar.
2. Change the breakpoint for the mobile navbar. Currently, the mobile navbar is displayed only for mobile (width <= 768px). After these changes, mobile navbar will be displayed on both mobile and tablet viewports (width <= 1024px)
3. Additionally, fixes the a11y issue with desktop version of nav - all items are now displayed inside a list.

## Screenshots

New navbar - admin:
https://user-images.githubusercontent.com/12835055/144049443-9870aaf6-cd5d-4cb2-8a03-e7048b215773.mov
New navbar - end user:
https://user-images.githubusercontent.com/12835055/144049466-8b5d1496-7883-43de-b205-0286ac5dc4b3.mov

<img width="712" alt="Screenshot 2021-11-30 at 13 40 49" src="https://user-images.githubusercontent.com/12835055/144049545-cffc59e9-3fd1-4cd8-aaf5-9c8250c8ecfa.png">
<img width="709" alt="Screenshot 2021-11-30 at 13 40 32" src="https://user-images.githubusercontent.com/12835055/144049550-c9d546d7-87c7-443a-b123-eef14a80aa28.png">
<img width="713" alt="Screenshot 2021-11-30 at 13 40 19" src="https://user-images.githubusercontent.com/12835055/144049551-d393f8af-6e2a-46f1-949b-c0d4ff64c94c.png">
<img width="713" alt="Screenshot 2021-11-30 at 13 40 10" src="https://user-images.githubusercontent.com/12835055/144049556-ce4813fa-07a4-43b5-82c0-bb3c631f2976.png">

## Checklist

- [x] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [x] :nail_care: SASS files are compiled
- [x] :arrow_left: changes are compatible with RTL direction
- [x] :wheelchair: changes are accessible
- [x] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [x] :iphone: changes are responsive and tested in mobile
- [x] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->