### PR TITLE
feat: trim the statuses using css, when they're longer than the allowed space

### DIFF
--- a/style.css
+++ b/style.css
@@ -2803,6 +2803,19 @@ ul {
   background-color: #000;
 }
 
+.status-label-request {
+  max-width: 100%;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+@media (max-width: 768px) {
+  .status-label-request {
+    max-width: 150px;
+  }
+}
+
 /***** Post *****/
 /*
 * The post grid is defined this way:

--- a/styles/_status-label.scss
+++ b/styles/_status-label.scss
@@ -73,4 +73,14 @@
   &-hold {
     background-color: #000;
   }
+
+  &-request {
+    @include mobile {
+      max-width: 150px;
+    }
+    max-width: 100%;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
 }

--- a/templates/request_page.hbs
+++ b/templates/request_page.hbs
@@ -174,7 +174,7 @@
 
           <dt>{{t 'status'}}</dt>
           <dd>
-            <span class="status-label status-label-{{request.status}}" title="{{request.status_description}}">
+            <span class="status-label status-label-request status-label-{{request.status}}" title="{{request.status_description}}">
               {{request.status_name}}
             </span>
           </dd>

--- a/templates/requests_page.hbs
+++ b/templates/requests_page.hbs
@@ -97,10 +97,10 @@
                 </a>
 
                 <!-- Visible on mobile -->
-                <div class="requests-table-meta meta-group">
+                <div class="requests-table-meta">
                   <span class="meta-data">#{{id}}</span>
                   <span class="meta-data">{{date created_at timeago=true}}</span>
-                  <span class="status-label status-label-{{status}}" title="{{status_description}}">
+                  <span class="status-label status-label-request status-label-{{status}}" title="{{status_description}}">
                     {{status_name}}
                   </span>
                 </div>
@@ -115,7 +115,7 @@
               </td>
               <td>{{date updated_at timeago=true}}</td>
               <td class="requests-table-status">
-                <span class="status-label status-label-{{status}}" title="{{status_description}}">
+                <span class="status-label status-label-request status-label-{{status}}" title="{{status_description}}">
                   {{status_name}}
                 </span>
               </td>


### PR DESCRIPTION
## Description

Custom statuses are coming, with a limit of 45 characters, this doesn't really work well with the UI, this will help truncate statuses that would otherwise lose information due to being too large for the label. 

The reason for doing it in-theme, instead of truncating it on the backend, is that we don't want to limit our customers from the full information of a status, if they have a UI geared towards showing more characters. 

## Screenshots

**BEFORE**
<img width="1288" alt="Screenshot 2022-03-31 at 14 01 04" src="https://user-images.githubusercontent.com/52407144/161058110-c6861aee-d287-43a8-8158-3aca720f0ac7.png">
<img width="1292" alt="Screenshot 2022-03-31 at 14 00 52" src="https://user-images.githubusercontent.com/52407144/161058117-365245b3-d3d4-48ce-81c8-a1888830493b.png">

**AFTER**

_Pixel 5:_ 
<img width="397" alt="Screenshot 2022-04-12 at 08 06 48" src="https://user-images.githubusercontent.com/52407144/162891965-3f635c45-0d9c-4b3a-aef0-2def6744fec1.png">
_Ipad Air:_
<img width="577" alt="Screenshot 2022-04-12 at 08 07 07" src="https://user-images.githubusercontent.com/52407144/162891957-07609508-3b24-44f5-b049-cf9bce5fd0db.png">
_Desktop:_ 
<img width="1224" alt="Screenshot 2022-04-12 at 08 06 30" src="https://user-images.githubusercontent.com/52407144/162891968-23883c4d-a0c4-4ff4-b864-73fc79b0fc60.png">

_Pixel 5:_ 
<img width="395" alt="Screenshot 2022-04-12 at 08 06 10" src="https://user-images.githubusercontent.com/52407144/162891975-ef77fd1e-260b-4646-b5ee-7f06c496a9cd.png">
_Ipad Air:_
<img width="575" alt="Screenshot 2022-04-12 at 08 05 58" src="https://user-images.githubusercontent.com/52407144/162891977-c3857074-8657-4962-a30d-e1432d948c59.png">
_Desktop:_ 
<img width="1208" alt="Screenshot 2022-04-12 at 08 06 20" src="https://user-images.githubusercontent.com/52407144/162891970-9e3f23d5-98db-4c33-b853-fbb8528f8133.png">
## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :nail_care: SASS files are compiled
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: changes are accessible
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->