### PR TITLE
feat(settings): Add "show_new_request" check box to settings.

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -384,6 +384,18 @@
           "value": true
         }
       ]
+    },
+    {
+      "label": "navigation_settings_label",
+      "variables": [
+        {
+          "identifier": "show_new_request",
+          "type": "checkbox",
+          "description": "show_new_request_description",
+          "label": "show_new_request_label",
+          "value": true
+        }
+      ]
     }
   ]
 }

--- a/templates/header.hbs
+++ b/templates/header.hbs
@@ -3,10 +3,10 @@
 <header class="header">
   <div class="logo">
     {{#link 'help_center'}}
-      <img src="{{settings.logo}}" alt="{{t 'home_page' name=help_center.name}}" />
-      {{#if settings.show_brand_name}}
-        <span aria-hidden="true">{{help_center.name}}</span>
-      {{/if}}
+    <img src="{{settings.logo}}" alt="{{t 'home_page' name=help_center.name}}" />
+    {{#if settings.show_brand_name}}
+    <span aria-hidden="true">{{help_center.name}}</span>
+    {{/if}}
     {{/link}}
   </div>
 
@@ -14,80 +14,87 @@
     <nav class="user-nav" id="user-nav">
       <ul class="user-nav-list">
         <li>{{link 'community'}}</li>
+        {{#if settings.show_new_request}}
         <li>{{link 'new_request' class='submit-a-request'}}</li>
+        {{/if}}
         {{#unless signed_in}}
-          <li>
-            {{#link "sign_in" class="sign-in"}}
-              {{t 'sign_in'}}
-            {{/link}}
-          </li>
+        <li>
+          {{#link "sign_in" class="sign-in"}}
+          {{t 'sign_in'}}
+          {{/link}}
+        </li>
         {{/unless}}
       </ul>
     </nav>
     {{#if signed_in}}
-      <div class="user-info dropdown">
-        <button class="dropdown-toggle" aria-haspopup="true">
-          {{user_avatar class="user-avatar"}}
-          <span>
-            {{user_name}}
-            <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" focusable="false" viewBox="0 0 12 12" class="dropdown-chevron-icon" aria-hidden="true">
-              <path fill="none" stroke="currentColor" stroke-linecap="round" d="M3 4.5l2.6 2.6c.2.2.5.2.7 0L9 4.5"/>
-            </svg>
-          </span>
-        </button>
-        <div class="dropdown-menu" role="menu">
-          {{#my_profile role="menuitem"}}{{t 'profile'}}{{/my_profile}}
-          {{link "requests" role="menuitem"}}
-          {{#link "contributions" role="menuitem"}}{{t "activities"}}{{/link}}
-          {{contact_details role="menuitem"}}
-          {{change_password role="menuitem"}}
-          {{link "sign_out" role="menuitem"}}
-        </div>
+    <div class="user-info dropdown">
+      <button class="dropdown-toggle" aria-haspopup="true">
+        {{user_avatar class="user-avatar"}}
+        <span>
+          {{user_name}}
+          <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" focusable="false" viewBox="0 0 12 12"
+            class="dropdown-chevron-icon" aria-hidden="true">
+            <path fill="none" stroke="currentColor" stroke-linecap="round" d="M3 4.5l2.6 2.6c.2.2.5.2.7 0L9 4.5" />
+          </svg>
+        </span>
+      </button>
+      <div class="dropdown-menu" role="menu">
+        {{#my_profile role="menuitem"}}{{t 'profile'}}{{/my_profile}}
+        {{link "requests" role="menuitem"}}
+        {{#link "contributions" role="menuitem"}}{{t "activities"}}{{/link}}
+        {{contact_details role="menuitem"}}
+        {{change_password role="menuitem"}}
+        {{link "sign_out" role="menuitem"}}
       </div>
+    </div>
     {{/if}}
   </div>
 
   <div class="nav-wrapper-mobile">
-    <button class="menu-button-mobile" aria-controls="user-nav-mobile" aria-expanded="false" aria-label="{{t 'toggle_navigation'}}">
+    <button class="menu-button-mobile" aria-controls="user-nav-mobile" aria-expanded="false"
+      aria-label="{{t 'toggle_navigation'}}">
       {{#if signed_in}}
-        {{user_avatar class="user-avatar"}}
+      {{user_avatar class="user-avatar"}}
       {{/if}}
-      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" focusable="false" viewBox="0 0 16 16" class="icon-menu">
-        <path fill="none" stroke="currentColor" stroke-linecap="round" d="M1.5 3.5h13m-13 4h13m-13 4h13"/>
+      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" focusable="false" viewBox="0 0 16 16"
+        class="icon-menu">
+        <path fill="none" stroke="currentColor" stroke-linecap="round" d="M1.5 3.5h13m-13 4h13m-13 4h13" />
       </svg>
     </button>
     <nav class="menu-list-mobile" id="user-nav-mobile" aria-expanded="false">
       <ul class="menu-list-mobile-items">
         {{#if signed_in}}
-          <li class="user-avatar-item item">
-            {{#my_profile role="menuitem" class="my-profile"}}
-              {{user_avatar class="menu-profile-avatar"}}
-              <div class="menu-profile-name">
-                <div>{{user_name}}</div>
-                <div class="my-profile-tooltip">{{t 'profile'}}</div>
-              </div>
-            {{/my_profile}}
-          </li>
-          <li class="item">{{link "requests" role="menuitem"}}</li>
-          <li class="item">{{#link "contributions" role="menuitem"}}{{t "activities"}}{{/link}}</li>
-          <li class="item">{{contact_details role="menuitem"}}</li>
-          <li class="item">{{change_password role="menuitem" class='change-password'}}</li>
-          <li class="nav-divider"></li>
+        <li class="user-avatar-item item">
+          {{#my_profile role="menuitem" class="my-profile"}}
+          {{user_avatar class="menu-profile-avatar"}}
+          <div class="menu-profile-name">
+            <div>{{user_name}}</div>
+            <div class="my-profile-tooltip">{{t 'profile'}}</div>
+          </div>
+          {{/my_profile}}
+        </li>
+        <li class="item">{{link "requests" role="menuitem"}}</li>
+        <li class="item">{{#link "contributions" role="menuitem"}}{{t "activities"}}{{/link}}</li>
+        <li class="item">{{contact_details role="menuitem"}}</li>
+        <li class="item">{{change_password role="menuitem" class='change-password'}}</li>
+        <li class="nav-divider"></li>
         {{else}}
-          <li class="item">
-            {{#link "sign_in" role="menuitem"}}
-              {{t 'sign_in'}}
-            {{/link}}
-          </li>
-          <li class="nav-divider"></li>
+        <li class="item">
+          {{#link "sign_in" role="menuitem"}}
+          {{t 'sign_in'}}
+          {{/link}}
+        </li>
+        <li class="nav-divider"></li>
         {{/if}}
         <li class="item">{{link 'community' role="menuitem"}}</li>
+        {{#if settings.show_new_request}}
         <li class="item">{{link 'new_request' role="menuitem" class='submit-a-request'}}</li>
+        {{/if}}
         <li class="nav-divider"></li>
         {{#if signed_in}}
-          <li class="item">
-            {{link "sign_out" role="menuitem"}}
-          </li>
+        <li class="item">
+          {{link "sign_out" role="menuitem"}}
+        </li>
         {{/if}}
         </li>
       </ul>

--- a/translations.yml
+++ b/translations.yml
@@ -365,3 +365,19 @@ parts:
       title: "Description for the show brand name setting"
       screenshot: "https://drive.google.com/file/d/16zQao3zk3uRScIUpkyc6bXAWwqHh3Zh-/view?usp=sharing"
       value: "Display the Help Center name next to the logo"
+  - translation:
+      key: "txt.help_center_copenhagen_theme.navigation_settings_label"
+      title: "Label for navigation settings group"
+      screenshot: "https://drive.google.com/file/d/1Rk7x7YrGfKvgivs1fXcjrsIjZ2EchWTh/view"
+      value: "Navigation Settings"
+  - translation:
+      key: "txt.help_center_copenhagen_theme.show_new_request_label"
+      title: "Label for the show new request link setting"
+      screenshot: "https://drive.google.com/file/d/1Rk7x7YrGfKvgivs1fXcjrsIjZ2EchWTh/view"
+      value: "Submit a request"
+  - translation:
+      key: "txt.help_center_copenhagen_theme.show_new_request_description"
+      title: "Description for the show new request link setting"
+      screenshot: "https://drive.google.com/file/d/1Rk7x7YrGfKvgivs1fXcjrsIjZ2EchWTh/view"
+      value: "Show submit a request link in the navigation"
+

--- a/translations/en-us.json
+++ b/translations/en-us.json
@@ -66,5 +66,8 @@
   "follow_topic_label": "Follow",
   "follow_topic_description": "Users can follow a specific topic",
   "show_brand_name_label": "Show Help Center name",
-  "show_brand_name_description": "Display the Help Center name next to the logo"
+  "show_brand_name_description": "Display the Help Center name next to the logo",
+  "navigation_settings_label": "Navigation Settings",
+  "show_new_request_label": "Submit a request",
+  "show_new_request_description": "Show the submit a request link in the navigation"
 }

--- a/translations/en-x-keys.json
+++ b/translations/en-x-keys.json
@@ -26,5 +26,8 @@
   "community_background_image_description": "txt.help_center_copenhagen_theme.community_background_image_description",
   "community_background_image_label": "txt.help_center_copenhagen_theme.community_background_image_label",
   "community_image_description": "txt.help_center_copenhagen_theme.community_image_description",
-  "community_image_label": "txt.help_center_copenhagen_theme.community_image_label"
+  "community_image_label": "txt.help_center_copenhagen_theme.community_image_label",
+  "navigation_settings_label": "txt.help_center_copenhagen_theme.navigation_settings_label",
+  "show_new_request_label": "txt.help_center_copenhagen_theme.show_new_request_label",
+  "show_new_request_description": "txt.help_center_copenhagen_theme.show_new_request_description"
 }


### PR DESCRIPTION
## Description

We wanted the ability to hide the "Submit a request" link from the navigation bar to add a bit of friction to hopefully encourage users to look through our support documentation first. I saw a decent amount of activity on [this post](https://support.zendesk.com/hc/en-us/articles/4408822542234-How-can-I-remove-the-Submit-a-request-link-from-my-Help-Center-) which made me think there are others who would appreciate this as well.

## Screenshots
https://drive.google.com/file/d/1Rk7x7YrGfKvgivs1fXcjrsIjZ2EchWTh/view

## Checklist

- [x] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :nail_care: SASS files are compiled
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: changes are accessible
- [x] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [x] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings
