### PR TITLE
[GG-2903] Increase contrast ratio for more theme elements

### DIFF
--- a/style.css
+++ b/style.css
@@ -590,6 +590,7 @@ ul {
 
 .form-field .nesty-input {
   border-radius: 4px;
+  border: 1px solid #87929D;
   height: 40px;
   line-height: 40px;
   outline: none;
@@ -599,6 +600,10 @@ ul {
 .form-field .nesty-input:focus {
   border: 1px solid $brand_color;
   text-decoration: none;
+}
+
+.form-field .hc-multiselect-toggle {
+  border: 1px solid #87929D;
 }
 
 .form-field .hc-multiselect-toggle:focus {
@@ -5058,7 +5063,7 @@ html[dir="rtl"] .notification-left-aligned {
 
 .dropdown-menu {
   background: #fff;
-  border: 1px solid #d8d8d8;
+  border: 1px solid #87929D;
   border-radius: 3px;
   box-shadow: 0 1px 5px rgba(0, 0, 0, 0.1);
   display: none;
@@ -5193,4 +5198,14 @@ html[dir="rtl"] .notification-left-aligned {
 
 .content-tag-list li:last-child {
   border: none;
+}
+
+/***** WYSIWYG Editor *****/
+#hc-wysiwyg {
+  border: 1px solid #87929D;
+}
+
+/***** Upload Dropzone *****/
+.upload-dropzone {
+  border: 1px solid #87929D;
 }

--- a/styles/_dropdowns.scss
+++ b/styles/_dropdowns.scss
@@ -23,7 +23,7 @@
 
 .dropdown-menu {
   background: #fff;
-  border: 1px solid rgb(216, 216, 216);
+  border: 1px solid $high-contrast-border-color;
   border-radius: 3px;
   box-shadow: 0 1px 5px rgba(0, 0, 0 , .1);
   display: none;

--- a/styles/_forms.scss
+++ b/styles/_forms.scss
@@ -37,6 +37,7 @@
 // Select box
 .form-field .nesty-input {
   border-radius: 4px;
+  border: 1px solid $high-contrast-border-color;
   height: 40px;
   line-height: 40px;
   outline: none;
@@ -45,6 +46,12 @@
   &:focus {
     border: 1px solid $brand_color;
     text-decoration: none;
+  }
+}
+
+.form-field .hc-multiselect {
+  &-toggle {
+    border: 1px solid $high-contrast-border-color;
   }
 }
 

--- a/styles/_upload_dropzone.scss
+++ b/styles/_upload_dropzone.scss
@@ -1,0 +1,4 @@
+/***** Upload Dropzone *****/
+.upload-dropzone {
+  border: 1px solid $high-contrast-border-color;
+}

--- a/styles/_wysiwyg.scss
+++ b/styles/_wysiwyg.scss
@@ -1,0 +1,4 @@
+/***** WYSIWYG Editor *****/
+#hc-wysiwyg {
+  border: 1px solid $high-contrast-border-color;
+}

--- a/styles/index.scss
+++ b/styles/index.scss
@@ -41,3 +41,5 @@
 @import "notifications";
 @import "dropdowns";
 @import "content-tags";
+@import "wysiwyg";
+@import "upload_dropzone";


### PR DESCRIPTION
Initially I added these changes to Help Center directly. It turns out that doing so would amount to a breaking change for customers who assume that these elements will remain the same color in their custom themes. To err on the side of caution, I am adding them to the Copenhagen theme instead.

## Description

Follow up to https://github.com/zendesk/copenhagen_theme/pull/333

Initially I added these changes to Help Center directly. It turns out that doing so would amount to a breaking change for customers who assume that these elements will remain the same color in their custom themes. To err on the side of caution, I am adding them to the Copenhagen theme instead.

## Screenshots

<img width="537" alt="Screenshot 2022-12-12 at 16 13 57" src="https://user-images.githubusercontent.com/1755162/207081842-b82ceb4c-01e3-44d7-8028-831b161e1b94.png">

## Checklist

- [x] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [x] :nail_care: SASS files are compiled
- [x] :arrow_left: changes are compatible with RTL direction
- [x] :wheelchair: changes are accessible
- [x] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [x] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->