### PR TITLE
chore: add translation keys for hover link color

### DIFF
--- a/translations.yml
+++ b/translations.yml
@@ -64,6 +64,16 @@ parts:
       screenshot: "https://drive.google.com/file/d/1ZOoBb6K_mpYtyd3ulkEKawmSj1dZPuFw/view?usp=sharing"
       value: "Text color for visited link elements"
   - translation:
+      key: "txt.help_center_copenhagen_theme.hover_link_color_label"
+      title: "Label for the hover link color setting"
+      screenshot: "https://drive.google.com/file/d/14Wh8h1I-ej3d2TRrPHFMvydDeEO_8sxr/view?usp=sharing"
+      value: "Hover link color"
+  - translation:
+      key: "txt.help_center_copenhagen_theme.hover_link_color_description"
+      title: "Description for the hover link color setting"
+      screenshot: "https://drive.google.com/file/d/14Wh8h1I-ej3d2TRrPHFMvydDeEO_8sxr/view?usp=sharing"
+      value: "Text color for the hover state of link elements"
+  - translation:
       key: "txt.help_center_copenhagen_theme.visited_link_color_label"
       title: "Label for the visited link color setting"
       screenshot: "https://drive.google.com/file/d/1ZOoBb6K_mpYtyd3ulkEKawmSj1dZPuFw/view?usp=sharing"


### PR DESCRIPTION
## Description
This PR adds translation keys for hover link setting. This setting will be introduced in https://github.com/zendesk/copenhagen_theme/pull/297

## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :nail_care: SASS files are compiled
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: changes are accessible
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->