### PR TITLE
Add separator in user dropdown

### DIFF
--- a/style.css
+++ b/style.css
@@ -4778,11 +4778,7 @@ html[dir="rtl"] .notification-left-aligned {
 }
 
 .dropdown-menu [role="separator"] {
-  border-bottom: 1px solid #ddd;
-  color: #969696;
-  display: block;
-  font-weight: normal;
-  font-size: 11px;
+  border-bottom: 1px solid #e9ebed;
   margin: 4px 0;
 }
 

--- a/style.css
+++ b/style.css
@@ -4778,13 +4778,12 @@ html[dir="rtl"] .notification-left-aligned {
 }
 
 .dropdown-menu [role="separator"] {
-  border-bottom: 1px solid #d8d8d8;
+  border-bottom: 1px solid #ddd;
   color: #969696;
   display: block;
   font-weight: normal;
   font-size: 11px;
-  padding: 5px 0;
-  margin: 5px 20px 10px 20px;
+  margin: 4px 0;
 }
 
 .dropdown-menu [role="menuitem"] {

--- a/styles/_dropdowns.scss
+++ b/styles/_dropdowns.scss
@@ -47,13 +47,12 @@
   }
 
   [role="separator"] {
-    border-bottom: 1px solid rgb(216, 216, 216);
+    border-bottom: 1px solid $border-color;
     color: rgb(150, 150, 150);
     display: block;
     font-weight: normal;
     font-size: 11px;
-    padding: 5px 0;
-    margin: 5px 20px 10px 20px;
+    margin: 4px 0;
   }
 
   [role="menuitem"] {

--- a/styles/_dropdowns.scss
+++ b/styles/_dropdowns.scss
@@ -47,11 +47,7 @@
   }
 
   [role="separator"] {
-    border-bottom: 1px solid $border-color;
-    color: rgb(150, 150, 150);
-    display: block;
-    font-weight: normal;
-    font-size: 11px;
+    border-bottom: 1px solid #e9ebed;
     margin: 4px 0;
   }
 

--- a/templates/header.hbs
+++ b/templates/header.hbs
@@ -41,6 +41,7 @@
           {{#link "contributions" role="menuitem"}}{{t "activities"}}{{/link}}
           {{contact_details role="menuitem"}}
           {{change_password role="menuitem"}}
+          <div class="separator" role="separator"></div>
           {{link "sign_out" role="menuitem"}}
         </div>
       </div>


### PR DESCRIPTION
## Description

Added a missing separator between Sign out and Change password options in the user dropdown menu.
Issue: https://zendesk.atlassian.net/browse/COMM-1599

## Screenshots
Before
<img width="386" alt="Screenshot 2022-01-20 at 14 47 40" src="https://user-images.githubusercontent.com/17469404/150350826-3b91ad55-1217-4a65-b1a7-f9a175d302a1.png">

After
<img width="386" alt="Screenshot 2022-01-20 at 14 47 24" src="https://user-images.githubusercontent.com/17469404/150350854-af28c68d-e066-453a-b419-7309b75b1045.png">


## Checklist

- [x] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [x] :nail_care: SASS files are compiled
- [x] :arrow_left: changes are compatible with RTL direction
- [x] :wheelchair: changes are accessible
- [x] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [x] :iphone: changes are responsive and tested in mobile
- [x] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->