### PR TITLE
Remove unused code and fix auto-focus issue

### DIFF
--- a/script.js
+++ b/script.js
@@ -133,14 +133,14 @@ document.addEventListener('DOMContentLoaded', function() {
     requestCommentFields = document.querySelectorAll('.request-container .comment-container .comment-fields'),
     requestCommentSubmit = document.querySelector('.request-container .comment-container .request-submit-comment');
 
-    if (showRequestCommentContainerTrigger) {
+  if (showRequestCommentContainerTrigger) {
     showRequestCommentContainerTrigger.addEventListener('click', function() {
       showRequestCommentContainerTrigger.style.display = 'none';
       Array.prototype.forEach.call(requestCommentFields, function(e) { e.style.display = 'block'; });
       requestCommentSubmit.style.display = 'inline-block';
 
-      if (commentContainerTextarea) {
-        commentContainerTextarea.focus();
+      if (window.tinymce && window.tinymce.editors.length === 1) {
+        window.tinymce.editors[0].focus();
       }
     });
   }

--- a/script.js
+++ b/script.js
@@ -128,27 +128,12 @@ document.addEventListener('DOMContentLoaded', function() {
     returnFocusToEl && returnFocusToEl.focus && returnFocusToEl.focus();
   }
 
-  // show form controls when the textarea receives focus or backbutton is used and value exists
-  var commentContainerTextarea = document.querySelector('.comment-container textarea'),
-    commentContainerFormControls = document.querySelector('.comment-form-controls, .comment-ccs');
-
-  if (commentContainerTextarea) {
-    commentContainerTextarea.addEventListener('focus', function focusCommentContainerTextarea() {
-      commentContainerFormControls.style.display = 'block';
-      commentContainerTextarea.removeEventListener('focus', focusCommentContainerTextarea);
-    });
-
-    if (commentContainerTextarea.value !== '') {
-      commentContainerFormControls.style.display = 'block';
-    }
-  }
-
   // Expand Request comment form when Add to conversation is clicked
   var showRequestCommentContainerTrigger = document.querySelector('.request-container .comment-container .comment-show-container'),
     requestCommentFields = document.querySelectorAll('.request-container .comment-container .comment-fields'),
     requestCommentSubmit = document.querySelector('.request-container .comment-container .request-submit-comment');
 
-  if (showRequestCommentContainerTrigger) {
+    if (showRequestCommentContainerTrigger) {
     showRequestCommentContainerTrigger.addEventListener('click', function() {
       showRequestCommentContainerTrigger.style.display = 'none';
       Array.prototype.forEach.call(requestCommentFields, function(e) { e.style.display = 'block'; });


### PR DESCRIPTION
## Description

<!-- a summary of the changes introduced by this PR and the motivation behind them -->
This PR fixes the autofocus on the request page which has previously has stopped working when [this](https://github.com/zendesk/copenhagen_theme/commit/b38cf050e4e2d04f4a4a8f65e282e963f7042de7#diff-6ad1fc7cb0228bea3cbe9f3ea80635d321c3ff5ea73f01fa327ed984708aead4) change was made.

A chunk of dead code was also removed, since it targeted plain textareas, which now have been replaced by the wysiwyg editor.

## Screenshots

<!-- (optional) when applicable, please include some screenshots or gifs that illustrate the changes -->

Before:
![auto-focus-actual](https://user-images.githubusercontent.com/6997051/151195986-ee9a4a1d-32c8-4d78-8b6b-b9b1facfff66.gif)

After:
![auto-focus-expected](https://user-images.githubusercontent.com/6997051/151196007-1e62a817-1e37-401c-a642-2ddf5064e3cd.gif)


## Checklist

- [x] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [x] :nail_care: SASS files are compiled
- [x] :arrow_left: changes are compatible with RTL direction
- [x] :wheelchair: changes are accessible
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [x] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->