### PR TITLE
fix: only close content tag with click on close icon

### DIFF
--- a/style.css
+++ b/style.css
@@ -4632,14 +4632,14 @@ ul {
   flex-grow: 0;
 }
 
-.search-results-sidebar .sidenav-tag a {
+.search-results-sidebar .sidenav-tag .content-tag {
   background: #E9EBED;
   border-radius: 4px;
   padding: 4px 12px;
   text-decoration: none;
 }
 
-.search-results-sidebar .sidenav-tag a .label {
+.search-results-sidebar .sidenav-tag .content-tag .label {
   font-style: normal;
   font-weight: 600;
   font-size: 12px;
@@ -4652,7 +4652,7 @@ ul {
   display: inline-block;
 }
 
-.search-results-sidebar .sidenav-tag a .close-icon {
+.search-results-sidebar .sidenav-tag .content-tag .close-icon {
   color: #555555;
   vertical-align: middle;
   display: inline-block;

--- a/styles/_search_results.scss
+++ b/styles/_search_results.scss
@@ -52,7 +52,7 @@
       align-items: flex-start;
       flex-grow: 0;
 
-      a {
+      .content-tag {
         background: #E9EBED;
         border-radius: 4px;
         padding: 4px 12px;
@@ -60,21 +60,21 @@
 
         .label {
           font-style: normal;
-            font-weight: 600;
-            font-size: 12px;
-            line-height: 24px;
-            text-align: center;
-            letter-spacing: -0.000427656px;
-            color: #49545C;
-            flex-grow: 0;
-            vertical-align: middle;
-            display: inline-block;
+          font-weight: 600;
+          font-size: 12px;
+          line-height: 24px;
+          text-align: center;
+          letter-spacing: -0.000427656px;
+          color: #49545C;
+          flex-grow: 0;
+          vertical-align: middle;
+          display: inline-block;
         }
 
         .close-icon {
           color: #555555;
-            vertical-align: middle;
-            display: inline-block;
+          vertical-align: middle;
+          display: inline-block;
         }
       }
     }

--- a/templates/search_results.hbs
+++ b/templates/search_results.hbs
@@ -121,14 +121,16 @@
             {{#each content_tag_filters}}
             	{{#if selected}}
                 <li class="sidenav-tag">
-                  <a href="{{url}}" aria-current="page">
+                  <div class="content-tag">
                     <span class="label">{{name}}</span>
-                    <span>
-                      <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" width="12" height="12" focusable="false"  aria-hidden="true" >
-                          <path stroke="currentColor" stroke-linecap="round" d="M3 9l6-6m0 6L3 3"/>
-                      </svg>
-                    </span>
-                  </a>
+                    <a href="{{url}}" aria-current="page">
+                      <span>
+                        <svg class="close-icon" xmlns="http://www.w3.org/2000/svg" width="12" height="12" focusable="false"  aria-hidden="true" >
+                            <path stroke="currentColor" stroke-linecap="round" d="M3 9l6-6m0 6L3 3"/>
+                        </svg>
+                      </span>
+                    </a>
+                  </div>
                 </li>
               {{/if}}
             {{/each}}


### PR DESCRIPTION
## Description

Related to GS-2252, so that the content tag can only be deselected by clicking on the cross/close-icon.

## Screenshots


https://user-images.githubusercontent.com/7979835/195088731-eb5c15b1-4ec8-490c-9b9f-f61d45cdccfc.mov



## Checklist

- [x] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [x] :nail_care: SASS files are compiled
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: changes are accessible
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->