### PR TITLE
feat: add content tag filter to search results

### DIFF
--- a/style.css
+++ b/style.css
@@ -4615,6 +4615,39 @@ ul {
   unicode-bidi: embed;
 }
 
+.search-results-sidebar .sidenav-tag {
+  display: flex;
+  flex-direction: row;
+  align-items: flex-start;
+  flex-grow: 0;
+}
+
+.search-results-sidebar .sidenav-tag a {
+  background: #E9EBED;
+  border-radius: 4px;
+  padding: 4px 12px;
+  text-decoration: none;
+}
+
+.search-results-sidebar .sidenav-tag a .label {
+  font-style: normal;
+  font-weight: 600;
+  font-size: 12px;
+  line-height: 24px;
+  text-align: center;
+  letter-spacing: -0.000427656px;
+  color: #49545C;
+  flex-grow: 0;
+  vertical-align: middle;
+  display: inline-block;
+}
+
+.search-results-sidebar .sidenav-tag a .close-icon {
+  color: #555555;
+  vertical-align: middle;
+  display: inline-block;
+}
+
 .search-results-sidebar .collapsible-sidebar {
   margin-bottom: 30px;
 }

--- a/styles/_search_results.scss
+++ b/styles/_search_results.scss
@@ -46,6 +46,39 @@
       unicode-bidi: embed;
     }
 
+    .sidenav-tag {
+      display: flex;
+      flex-direction: row;
+      align-items: flex-start;
+      flex-grow: 0;
+
+      a {
+        background: #E9EBED;
+        border-radius: 4px;
+        padding: 4px 12px;
+        text-decoration: none;
+
+        .label {
+          font-style: normal;
+            font-weight: 600;
+            font-size: 12px;
+            line-height: 24px;
+            text-align: center;
+            letter-spacing: -0.000427656px;
+            color: #49545C;
+            flex-grow: 0;
+            vertical-align: middle;
+            display: inline-block;
+        }
+
+        .close-icon {
+          color: #555555;
+            vertical-align: middle;
+            display: inline-block;
+        }
+      }
+    }
+
     .collapsible-sidebar {
       margin-bottom: 30px;
 

--- a/templates/search_results.hbs
+++ b/templates/search_results.hbs
@@ -140,7 +140,13 @@
     <section id="main-content" class="search-results-column">
       <h1 class="search-results-subheading">
         {{#is current_filter.identifier 'unified'}}
-          {{t 'results' query=query count=results_count}}
+          {{#if content_tag_filters }}
+            {{#each (filter content_tag_filters on="selected" equals=true)}}
+              {{t 'results_content_tag' content_tag=name count=../results_count}}
+            {{/each}}
+          {{else}}
+            {{t 'results' query=query count=results_count}}
+          {{/if}}
         {{else}}
           {{#unless current_subfilter.identifier}}
             {{t 'results' query=query count=results_count}}

--- a/templates/search_results.hbs
+++ b/templates/search_results.hbs
@@ -106,6 +106,35 @@
           </ul>
         </section>
       {{/if}}
+      {{#if content_tag_filters}}
+        <section class="filters-in-section collapsible-sidebar" aria-expanded="false">
+          <button type="button" class="collapsible-sidebar-toggle" aria-expanded="false">
+            <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" focusable="false" viewBox="0 0 12 12" aria-hidden="true" class="collapsible-sidebar-toggle-icon chevron-icon">
+              <path fill="none" stroke="currentColor" stroke-linecap="round" d="M3 4.5l2.6 2.6c.2.2.5.2.7 0L9 4.5"/>
+            </svg>
+            <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" focusable="false" viewBox="0 0 12 12" aria-hidden="true" class="collapsible-sidebar-toggle-icon x-icon">
+              <path stroke="currentColor" stroke-linecap="round" d="M3 9l6-6m0 6L3 3"/>
+            </svg>
+          </button>
+          <h3 class="collapsible-sidebar-title sidenav-title">{{t 'filter_by_content_tag'}}</h3>
+          <ul class="multibrand-filter-list multibrand-filter-list--collapsed">
+            {{#each content_tag_filters}}
+            	{{#if selected}}
+                <li class="sidenav-tag">
+                  <a href="{{url}}" aria-current="page">
+                    <span class="label">{{name}}</span>
+                    <span>
+                      <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" width="12" height="12" focusable="false"  aria-hidden="true" >
+                          <path stroke="currentColor" stroke-linecap="round" d="M3 9l6-6m0 6L3 3"/>
+                      </svg>
+                    </span>
+                  </a>
+                </li>
+              {{/if}}
+            {{/each}}
+          </ul>
+        </section>
+      {{/if}}
     </aside>
 
     <section id="main-content" class="search-results-column">

--- a/templates/search_results.hbs
+++ b/templates/search_results.hbs
@@ -116,7 +116,7 @@
               <path stroke="currentColor" stroke-linecap="round" d="M3 9l6-6m0 6L3 3"/>
             </svg>
           </button>
-          <h3 class="collapsible-sidebar-title sidenav-title">{{t 'filter_by_content_tag'}}</h3>
+          <h3 class="collapsible-sidebar-title sidenav-title">{{t 'filter_content_tag'}}</h3>
           <ul class="multibrand-filter-list multibrand-filter-list--collapsed">
             {{#each content_tag_filters}}
             	{{#if selected}}


### PR DESCRIPTION
## Description

Adds the content tag filter to the search results.

## Screenshots

<img width="1194" alt="Screenshot 2022-08-25 at 15 46 28" src="https://user-images.githubusercontent.com/7979835/186682236-368b7f9b-ec59-4b8c-beaa-dacdbcd6c8fc.png">


## Checklist

- [x] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [x] :nail_care: SASS files are compiled
- [x] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: changes are accessible
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->