### PR TITLE
refactor(badges): remove badge icon https check

### DIFF
--- a/templates/article_page.hbs
+++ b/templates/article_page.hbs
@@ -244,18 +244,7 @@
                           </div>
 
                           <div aria-label="{{t 'badges'}}" class="community-badge-container-achievements">
-                            {{#each (
-                              slice
-                                (
-                                  filter
-                                    (filter author.badges on="category_slug" equals="achievements")
-                                    on="icon_url"
-                                    starts_with="https"
-                                )
-                                0
-                                4
-                              )
-                            }}
+                            {{#each (slice (filter author.badges on="category_slug" equals="achievements") 0 4)}}
                               <div class="community-badge community-badge-achievements">
                                 <img src="{{icon_url}}" alt="{{name}}" title="{{name}} | {{description}}" />
                               </div>

--- a/templates/community_post_page.hbs
+++ b/templates/community_post_page.hbs
@@ -80,18 +80,7 @@
                   {{/if}}
                 </div>
                 <div class="community-badge-container-achievements">
-                  {{#each (
-                    slice
-                      (
-                        filter
-                          (filter post.author.badges on="category_slug" equals="achievements")
-                          on="icon_url"
-                          starts_with="https"
-                      )
-                      0
-                      4
-                    )
-                  }}
+                  {{#each (slice (filter post.author.badges on="category_slug" equals="achievements") 0 4)}}
                     <div class="community-badge community-badge-achievements">
                       <img src="{{icon_url}}" alt="{{name}}" title="{{name}} | {{description}}" />
                     </div>
@@ -250,18 +239,7 @@
                     </div>
 
                     <div aria-label="{{t 'badges'}}" class="community-badge-container-achievements">
-                      {{#each (
-                        slice
-                          (
-                            filter
-                              (filter author.badges on="category_slug" equals="achievements")
-                              on="icon_url"
-                              starts_with="https"
-                          )
-                          0
-                          4
-                        )
-                      }}
+                      {{#each (slice (filter author.badges on="category_slug" equals="achievements") 0 4)}}
                         <div class="community-badge community-badge-achievements">
                           <img src="{{icon_url}}" alt="{{name}}" title="{{name}} | {{description}}" />
                         </div>

--- a/templates/user_profile_page.hbs
+++ b/templates/user_profile_page.hbs
@@ -27,18 +27,7 @@
           {{/each}}
         </div>
         <div aria-label="{{t 'badges'}}" class="community-badge-container-achievements">
-          {{#each (
-            slice
-              (
-                filter
-                  (filter user.badges on="category_slug" equals="achievements")
-                  on="icon_url"
-                  starts_with="https"
-              )
-              0
-              4
-            )
-          }}
+          {{#each (slice (filter user.badges on="category_slug" equals="achievements") 0 4)}}
             <div class="community-badge community-badge-achievements">
               <img src="{{icon_url}}" alt="{{name}}" title="{{name}} | {{description}}" />
             </div>


### PR DESCRIPTION
## Description

This PR removes the user badge filter on icons that are served with `https`. User badge icons should be served with `https` by default.

## Checklist

- [x] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [x] :nail_care: SASS files are compiled
- [x] :arrow_left: changes are compatible with RTL direction
- [x] :wheelchair: changes are accessible
- [x] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [x] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->