### PR TITLE
Fix paragraph margins inside of table cells

### DIFF
--- a/style.css
+++ b/style.css
@@ -2047,6 +2047,16 @@ ul {
   transform: rotate(0.5turn);
 }
 
+.article td > p:first-child,
+.article th > p:first-child {
+  margin-top: 0;
+}
+
+.article td > p:last-child,
+.article th > p:last-child {
+  margin-bottom: 0;
+}
+
 .sidenav-title {
   font-size: 15px;
   position: relative;

--- a/styles/_article.scss
+++ b/styles/_article.scss
@@ -197,6 +197,16 @@
       @extend .button-primary;
     }
   }
+
+  td > p:first-child,
+  th > p:first-child {
+    margin-top: 0;
+  }
+
+  td > p:last-child,
+  th > p:last-child {
+    margin-bottom: 0;
+  }
 }
 
 .sidenav {


### PR DESCRIPTION
## Description

The current margins conflicts with table alignment:

<img width="741" alt="Screenshot 2022-08-15 at 09 31 29" src="https://user-images.githubusercontent.com/90802/184852158-2d14b2ae-5f54-48df-8b72-f80adfa594e9.png">

when applying this fix:


<img width="736" alt="Screenshot 2022-08-16 at 11 58 58" src="https://user-images.githubusercontent.com/90802/184852602-4e97d7d9-7ecd-4401-bf65-6b69c8a76a49.png">

## Checklist

- [x] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [x] :nail_care: SASS files are compiled
- [x] :arrow_left: changes are compatible with RTL direction
- [x] :wheelchair: changes are accessible
- [x] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [x] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->