### PR TITLE
fix: correct visited state for buttons

### DIFF
--- a/style.css
+++ b/style.css
@@ -376,7 +376,11 @@ ul {
   }
 }
 
-.button:visited, .split-button button:visited, .section-subscribe button:visited, .article-subscribe button:visited, .community-follow button:visited, .requests-table-toolbar .organization-subscribe button:visited, .subscriptions-subscribe button:visited, .pagination-next-link:visited, .pagination-prev-link:visited, .pagination-first-link:visited, .pagination-last-link:visited, .button:hover, .split-button button:hover, .section-subscribe button:hover, .article-subscribe button:hover, .community-follow button:hover, .requests-table-toolbar .organization-subscribe button:hover, .subscriptions-subscribe button:hover, .pagination-next-link:hover, .pagination-prev-link:hover, .pagination-first-link:hover, .pagination-last-link:hover, .button:active, .split-button button:active, .section-subscribe button:active, .article-subscribe button:active, .community-follow button:active, .requests-table-toolbar .organization-subscribe button:active, .subscriptions-subscribe button:active, .pagination-next-link:active, .pagination-prev-link:active, .pagination-first-link:active, .pagination-last-link:active, .button:focus, .split-button button:focus, .section-subscribe button:focus, .article-subscribe button:focus, .community-follow button:focus, .requests-table-toolbar .organization-subscribe button:focus, .subscriptions-subscribe button:focus, .pagination-next-link:focus, .pagination-prev-link:focus, .pagination-first-link:focus, .pagination-last-link:focus, .button.button-primary, .split-button button.button-primary, .section-subscribe button.button-primary, .section-subscribe button[data-selected="true"], .article-subscribe button.button-primary, .article-subscribe button[data-selected="true"], .community-follow button.button-primary, .requests-table-toolbar .organization-subscribe button.button-primary, .requests-table-toolbar .organization-subscribe button[data-selected="true"], .subscriptions-subscribe button.button-primary, .subscriptions-subscribe button[data-selected="true"], .button-primary.pagination-next-link, .button-primary.pagination-prev-link, .button-primary.pagination-first-link, .button-primary.pagination-last-link {
+.button:visited, .split-button button:visited, .section-subscribe button:visited, .article-subscribe button:visited, .community-follow button:visited, .requests-table-toolbar .organization-subscribe button:visited, .subscriptions-subscribe button:visited, .pagination-next-link:visited, .pagination-prev-link:visited, .pagination-first-link:visited, .pagination-last-link:visited {
+  color: $brand_color;
+}
+
+.button:hover, .split-button button:hover, .section-subscribe button:hover, .article-subscribe button:hover, .community-follow button:hover, .requests-table-toolbar .organization-subscribe button:hover, .subscriptions-subscribe button:hover, .pagination-next-link:hover, .pagination-prev-link:hover, .pagination-first-link:hover, .pagination-last-link:hover, .button:active, .split-button button:active, .section-subscribe button:active, .article-subscribe button:active, .community-follow button:active, .requests-table-toolbar .organization-subscribe button:active, .subscriptions-subscribe button:active, .pagination-next-link:active, .pagination-prev-link:active, .pagination-first-link:active, .pagination-last-link:active, .button:focus, .split-button button:focus, .section-subscribe button:focus, .article-subscribe button:focus, .community-follow button:focus, .requests-table-toolbar .organization-subscribe button:focus, .subscriptions-subscribe button:focus, .pagination-next-link:focus, .pagination-prev-link:focus, .pagination-first-link:focus, .pagination-last-link:focus, .button.button-primary, .split-button button.button-primary, .section-subscribe button.button-primary, .section-subscribe button[data-selected="true"], .article-subscribe button.button-primary, .article-subscribe button[data-selected="true"], .community-follow button.button-primary, .requests-table-toolbar .organization-subscribe button.button-primary, .requests-table-toolbar .organization-subscribe button[data-selected="true"], .subscriptions-subscribe button.button-primary, .subscriptions-subscribe button[data-selected="true"], .button-primary.pagination-next-link, .button-primary.pagination-prev-link, .button-primary.pagination-first-link, .button-primary.pagination-last-link {
   background-color: $brand_color;
   color: $brand_text_color;
   text-decoration: none;
@@ -410,6 +414,10 @@ ul {
   }
 }
 
+.button-large:visited, input[type="submit"]:visited {
+  color: $brand_text_color;
+}
+
 .button-large:hover, .button-large:active, .button-large:focus, input[type="submit"]:hover, input[type="submit"]:active, input[type="submit"]:focus {
   background-color: darken($brand_color, 20%);
 }
@@ -422,6 +430,10 @@ ul {
   color: lighten($text_color, 20%);
   border: 1px solid #ddd;
   background-color: transparent;
+}
+
+.button-secondary:visited {
+  color: lighten($text_color, 20%);
 }
 
 .button-secondary:hover, .button-secondary:focus, .button-secondary:active {

--- a/styles/_buttons.scss
+++ b/styles/_buttons.scss
@@ -19,7 +19,10 @@
   width: 100%;
   -webkit-touch-callout: none;
 
-  &:visited,
+  &:visited {
+    color: $button-color;
+  }
+
   &:hover,
   &:active,
   &:focus,
@@ -59,6 +62,10 @@
   padding: 0 1.9286em;
   width: 100%;
 
+  &:visited {
+    color: $brand_text_color;
+  }
+
   &:hover,
   &:active,
   &:focus {
@@ -75,6 +82,10 @@
   color: $secondary-text-color;
   border: 1px solid $border-color;
   background-color: transparent;
+
+  &:visited {
+    color: $secondary-text-color;
+  }
 
   &:hover,
   &:focus,


### PR DESCRIPTION
## Description

This PR fixes an issue with the visited state for buttons. The issue was found in the pagination buttons, but since it was a general bug with the visited state, it could also appear in other buttons as well.

Jira issue: https://zendesk.atlassian.net/browse/GG-2960

The bug was caused by the fact that for visited links that were extending the `.button` class, the following style was applied:
```css
& {
 background-color: $brand_color;
 color: $brand_text_color;
 text-decoration: none;
}
```

The default state for some buttons is having `background-color: transparent;` and it is not possible to override the background color for visited links if the default is transparent: https://developer.mozilla.org/en-US/docs/Web/CSS/Privacy_and_the_:visited_selector#limits_to_visited_link_styles. Other than that, that rule was setting the same visited style for any button, while we want the visited style to match the style of the default state.

The solution is to set the color of the link for any button variant (default, primary and secondary) to the same value as the default state. In this way the default visited color is overridden and the button has the same style as the default state.

## Screenshots

Before:
<img width="1296" alt="Screenshot 2022-11-09 at 16 08 42" src="https://user-images.githubusercontent.com/13420283/200869874-d1d41b38-c4f3-437f-9841-31c97c20253a.png">

After:
<img width="1296" alt="Screenshot 2022-11-09 at 16 04 28" src="https://user-images.githubusercontent.com/13420283/200869922-848e6908-f11e-46b3-835f-e038acbf5d3a.png">


## Checklist

- [x] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [x] :nail_care: SASS files are compiled
- [x] :arrow_left: changes are compatible with RTL direction
- [x] :wheelchair: changes are accessible
- [x] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [x] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->