### PR TITLE
chore: remove translations from `default` package

### DIFF
--- a/translations.yml
+++ b/translations.yml
@@ -9,7 +9,6 @@
 ---
 title: "Help Center Copenhagen theme"
 packages:
-  - default
   - help_center_copenhagen_theme
 
 parts:


### PR DESCRIPTION

## Description

The `default` package is no longer used and this can be removed.

## Screenshots

N/A

<!-- (optional) when applicable, please include some screenshots or gifs that illustrate the changes -->

## Checklist

- [x] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [x] :nail_care: SASS files are compiled
- [x] :arrow_left: changes are compatible with RTL direction
- [x] :wheelchair: changes are accessible
- [x] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [x] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->