### PR TITLE
Accessible go to comments icon

### DIFF
--- a/templates/article_page.hbs
+++ b/templates/article_page.hbs
@@ -119,16 +119,13 @@
           {{/if}}
           {{#if settings.show_article_comments}}
             {{#if comments}}
-              <a href="#article-comments" class="article-comment-count" title="{{t 'go_to_comments'}}">
-                <span class="visibility-hidden">
-                  {{t 'comments_count' count=article.comment_count}}
-                </span>
-                <span aria-hidden="true">
-                  <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" focusable="false" viewBox="0 0 12 12" class="article-comment-count-icon">
-                    <path fill="none" stroke="currentColor" d="M1 .5h10c.3 0 .5.2.5.5v7c0 .3-.2.5-.5.5H6l-2.6 2.6c-.3.3-.9.1-.9-.4V8.5H1C.7 8.5.5 8.3.5 8V1C.5.7.7.5 1 .5z"/>
-                  </svg>
-                  {{article.comment_count}}
-                </span>
+              <a href="#article-comments" class="article-comment-count">
+                <svg role="img" aria-labelledby="article-comments-title article-comments-desc" xmlns="http://www.w3.org/2000/svg" width="12" height="12" focusable="false" viewBox="0 0 12 12" class="article-comment-count-icon">
+                  <title id="article-comments-title">{{t 'go_to_comments'}}</title>
+                  <desc id="article-comments-desc">{{t 'comments_count' count=article.comment_count}}</desc>
+                  <path fill="none" stroke="currentColor" d="M1 .5h10c.3 0 .5.2.5.5v7c0 .3-.2.5-.5.5H6l-2.6 2.6c-.3.3-.9.1-.9-.4V8.5H1C.7 8.5.5 8.3.5 8V1C.5.7.7.5 1 .5z"/>
+                </svg>
+                <span aria-hidden="true">{{article.comment_count}}</span>
               </a>
             {{/if}}
           {{/if}}

--- a/templates/community_post_page.hbs
+++ b/templates/community_post_page.hbs
@@ -158,10 +158,12 @@
             <div class="post-share">{{share}}</div>
             {{#if comments}}
               <a href="#comment-overview" class="post-comment-count">
-                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" focusable="false" viewBox="0 0 16 16" class="icon-comments">
-                  <path fill="none" stroke="currentColor" d="M1 .5h14c.3 0 .5.2.5.5v10c0 .3-.2.5-.5.5H8l-3.6 3.6c-.3.3-.9.1-.9-.4v-3.3H1c-.3 0-.5-.2-.5-.5V1C.5.7.7.5 1 .5z"/>
+                <svg role="img" aria-labelledby="post-comments-title post-comments-desc" xmlns="http://www.w3.org/2000/svg" width="12" height="12" focusable="false" viewBox="0 0 12 12" class="icon-comments">
+                  <title id="post-comments-title">{{t 'go_to_comments'}}</title>
+                  <desc id="post-comments-desc">{{t 'comments_count' count=post.comment_count}}</desc>
+                  <path fill="none" stroke="currentColor" d="M1 .5h10c.3 0 .5.2.5.5v7c0 .3-.2.5-.5.5H6l-2.6 2.6c-.3.3-.9.1-.9-.4V8.5H1C.7 8.5.5 8.3.5 8V1C.5.7.7.5 1 .5z"/>
                 </svg>
-                {{post.comment_count}}
+                <span aria-hidden="true">{{post.comment_count}}</span>
               </a>
             {{/if}}
           </footer>


### PR DESCRIPTION
## Description

Providing alternative text for the comments icon ("go to comments" link) as meaningful information provided visually should also be conveyed to screen reader users.

## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :nail_care: SASS files are compiled
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: changes are accessible
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->