### PR TITLE
Skip checks on release commit

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -11,7 +11,7 @@
         }],
         ["@semantic-release/git", {
             "assets": ["manifest.json", "CHANGELOG.md"],
-            "message": "chore(release): ${nextRelease.version}\n\n${nextRelease.notes}"
+            "message": "chore(release): ${nextRelease.version}\n\n${nextRelease.notes}\n\nskip-checks: true"
         }],
         "@semantic-release/github"
     ]


### PR DESCRIPTION
## Description

Skip checking github status checks on release commit.
Currently, releases fail because of that https://github.com/zendesk/copenhagen_theme/runs/5091707828?check_suite_focus=true and we would have to either make the bot an admin or make the bot create a branch and then merge it.

## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :nail_care: SASS files are compiled
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: changes are accessible
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->