### PR TITLE
Remove aria-expanded from sections in search_result page

### DIFF
--- a/templates/search_results.hbs
+++ b/templates/search_results.hbs
@@ -14,7 +14,7 @@
   <div class="search-results">
     <aside class="search-results-sidebar">
       {{#if source_filters}}
-        <section class="filters-in-section collapsible-sidebar" aria-expanded="false">
+        <section class="filters-in-section collapsible-sidebar">
           <button type="button" class="collapsible-sidebar-toggle" aria-expanded="false" aria-label="{{t 'search_result_source_menu'}}">
             <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" focusable="false" viewBox="0 0 12 12" aria-hidden="true" class="collapsible-sidebar-toggle-icon chevron-icon">
               <path fill="none" stroke="currentColor" stroke-linecap="round" d="M3 4.5l2.6 2.6c.2.2.5.2.7 0L9 4.5"/>
@@ -42,7 +42,7 @@
         </section>
       {{/if}}
       {{#if type_filters}}
-        <section class="filters-in-section collapsible-sidebar" aria-expanded="false">
+        <section class="filters-in-section collapsible-sidebar">
           <button type="button" class="collapsible-sidebar-toggle" aria-expanded="false" aria-label="{{t 'search_result_type_menu'}}">
             <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" focusable="false" viewBox="0 0 12 12" aria-hidden="true" class="collapsible-sidebar-toggle-icon chevron-icon">
               <path fill="none" stroke="currentColor" stroke-linecap="round" d="M3 4.5l2.6 2.6c.2.2.5.2.7 0L9 4.5"/>
@@ -69,7 +69,7 @@
         </section>
       {{/if}}
       {{#if subfilters}}
-        <section class="filters-in-section collapsible-sidebar" aria-expanded="false">
+        <section class="filters-in-section collapsible-sidebar">
           <button type="button" class="collapsible-sidebar-toggle" aria-expanded="false" aria-label="{{t 'search_result_subfilter_menu'}}">
             <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" focusable="false" viewBox="0 0 12 12" aria-hidden="true" class="collapsible-sidebar-toggle-icon chevron-icon">
               <path fill="none" stroke="currentColor" stroke-linecap="round" d="M3 4.5l2.6 2.6c.2.2.5.2.7 0L9 4.5"/>
@@ -107,7 +107,7 @@
         </section>
       {{/if}}
       {{#if content_tag_filters}}
-        <section class="filters-in-section collapsible-sidebar" aria-expanded="false">
+        <section class="filters-in-section collapsible-sidebar">
           <button type="button" class="collapsible-sidebar-toggle" aria-expanded="false">
             <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" focusable="false" viewBox="0 0 12 12" aria-hidden="true" class="collapsible-sidebar-toggle-icon chevron-icon">
               <path fill="none" stroke="currentColor" stroke-linecap="round" d="M3 4.5l2.6 2.6c.2.2.5.2.7 0L9 4.5"/>


### PR DESCRIPTION
## Description

This jira [ticket](https://zendesk.atlassian.net/browse/GA11YFIX-99) suggests to remove aria-expanded on section as it is not allowed on this tag. Although I could not see any difference using voiceover, as the issue with collapsed button label in mobile view which is described in the comment was fixed here https://github.com/zendesk/copenhagen_theme/pull/296. It's better to remove areia-expanded on sectoin anyway.

I'm not sure why lighthouse check is breaking for new post page but it has failed for other recent [merges](https://github.com/zendesk/copenhagen_theme/actions) as well.

<!-- a summary of the changes introduced by this PR and the motivation behind them -->

## Screenshots

<!-- (optional) when applicable, please include some screenshots or gifs that illustrate the changes -->

## Checklist

- [x] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [x] :nail_care: SASS files are compiled
- [x] :arrow_left: changes are compatible with RTL direction
- [x] :wheelchair: changes are accessible
- [x] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [x] :iphone: changes are responsive and tested in mobile
- [x] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->