### PR TITLE
feat: Add a11y to new-post field error messages

### DIFF
--- a/templates/new_community_post_page.hbs
+++ b/templates/new_community_post_page.hbs
@@ -25,9 +25,9 @@
             {{t 'title_label'}}<span class="optional">({{t 'optional'}})</span>
           {{/label}}
         {{/required}}
-        {{input 'title' autofocus=true}}
+        {{input 'title' autofocus=true aria-describedby='title-error-notification'}}
         {{#validate 'title'}}
-          <div class="notification notification-error notification-inline">
+          <div id="title-error-notification" class="notification notification-error notification-inline">
             {{error 'title'}}
           </div>
         {{/validate}}
@@ -43,9 +43,9 @@
             {{t 'details_label'}}<span class="optional">({{t 'optional'}})</span>
           {{/label}}
         {{/required}}
-        {{wysiwyg 'details'}}
+        {{wysiwyg 'details' aria-describedby="details-error-notification"}}
         {{#validate 'details'}}
-          <div class="notification notification-error notification-inline">
+          <div id="details-error-notification" class="notification notification-error notification-inline">
             {{error 'details'}}
           </div>
         {{/validate}}
@@ -59,9 +59,9 @@
             {{t 'topic_label'}}<span class="optional">({{t 'optional'}})</span>
           {{/label}}
         {{/required}}
-        {{select 'topic'}}
+        {{select 'topic' aria-describedby="topic-error-notification"}}
         {{#validate 'topic'}}
-          <div class="notification notification-error notification-inline">
+          <div id="topic-error-notification" class="notification notification-error notification-inline">
             {{error 'topic'}}
           </div>
         {{/validate}}
@@ -76,9 +76,9 @@
           {{/label}}
         {{/required}}
         <span class="content-tags-add-hint">{{t 'content_tags_description'}}</span>
-        {{multiselect 'content_tags'}}
+        {{multiselect 'content_tags' aria-describedby='content-tags-error-notification'}}
         {{#validate 'content_tags'}}
-          <div class="notification notification-error notification-inline">
+          <div id="content-tags-error-notification" class="notification notification-error notification-inline">
             {{error 'content_tags'}}
           </div>
         {{/validate}}


### PR DESCRIPTION
## Description

Improves accessibility by adding id attributes and aria-describedby attributes on the fields of the new-post form.

## Screenshots

<!-- (optional) when applicable, please include some screenshots or gifs that illustrate the changes -->

## Checklist

- [x] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [x] :nail_care: SASS files are compiled
- [x] :arrow_left: changes are compatible with RTL direction
- [x] :wheelchair: changes are accessible
- [x] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [x] :iphone: changes are responsive and tested in mobile
- [x] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->