### PR TITLE
fix: add main content id to the request list container

### DIFF
--- a/templates/requests_page.hbs
+++ b/templates/requests_page.hbs
@@ -4,7 +4,9 @@
       <h1>{{t 'requests'}}</h1>
     </header>
 
-    {{request_list}}
+    <div id="main-content">
+      {{request_list}}
+    </div>
   {{else}}
     <header class="my-activities-header">
       <h1>{{t 'my_requests'}}</h1>


### PR DESCRIPTION
## Description

Adds a `main-content` container to the requests page, so the "Go to main content" button works properly.

https://zendesk.atlassian.net/browse/GG-2758

## Checklist

- [x] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [x] :nail_care: SASS files are compiled
- [x] :arrow_left: changes are compatible with RTL direction
- [x] :wheelchair: changes are accessible
- [x] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [x] :iphone: changes are responsive and tested in mobile
- [x] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->