### PR TITLE
fix: obsolete duplicated string and add new one

### DIFF
--- a/translations.yml
+++ b/translations.yml
@@ -385,8 +385,14 @@ parts:
       title: "Description of the request list beta setting"
       screenshot: "https://drive.google.com/file/d/1muzNJHcGzM96cpgXheHb_0mhWkdKEg4E/view?usp=sharing"
       value: "Users can sort and filter requests, add and remove columns"
+      obsolete: "2022-07-01"
   - translation:
       key: "txt.help_center_copenhagen_theme.request_list_group_label"
       title: "Label for the requests list settings group"
       screenshot: "https://drive.google.com/file/d/18d736vhJIuaYHO_uPeg9E4IBaVnJCoVM/view?usp=sharing"
       value: "Requests list"
+  - translation:
+      key: "txt.help_center_copenhagen_theme.request_list_beta_desc"
+      title: "Description of the request list beta setting"
+      screenshot: "https://drive.google.com/file/d/1muzNJHcGzM96cpgXheHb_0mhWkdKEg4E/view?usp=sharing"
+      value: "Users can sort and filter requests, add and remove columns"


### PR DESCRIPTION
## Description

I added a string with `txt.help_center_copenhagen_theme.request_list_beta_description` description in 2 places, so we have to obsolete them and replace them with a different key.

## Checklist

- [x] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [x] :nail_care: SASS files are compiled
- [x] :arrow_left: changes are compatible with RTL direction
- [x] :wheelchair: changes are accessible
- [x] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [x] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->