### PR TITLE
fix: don't apply code styles when directly nested inside a pre

### DIFF
--- a/style.css
+++ b/style.css
@@ -1891,7 +1891,7 @@ ul {
   list-style-type: disc;
 }
 
-.article-body code {
+.article-body :not(pre) > code {
   background: darken($background_color, 3%);
   border: 1px solid #ddd;
   border-radius: 3px;
@@ -2376,7 +2376,7 @@ ul {
   list-style-type: disc;
 }
 
-.comment-body code {
+.comment-body :not(pre) > code {
   background: darken($background_color, 3%);
   border: 1px solid #ddd;
   border-radius: 3px;
@@ -2977,7 +2977,7 @@ ul {
   list-style-type: disc;
 }
 
-.post-body code {
+.post-body :not(pre) > code {
   background: darken($background_color, 3%);
   border: 1px solid #ddd;
   border-radius: 3px;

--- a/styles/_mixins.scss
+++ b/styles/_mixins.scss
@@ -100,7 +100,7 @@
     list-style-type: disc;
   }
 
-  code {
+  :not(pre) > code {
     background: $primary-shade;
     border: 1px solid $border-color;
     border-radius: 3px;


### PR DESCRIPTION
## Description

You often handle code blocks with the following markup, that conficts with our current styling:

```html
<pre>
    <code class="language-javascript">console.log('Hello')</code>
</pre>
```

## Screenshots

### before

<img width="743" alt="Screenshot 2022-02-16 at 07 40 07" src="https://user-images.githubusercontent.com/90802/154210338-8345297f-ef12-4c96-9602-2c3c8d548900.png">

### after

<img width="751" alt="Screenshot 2022-02-16 at 07 39 57" src="https://user-images.githubusercontent.com/90802/154210360-e3a9dee7-2551-4ac5-8e07-fd53d1d6fef4.png">

## Checklist

- [x] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [x] :nail_care: SASS files are compiled
- [x] :arrow_left: changes are compatible with RTL direction
- [x] :wheelchair: changes are accessible
- [x] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [x] :iphone: changes are responsive and tested in mobile
- [x] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->