### PR TITLE
fix: add aria-label to the '+ N more badges' links

### DIFF
--- a/templates/article_page.hbs
+++ b/templates/article_page.hbs
@@ -250,7 +250,9 @@
 
                             {{#if (compare (calc author.badges.length "-" 4) ">" 0)}}
                               <div class="community-badge community-badge-achievements">
-                                {{#link "user_profile" id=author.id filter_by="badges" class="community-badge-achievements-rest"}}{{t 'plus_more' count=(calc author.badges.length "-" 4)}}{{/link}}
+                                <a href="{{page_path "user_profile" id=author.id filter_by="badges"}}" class="community-badge-achievements-rest"  aria-label="{{t 'more_awards_to' count=(calc author.badges.length "-" 4) name=author.name}}">
+                                  {{t 'plus_more' count=(calc author.badges.length "-" 4)}}
+                                </a>
                               </div>
                             {{/if}}
                           </div>

--- a/templates/community_post_page.hbs
+++ b/templates/community_post_page.hbs
@@ -99,7 +99,9 @@
 
                   {{#if (compare (calc post.author.badges.length "-" 4) ">" 0)}}
                     <div class="community-badge community-badge-achievements">
-                      {{#link "user_profile" id=post.author.id filter_by="badges" class="community-badge-achievements-rest"}}{{t 'plus_more' count=(calc post.author.badges.length "-" 4)}}{{/link}}
+                      <a href="{{page_path "user_profile" id=post.author.id filter_by="badges"}}" class="community-badge-achievements-rest"  aria-label="{{t 'more_awards_to' count=(calc post.author.badges.length "-" 4) name=post.author.name}}">
+                        {{t 'plus_more' count=(calc post.author.badges.length "-" 4)}}
+                      </a>
                     </div>
                   {{/if}}
 
@@ -250,7 +252,9 @@
 
                       {{#if (compare (calc author.badges.length "-" 4) ">" 0)}}
                         <div class="community-badge community-badge-achievements">
-                          {{#link "user_profile" id=author.id filter_by="badges" class="community-badge-achievements-rest"}}{{t 'plus_more' count=(calc author.badges.length "-" 4)}}{{/link}}
+                          <a href="{{page_path "user_profile" id=author.id filter_by="badges"}}" class="community-badge-achievements-rest"  aria-label="{{t 'more_awards_to' count=(calc author.badges.length "-" 4) name=author.name}}">
+                            {{t 'plus_more' count=(calc author.badges.length "-" 4)}}
+                          </a>
                         </div>
                       {{/if}}
                     </div>

--- a/templates/user_profile_page.hbs
+++ b/templates/user_profile_page.hbs
@@ -46,7 +46,9 @@
 
           {{#if (compare (calc user.badges.length "-" 4) ">" 0)}}
             <div class="community-badge community-badge-achievements">
-              {{#link "user_profile" id=user.id filter_by="badges" class="community-badge-achievements-rest"}}{{t 'plus_more' count=(calc user.badges.length "-" 4)}}{{/link}}
+              <a href="{{page_path "user_profile" id=user.id filter_by="badges"}}" class="community-badge-achievements-rest" aria-label="{{t 'more_awards_to' count=(calc user.badges.length "-" 4) name=user.name}}">
+                {{t 'plus_more' count=(calc user.badges.length "-" 4)}}
+              </a>
             </div>
           {{/if}}
         </div>


### PR DESCRIPTION
## Description

Adds aria-label to the "+ n more" badges link.

## References
- https://zendesk.atlassian.net/browse/PRODA11Y-247

## Checklist

- [x] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [x] :nail_care: SASS files are compiled
- [x] :arrow_left: changes are compatible with RTL direction
- [x] :wheelchair: changes are accessible
- [x] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [x] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->