### PR TITLE
feat: introduce content tags

### DIFF
--- a/style.css
+++ b/style.css
@@ -5082,3 +5082,39 @@ html[dir="rtl"] .notification-left-aligned {
 .dropdown-chevron-icon {
   vertical-align: middle;
 }
+
+.content-tags > p {
+  color: #68737D;
+  margin-top: 32px;
+  margin-bottom: 4px;
+}
+
+.content-tags-add-hint {
+  color: #68737D;
+  font-size: 14px;
+}
+
+.content-tag-list {
+  display: flex;
+  flex-wrap: wrap;
+  word-break: break-word;
+}
+
+.content-tag-list li {
+  border-right: 1px solid #C2C8CC;
+  margin-bottom: 4px;
+}
+
+[dir="ltr"] .content-tag-list li {
+  padding-right: 8px;
+  margin-right: 8px;
+}
+
+[dir="rtl"] .content-tag-list li {
+  padding-left: 8px;
+  margin-left: 8px;
+}
+
+.content-tag-list li:last-child {
+  border: none;
+}

--- a/styles/_content-tags.scss
+++ b/styles/_content-tags.scss
@@ -1,0 +1,36 @@
+.content-tags {
+  > p {
+    color: #68737D;
+    margin-top: 32px;
+    margin-bottom: 4px;
+  }
+
+  &-add-hint {
+    color: #68737D;
+    font-size: 14px;
+  }
+}
+
+.content-tag-list {
+  display: flex;
+  flex-wrap: wrap;
+  word-break: break-word;
+
+  li {
+    border-right: 1px solid #C2C8CC;
+    margin-bottom: 4px;
+
+    [dir="ltr"] & {
+      padding-right: 8px;
+      margin-right: 8px;
+    }
+    [dir="rtl"] & {
+      padding-left: 8px;
+      margin-left: 8px;
+    }
+
+    &:last-child {
+      border: none;
+    }
+  }
+}

--- a/styles/index.scss
+++ b/styles/index.scss
@@ -40,3 +40,4 @@
 @import "search_results";
 @import "notifications";
 @import "dropdowns";
+@import "content-tags";

--- a/templates/article_page.hbs
+++ b/templates/article_page.hbs
@@ -91,6 +91,22 @@
       <section class="article-info">
         <div class="article-content">
           <div class="article-body">{{article.body}}</div>
+
+          {{#if (compare article.content_tags.length ">" 0)}}
+            <section class="content-tags">
+              <p>{{t 'content_tags_label'}}</p>
+              <ul class="content-tag-list">
+                {{#each article.content_tags}}
+                  <li class="content-tag-item" data-content-tag-id="{{id}}">
+                    {{#link "search_result" content_tag_id=id target="_blank"}}
+                      {{name}}
+                    {{/link}}
+                  </li>
+                {{/each}}
+              </ul>
+            </section>
+          {{/if}}
+
           {{#if attachments}}
             <div class="article-attachments">
               <ul class="attachments">

--- a/templates/community_post_page.hbs
+++ b/templates/community_post_page.hbs
@@ -123,6 +123,21 @@
             <div class="post-content">
               <div class="post-body">{{post.details}}</div>
             </div>
+
+            {{#if (compare post.content_tags.length ">" 0)}}
+              <section class="content-tags">
+                <p>{{t 'content_tags_label'}}</p>
+                <ul class="content-tag-list">
+                  {{#each post.content_tags}}
+                    <li class="content-tag-item" data-content-tag-id="{{id}}">
+                      {{#link "search_result" content_tag_id=id target="_blank"}}
+                        {{name}}
+                      {{/link}}
+                    </li>
+                  {{/each}}
+                </ul>
+              </section>
+            {{/if}}
           </div>
 
           <div class="post-actions-wrapper">

--- a/templates/new_community_post_page.hbs
+++ b/templates/new_community_post_page.hbs
@@ -67,6 +67,23 @@
         {{/validate}}
       </div>
 
+      <div class="form-field">
+        {{#required 'content_tags'}}
+          {{label 'content_tags'}}
+        {{else}}
+          {{#label 'content_tags'}}
+            {{t 'content_tags_label'}}<span class="optional">({{t 'optional'}})</span>
+          {{/label}}
+        {{/required}}
+        <span class="content-tags-add-hint">{{t 'content_tags_description'}}</span>
+        {{multiselect 'content_tags'}}
+        {{#validate 'content_tags'}}
+          <div class="notification notification-error notification-inline">
+            {{error 'content_tags'}}
+          </div>
+        {{/validate}}
+      </div>
+
       <footer>{{input type='submit'}}</footer>
     {{/form}}
   </div>


### PR DESCRIPTION
## Description

This PR introduces content tags on the following three pages:

1. `New post page`: a new content tags field is added.
2. `Article page`: a new section listing the article content tags is added.
3. `Post page`: a new section listing the post content tags is added.

I couldn't use the following markup to render the content tag links:

```hbs
{{#link "search_result" content_tag_id=(id) target="_blank"}}
  {{name}}
{{/link}}
```

for the following two reasons:

1. There seems to be a bug in Curlybars because `content_tag_id=(id)` does not validate. I'll need to look into that.
2. `target="_blank"` is ignored by the link helper, we would need to add the attribute to the allowlist.

## Screenshots

New post page:

<img width="743" alt="Screenshot 2022-08-31 at 09 19 05" src="https://user-images.githubusercontent.com/5737996/187617237-a7b1f6a2-2a20-4493-abc2-23a7ab302b8b.png">

Content tags section:

<img width="262" alt="Screenshot 2022-08-31 at 09 21 40" src="https://user-images.githubusercontent.com/5737996/187617726-4feaa3ef-2415-4142-95c8-fd1f7e6534fe.png">

<!-- (optional) when applicable, please include some screenshots or gifs that illustrate the changes -->

## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :nail_care: SASS files are compiled
- [x] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: changes are accessible
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->