### PR TITLE
Update user dropdown menu items

### DIFF
--- a/templates/contributions_page.hbs
+++ b/templates/contributions_page.hbs
@@ -10,9 +10,6 @@
         </svg>
       </button>
       <ul class="collapsible-nav-list">
-        {{#if help_center.request_management_enabled}}
-          <li>{{link 'requests'}}</li>
-        {{/if}}
         <li class="current">
           <a href="{{page_path 'contributions'}}" aria-current="page">{{ t 'contributions' }}</a>
         </li>

--- a/templates/header.hbs
+++ b/templates/header.hbs
@@ -31,8 +31,9 @@
           </span>
         </button>
         <div class="dropdown-menu" role="menu">
-          {{link "my_activities" role="menuitem"}}
-          {{my_profile role="menuitem"}}
+          {{#my_profile role="menuitem"}}{{t 'profile'}}{{/my_profile}}
+          {{link "requests" role="menuitem"}}
+          {{#link "contributions" role="menuitem"}}{{t "activities"}}{{/link}}
           {{contact_details role="menuitem"}}
           {{change_password role="menuitem"}}
           {{link "sign_out" role="menuitem"}}

--- a/templates/requests_page.hbs
+++ b/templates/requests_page.hbs
@@ -9,13 +9,6 @@
           <path stroke="currentColor" stroke-linecap="round" d="M3 9l6-6m0 6L3 3"/>
         </svg>
       </button>
-      <ul class="collapsible-nav-list">
-        <li class="current">
-          <a href="{{page_path 'requests'}}" aria-current="page">{{ t 'requests' }}</a>
-        </li>
-        <li>{{link 'contributions'}}</li>
-        <li>{{link 'subscriptions'}}</li>
-      </ul>
     </nav>
   </div>
 </div>

--- a/templates/subscriptions_page.hbs
+++ b/templates/subscriptions_page.hbs
@@ -10,9 +10,6 @@
         </svg>
       </button>
       <ul class="collapsible-nav-list">
-        {{#if help_center.request_management_enabled}}
-          <li>{{link 'requests'}}</li>
-        {{/if}}
         <li>{{link 'contributions'}}</li>
         <li class="current">
           <a href="{{page_path 'following'}}" aria-current="page">{{ t 'following' }}</a>


### PR DESCRIPTION
## Description

**User dropdown menu:**
- Use `{{ t 'profile'}}` in the `my_profile` helper in order to update the wording from "My profile" to "Profile".
- Use `"contributions"` linker instead of the `"my_activities"` linker, since the "Request" link is added as a separate menu item.
- Add `"requests"` linker.

**Requests page:**
- Remove sub-navigation panel altogether

**Contributions page**
- Exclude the "Requests" link from the sub-navigation panel.

**Subscriptions page**
- Exclude the "Requests" link from the sub-navigation panel.

## Screenshots

![image](https://user-images.githubusercontent.com/6997051/143569681-5d37a9eb-d2c7-4534-bcf8-d4dcc0efca59.png)

<img width="671" alt="Screenshot 2021-11-26 at 11 47 08" src="https://user-images.githubusercontent.com/6997051/143569192-500245fb-99ff-4515-b318-54f447a1c3c8.png">

<img width="673" alt="Screenshot 2021-11-26 at 11 47 20" src="https://user-images.githubusercontent.com/6997051/143569202-44975013-7554-4839-8539-2c1518f4609e.png">


## Checklist

- [x] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [x] :nail_care: SASS files are compiled
- [x] :arrow_left: changes are compatible with RTL direction
- [x] :wheelchair: changes are accessible
- [x] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [x] :iphone: changes are responsive and tested in mobile
- [x] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->