### PR TITLE
[GG-2903] Improve contrast in theme elements

### DIFF
--- a/style.css
+++ b/style.css
@@ -270,7 +270,7 @@ select {
   -moz-appearance: none;
   background: url("data:image/svg+xml,%3C%3Fxml version='1.0' encoding='UTF-8'%3F%3E%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'%3E%3Cpath fill='%23CCC' d='M0 0h10L5 6 0 0z'/%3E%3C/svg%3E%0A") no-repeat #fff;
   background-position: right 10px center;
-  border: 1px solid #ddd;
+  border: 1px solid #87929D;
   border-radius: 4px;
   padding: 8px 30px 8px 10px;
   outline: none;
@@ -287,7 +287,7 @@ select::-ms-expand {
 }
 
 textarea {
-  border: 1px solid #ddd;
+  border: 1px solid #87929D;
   border-radius: 2px;
   resize: vertical;
   width: 100%;
@@ -428,7 +428,7 @@ ul {
 
 .button-secondary {
   color: lighten($text_color, 20%);
-  border: 1px solid #ddd;
+  border: 1px solid #87929D;
   background-color: transparent;
 }
 
@@ -438,7 +438,7 @@ ul {
 
 .button-secondary:hover, .button-secondary:focus, .button-secondary:active {
   color: $text_color;
-  border: 1px solid #ddd;
+  border: 1px solid #87929D;
   background-color: darken($background_color, 3%);
 }
 
@@ -565,7 +565,7 @@ ul {
 }
 
 .form-field input {
-  border: 1px solid #ddd;
+  border: 1px solid #87929D;
   border-radius: 4px;
   padding: 10px;
   width: 100%;
@@ -576,7 +576,7 @@ ul {
 }
 
 .form-field input[type="text"] {
-  border: 1px solid #ddd;
+  border: 1px solid #87929D;
   border-radius: 4px;
 }
 
@@ -1090,7 +1090,7 @@ ul {
 }
 
 .search {
-  border-color: #ddd;
+  border-color: #87929D;
   border-radius: 30px;
   border-style: solid;
   border-width: 1px;
@@ -2036,7 +2036,7 @@ ul {
 }
 
 .article-return-to-top {
-  border-top: 1px solid #ddd;
+  border-top: 1px solid #87929D;
 }
 
 @media (min-width: 1024px) {

--- a/styles/_article.scss
+++ b/styles/_article.scss
@@ -117,8 +117,8 @@
       height: auto;
     }
 
-    border-bottom: 1px solid $border-color;
-    border-top: 1px solid $border-color;
+    border-bottom: 1px solid $low-contrast-border-color;
+    border-top: 1px solid $low-contrast-border-color;
     flex: 1 0 auto; //Explicit values needed whith flex-direction: column for IE11
     margin-bottom: 20px;
     padding: 0;
@@ -129,7 +129,7 @@
       flex-direction: row;
     }
 
-    border-top: 1px solid $border-color;
+    border-top: 1px solid $low-contrast-border-color;
     display: flex;
     flex-direction: column;
     padding: 20px 0;
@@ -151,7 +151,7 @@
   }
 
   &-votes {
-    border-top: 1px solid $border-color;
+    border-top: 1px solid $low-contrast-border-color;
     padding: 30px 0;
     text-align: center;
   }
@@ -173,7 +173,7 @@
       display: none;
     }
 
-    border-top: 1px solid $border-color;
+    border-top: 1px solid $high-contrast-border-color;
 
     a {
       color: $text_color;

--- a/styles/_base.scss
+++ b/styles/_base.scss
@@ -90,7 +90,7 @@ select {
   background: url("data:image/svg+xml,%3C%3Fxml version='1.0' encoding='UTF-8'%3F%3E%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'%3E%3Cpath fill='%23CCC' d='M0 0h10L5 6 0 0z'/%3E%3C/svg%3E%0A")
     no-repeat #fff;
   background-position: right 10px center;
-  border: 1px solid $border-color;
+  border: 1px solid $high-contrast-border-color;
   border-radius: 4px;
   padding: 8px 30px 8px 10px;
   outline: none;
@@ -107,7 +107,7 @@ select {
 }
 
 textarea {
-  border: 1px solid $border-color;
+  border: 1px solid $high-contrast-border-color;
   border-radius: 2px;
   resize: vertical;
   width: 100%;
@@ -124,7 +124,7 @@ textarea {
 }
 
 .container-divider {
-  border-top: 1px solid $border-color;
+  border-top: 1px solid $low-contrast-border-color;
   margin-bottom: 20px;
 }
 

--- a/styles/_blocks.scss
+++ b/styles/_blocks.scss
@@ -41,7 +41,7 @@
 
     &-internal {
       background-color: transparent;
-      border: 1px solid $border-color;
+      border: 1px solid $low-contrast-border-color;
 
       .icon-lock {
         height: 15px;

--- a/styles/_buttons.scss
+++ b/styles/_buttons.scss
@@ -80,7 +80,7 @@
 
 .button-secondary {
   color: $secondary-text-color;
-  border: 1px solid $border-color;
+  border: 1px solid $high-contrast-border-color;
   background-color: transparent;
 
   &:visited {
@@ -91,7 +91,7 @@
   &:focus,
   &:active {
     color: $text_color;
-    border: 1px solid $border-color;
+    border: 1px solid $high-contrast-border-color;
     background-color: $primary-shade;
   }
 }

--- a/styles/_collapsible-nav.scss
+++ b/styles/_collapsible-nav.scss
@@ -14,8 +14,8 @@
     border-top: 0;
   }
 
-  border-bottom: 1px solid $border-color;
-  border-top: 1px solid $border-color;
+  border-bottom: 1px solid $low-contrast-border-color;
+  border-top: 1px solid $low-contrast-border-color;
 }
 
 .collapsible-nav-toggle {

--- a/styles/_comments.scss
+++ b/styles/_comments.scss
@@ -1,7 +1,7 @@
 /***** Comments *****/
 /* Styles comments inside articles, posts and requests */
 .comment {
-  border-bottom: 1px solid $border-color;
+  border-bottom: 1px solid $low-contrast-border-color;
   padding: 20px 0;
 
   &-heading {
@@ -12,8 +12,8 @@
   }
 
   &-overview {
-    border-bottom: 1px solid $border-color;
-    border-top: 1px solid $border-color;
+    border-bottom: 1px solid $low-contrast-border-color;
+    border-top: 1px solid $low-contrast-border-color;
     padding: 20px 0;
 
     p { margin-top: 0; }

--- a/styles/_community.scss
+++ b/styles/_community.scss
@@ -58,7 +58,7 @@
 
 .topic-header {
   @include tablet { padding-bottom: 10px; }
-  border-bottom: 1px solid $border-color;
+  border-bottom: 1px solid $low-contrast-border-color;
   font-size: $font-size-small;
 
   .dropdown {
@@ -70,7 +70,7 @@
     }
 
     display: block;
-    border-top: 1px solid $border-color;
+    border-top: 1px solid $low-contrast-border-color;
     padding: 10px 0;
   }
 }

--- a/styles/_footer.scss
+++ b/styles/_footer.scss
@@ -1,6 +1,6 @@
 /***** Footer *****/
 .footer {
-  border-top: 1px solid $border-color;
+  border-top: 1px solid $low-contrast-border-color;
   margin-top: 60px;
   padding: 30px 0;
 

--- a/styles/_forms.scss
+++ b/styles/_forms.scss
@@ -15,7 +15,7 @@
 }
 
 .form-field input {
-  border: 1px solid $border-color;
+  border: 1px solid $high-contrast-border-color;
   border-radius: 4px;
   padding: 10px;
   width: 100%;
@@ -24,7 +24,7 @@
 }
 
 .form-field input[type="text"] {
-  border: 1px solid $border-color;
+  border: 1px solid $high-contrast-border-color;
   border-radius: 4px;
 
   &:focus { border: 1px solid $brand_color; }
@@ -89,7 +89,7 @@
   margin-top: 30px;
 
   label {
-    border-bottom: 1px solid $border-color;
+    border-bottom: 1px solid $low-contrast-border-color;
     display: block;
     padding-bottom: 5px;
   }

--- a/styles/_home-page.scss
+++ b/styles/_home-page.scss
@@ -39,7 +39,7 @@
 
     a {
       display: block;
-      border-bottom: 1px solid $border-color;
+      border-bottom: 1px solid $low-contrast-border-color;
       padding: 15px 0;
     }
 
@@ -49,7 +49,7 @@
 
     &:last-child a {
       @include desktop {
-        border-bottom: 1px solid $border-color;
+        border-bottom: 1px solid $low-contrast-border-color;
       }
 
       border: 0;
@@ -76,6 +76,6 @@
 
 .community,
 .activity {
-  border-top: 1px solid $border-color;
+  border-top: 1px solid $low-contrast-border-color;
   padding: 30px 0;
 }

--- a/styles/_mixins.scss
+++ b/styles/_mixins.scss
@@ -102,7 +102,7 @@
 
   :not(pre) > code {
     background: $primary-shade;
-    border: 1px solid $border-color;
+    border: 1px solid $low-contrast-border-color;
     border-radius: 3px;
     padding: 0 5px;
     margin: 0 2px;
@@ -110,7 +110,7 @@
 
   pre {
     background: $primary-shade;
-    border: 1px solid $border-color;
+    border: 1px solid $low-contrast-border-color;
     border-radius: 3px;
     padding: 10px 15px;
     overflow: auto;
@@ -118,7 +118,7 @@
   }
 
   blockquote {
-    border-left: 1px solid $border-color;
+    border-left: 1px solid $low-contrast-border-color;
     color: $secondary-text-color;
     font-style: italic;
     padding: 0 15px;

--- a/styles/_post.scss
+++ b/styles/_post.scss
@@ -134,7 +134,7 @@
       [dir="rtl"] & { padding: 0 50px 0 0; }
     }
 
-    border-top: 1px solid $border-color;
+    border-top: 1px solid $low-contrast-border-color;
     flex: 1;
     padding: 30px 0;
     text-align: center;

--- a/styles/_recent-activity.scss
+++ b/styles/_recent-activity.scss
@@ -9,7 +9,7 @@
   &-list { padding: 0; }
 
   &-item {
-    border-bottom: 1px solid $border-color;
+    border-bottom: 1px solid $low-contrast-border-color;
     overflow: auto;
     padding: 20px 0;
   }

--- a/styles/_request.scss
+++ b/styles/_request.scss
@@ -45,7 +45,7 @@
 
     .comment-show-container {
       border-radius: 2px;
-      border: 1px solid $border-color;
+      border: 1px solid $low-contrast-border-color;
       color: $secondary-text-color;
       text-align: inherit;
       padding: 8px 25px;
@@ -89,7 +89,7 @@
 
   &-title {
     @include desktop {
-      border-bottom: 1px solid $border-color;
+      border-bottom: 1px solid $low-contrast-border-color;
       margin-bottom: 0;
       max-width: 66%; //Same as main container
       padding-bottom: 20px;
@@ -108,8 +108,8 @@
       width: 30%; //IE11 fix
     }
 
-    border-bottom: 1px solid $border-color;
-    border-top: 1px solid $border-color;
+    border-bottom: 1px solid $low-contrast-border-color;
+    border-top: 1px solid $low-contrast-border-color;
     flex: 1 0 auto;
     order: 0; //Bring to top
 
@@ -125,7 +125,7 @@
   }
 
   &-details {
-    border-bottom: 1px solid $border-color;
+    border-bottom: 1px solid $low-contrast-border-color;
     font-size: 0; // To remove whitespace and do a 40%/60% split
     margin: 0;
     padding-bottom: 20px;

--- a/styles/_search.scss
+++ b/styles/_search.scss
@@ -9,7 +9,7 @@ $padding-right: 20px;
 }
 
 .search {
-  border-color: $border-color;
+  border-color: $high-contrast-border-color;
   border-radius: 30px;
   border-style: solid;
   border-width: 1px;

--- a/styles/_search_results.scss
+++ b/styles/_search_results.scss
@@ -18,7 +18,7 @@
   }
 
   &-sidebar {
-    border-top: 1px solid $border-color;
+    border-top: 1px solid $low-contrast-border-color;
     flex: 1 0 auto;
     margin-bottom: 20px;
     padding: 0;
@@ -131,7 +131,7 @@
     > li {
       padding: 20px 0;
       &:first-child {
-        border-top: 1px solid $border-color;
+        border-top: 1px solid $low-contrast-border-color;
       }
 
       h2 {

--- a/styles/_section.scss
+++ b/styles/_section.scss
@@ -25,12 +25,12 @@
 }
 
 .section-list-item {
-  border-bottom: 1px solid $border-color;
+  border-bottom: 1px solid $low-contrast-border-color;
   font-size: $font-size-bigger;
   padding: 15px 0;
 
   &:first-child {
-    border-top: 1px solid $border-color;
+    border-top: 1px solid $low-contrast-border-color;
   }
 
   a {

--- a/styles/_striped_list.scss
+++ b/styles/_striped_list.scss
@@ -10,7 +10,7 @@
     }
 
     align-items: flex-start;
-    border-bottom: 1px solid $border-color;
+    border-bottom: 1px solid $low-contrast-border-color;
     display: flex;
     flex-direction: column;
     justify-content: flex-end;

--- a/styles/_tables.scss
+++ b/styles/_tables.scss
@@ -19,7 +19,7 @@
   tr {
     @include tablet { display: table-row; }
 
-    border-bottom: 1px solid $border-color;
+    border-bottom: 1px solid $low-contrast-border-color;
     display: block;
     padding: 20px 0;
   }

--- a/styles/_user-profiles.scss
+++ b/styles/_user-profiles.scss
@@ -324,7 +324,7 @@
   }
 
   &-item {
-    border-top: 1px solid $border-color;
+    border-top: 1px solid $low-contrast-border-color;
     display: flex;
     flex: 1;
     flex-direction: row;

--- a/styles/_variables.scss
+++ b/styles/_variables.scss
@@ -13,7 +13,8 @@ $font-size-navigation: 14px;
 $font-size-small: 13px;
 $font-size-smaller: 11px;
 
-$border-color: #ddd;
+$high-contrast-border-color: #87929D; // maintains a 3:1 contrast ratio with default background color (#FFF). Use for controls and inputs
+$low-contrast-border-color: #ddd; // less than 3:1 contrast ratio with default background color. Use for elements that do not require user interaction
 
 $button-color: $brand_color;
 


### PR DESCRIPTION
## Description

According to A11y best practices input elements should have a contrast ratio of at least 3:1 with surrounding elements.

After this change, the border color of many input elements changes from `#dddddd` to `#87929D`. The latter has a contrast ratio of > 3 with the theme's default background color: `#ffffff`.

We still have a need for some elements to use the lower contrast border color -- `#ddd` -- so this PR splits the `$border-color` SASS variable into two separate values.

| Page name    |  Page element | Fixed?           | Screenshot   |
| ------------- | ------------- | ------------- | ------------- |
| Search results page  | Search bar  | ✅                    |   <img width="1392" alt="Screenshot 2022-11-24 at 11 17 05" src="https://user-images.githubusercontent.com/1755162/203758968-9978d76a-27ec-43ac-9959-5820e3b854ec.png"> |
| My requests page  | Search bar  |              ✅           |        <img width="1392" alt="Screenshot 2022-11-24 at 11 21 45" src="https://user-images.githubusercontent.com/1755162/203760079-c4f5d77c-f599-4710-8d18-abf051d2770e.png">   |
| My requests page  | Status dropdown  |              ✅           |        <img width="1392" alt="Screenshot 2022-11-24 at 11 21 45" src="https://user-images.githubusercontent.com/1755162/203760079-c4f5d77c-f599-4710-8d18-abf051d2770e.png">   |
| Article page | Search bar | ✅ | <img width="1520" alt="Screenshot 2022-11-28 at 12 53 38" src="https://user-images.githubusercontent.com/1755162/204271461-08c0069b-1f92-4074-a83f-628a01e23e0e.png"> |
| Article page | Comment form | 🟨 Partial fix -- editor must be updated in HC | <img width="1210" alt="Screenshot 2022-11-28 at 15 35 01" src="https://user-images.githubusercontent.com/1755162/204304194-814cd672-2c07-4a96-8aeb-1fa8ee8e2dae.png"> |
| Submit a request page | Form fields | 🟨 Partial fix -- some elements need to be updated in HC |  <img width="1716" alt="Screenshot 2022-11-28 at 12 43 59" src="https://user-images.githubusercontent.com/1755162/204270041-dcc4ea61-cd77-484a-b8e0-985bef073fbc.png"> | 
| Topic show page | Search bar | ✅ | <img width="1520" alt="Screenshot 2022-11-28 at 12 55 19" src="https://user-images.githubusercontent.com/1755162/204271771-c9f4d130-205c-40e6-8441-417809ca5bdb.png"> |
| New post page | Form fields | 🟨 Partial fix -- some elements need to be updated in HC | <img width="1520" alt="Screenshot 2022-11-28 at 13 00 43" src="https://user-images.githubusercontent.com/1755162/204272859-788679f9-6390-4ba0-97ce-a2287a2e13b8.png"> |
| Edit post modal | Form fields | ❌ must be updated in HC | N/A |
| Create a ticket modal | Form fields | ❌ must be updated in HC | N/A |
| Award badges modal | Form fields | ❌ must be updated in HC | N/A |
| Post page page | Comment form | 🟨 Partial fix -- editor must be updated in HC | <img width="1210" alt="Screenshot 2022-11-28 at 15 33 54" src="https://user-images.githubusercontent.com/1755162/204304017-e915a76a-04c0-41eb-b01a-df44d6ed6b4e.png"> |

## Checklist

- [x] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [x] :nail_care: SASS files are compiled
- [x] :arrow_left: changes are compatible with RTL direction
- [x] :wheelchair: changes are accessible
- [x] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [x] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings