### PR TITLE
refactor: open content tag search links in the same tab

### DIFF
--- a/templates/article_page.hbs
+++ b/templates/article_page.hbs
@@ -98,7 +98,7 @@
               <ul class="content-tag-list">
                 {{#each article.content_tags}}
                   <li class="content-tag-item" data-content-tag-id="{{id}}">
-                    {{#link "search_result" content_tag_id=id target="_blank"}}
+                    {{#link "search_result" content_tag_id=id}}
                       {{name}}
                     {{/link}}
                   </li>

--- a/templates/community_post_page.hbs
+++ b/templates/community_post_page.hbs
@@ -130,7 +130,7 @@
                 <ul class="content-tag-list">
                   {{#each post.content_tags}}
                     <li class="content-tag-item" data-content-tag-id="{{id}}">
-                      {{#link "search_result" content_tag_id=id target="_blank"}}
+                      {{#link "search_result" content_tag_id=id}}
                         {{name}}
                       {{/link}}
                     </li>


### PR DESCRIPTION
## Description

This PR changes how content tag search links should be opened: on the same page, instead of in a new tab.

## Screenshots

<!-- (optional) when applicable, please include some screenshots or gifs that illustrate the changes -->

## Checklist

- [x] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [x] :nail_care: SASS files are compiled
- [x] :arrow_left: changes are compatible with RTL direction
- [x] :wheelchair: changes are accessible
- [x] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [x] :iphone: changes are responsive and tested in mobile
- [x] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->