### PR TITLE
fix(badges): render badges as lists

### DIFF
--- a/style.css
+++ b/style.css
@@ -2267,7 +2267,7 @@ ul {
 }
 
 .comment-meta {
-  flex: 1 0 auto;
+  flex: 1 1 auto;
 }
 
 .comment-labels {
@@ -3101,52 +3101,29 @@ ul {
   padding: 0px 8px;
   vertical-align: top;
   white-space: nowrap;
-  display: inline-flex;
+  display: inline-block;
   line-height: 18px;
   vertical-align: middle;
 }
 
-.profile-info .community-badge-title {
-  padding: 2px 8px;
-  line-height: 20px;
+.community-badge-titles {
+  display: inline;
 }
 
-.community-badge-container-achievements {
-  display: flex;
-}
-
-.community-badge-container-achievements > .community-badge-titles {
-  margin-left: calc(28px - 0.5em);
-}
-
-[dir="rtl"] .community-badge-container-achievements > .community-badge-titles {
-  margin-right: calc(28px - 0.5em);
-}
-
-.community-name-and-title-badges {
-  display: flex;
-  flex-wrap: wrap;
-}
-
-.community-badge {
-  margin: 2px;
-}
-
-.community-badge-achievements {
+.community-badge-achievement {
   display: block;
   height: 16px;
   white-space: nowrap;
   width: 16px;
 }
 
-.profile-info .community-badge-achievements {
-  height: 40px;
-  width: 40px;
+.community-badge-achievement img {
+  width: 100%;
+  height: 100%;
 }
 
-.community-title-badges {
-  flex-basis: 100%;
-  margin-top: 15px;
+.community-badge-achievements {
+  display: flex;
 }
 
 .community-badge-achievements-rest {
@@ -3157,14 +3134,18 @@ ul {
   vertical-align: top;
 }
 
-.community-badge-achievements img {
-  width: 100%;
-  height: 100%;
+.community-badge {
+  margin: 2px;
 }
 
-.community-badge-titles img {
-  width: 20px;
-  height: 20px;
+.profile-info .community-badge-title {
+  padding: 2px 8px;
+  line-height: 20px;
+}
+
+.profile-info .community-badge-achievement {
+  height: 40px;
+  width: 40px;
 }
 
 .profile-info .community-badge-achievements-rest {
@@ -4016,6 +3997,8 @@ ul {
 .profile-header .basic-info .name {
   margin: 0;
   line-height: 25px;
+  vertical-align: middle;
+  display: inline;
 }
 
 .profile-header .options {

--- a/styles/_comments.scss
+++ b/styles/_comments.scss
@@ -85,7 +85,7 @@
   }
 
   &-meta {
-    flex: 1 0 auto;
+    flex: 1 1 auto;
   }
 
   &-labels {

--- a/styles/_community_badge.scss
+++ b/styles/_community_badge.scss
@@ -9,52 +9,29 @@
   padding: 0px 8px;
   vertical-align: top;
   white-space: nowrap;
-  display: inline-flex;
+  display: inline-block;
   line-height: 18px;
   vertical-align: middle;
 }
 
-.profile-info .community-badge-title {
-  padding: 2px 8px;
-  line-height: 20px;
+.community-badge-titles {
+  display: inline;
 }
 
-.community-badge-container-achievements {
-  display: flex;
-}
-
-.community-badge-container-achievements > .community-badge-titles {
-  margin-left: calc(28px - 0.5em);
-}
-
-[dir="rtl"] .community-badge-container-achievements > .community-badge-titles {
-  margin-right: calc(28px - 0.5em);
-}
-
-.community-name-and-title-badges {
-  display: flex;
-  flex-wrap: wrap;
-}
-
-.community-badge {
-  margin: 2px;
-}
-
-.community-badge-achievements {
+.community-badge-achievement {
   display: block;
   height: 16px;
   white-space: nowrap;
   width: 16px;
+
+  img {
+    width: 100%;
+    height: 100%;
+  }
 }
 
-.profile-info .community-badge-achievements {
-  height: 40px;
-  width: 40px;
-}
-
-.community-title-badges {
-  flex-basis: 100%;
-  margin-top: 15px;
+.community-badge-achievements {
+  display: flex;
 }
 
 .community-badge-achievements-rest {
@@ -65,17 +42,23 @@
   vertical-align: top;
 }
 
-.community-badge-achievements img {
-  width: 100%;
-  height: 100%;
+.community-badge {
+  margin: 2px;
 }
 
-.community-badge-titles img {
-  width: 20px;
-  height: 20px;
-}
+.profile-info {
+  .community-badge-title {
+    padding: 2px 8px;
+    line-height: 20px;
+  }
 
-.profile-info .community-badge-achievements-rest {
-  line-height: 40px;
-  font-size: 20px;
+  .community-badge-achievement {
+    height: 40px;
+    width: 40px;
+  }
+
+  .community-badge-achievements-rest {
+    line-height: 40px;
+    font-size: 20px;
+  }
 }

--- a/styles/_user-profiles.scss
+++ b/styles/_user-profiles.scss
@@ -57,6 +57,8 @@
   .name {
     margin: 0;
     line-height: 25px;
+    vertical-align: middle;
+    display: inline;
   }
 }
 

--- a/templates/article_page.hbs
+++ b/templates/article_page.hbs
@@ -226,13 +226,13 @@
                             {{/link}}
                           </span>
 
-                          <span aria-label="{{t 'badges'}}" class="community-badge community-badge-titles">
+                          <ul aria-label="{{t 'badges'}}" class="community-badge-titles">
                             {{#each (filter author.badges on="category_slug" equals="titles")}}
-                              <div class="community-badge community-badge-title" title="{{description}}" aria-label="{{name}}">
+                              <li class="community-badge community-badge-title" title="{{description}}" aria-label="{{name}}">
                                 {{name}}
-                              </div>
+                              </li>
                             {{/each}}
-                          </span>
+                          </ul>
 
                           <div class="meta-group meta-group-opposite">
                             {{#if editor}}
@@ -243,21 +243,21 @@
                             {{/if}}
                           </div>
 
-                          <div aria-label="{{t 'badges'}}" class="community-badge-container-achievements">
+                          <ul aria-label="{{t 'badges'}}" class="community-badge-achievements">
                             {{#each (slice (filter author.badges on="category_slug" equals="achievements") 0 4)}}
-                              <div class="community-badge community-badge-achievements">
+                              <li class="community-badge community-badge-achievement">
                                 <img src="{{icon_url}}" alt="{{name}}" title="{{name}} | {{description}}" />
-                              </div>
+                              </li>
                             {{/each}}
 
                             {{#if (compare (calc author.badges.length "-" 4) ">" 0)}}
-                              <div class="community-badge community-badge-achievements">
+                              <li class="community-badge community-badge-achievement">
                                 <a href="{{page_path "user_profile" id=author.id filter_by="badges"}}" class="community-badge-achievements-rest"  aria-label="{{t 'more_awards_to' count=(calc author.badges.length "-" 4) name=author.name}}">
                                   {{t 'plus_more' count=(calc author.badges.length "-" 4)}}
                                 </a>
-                              </div>
+                              </li>
                             {{/if}}
-                          </div>
+                          </ul>
                         </div>
                         <div class="comment-labels">
                           {{#with ticket}}

--- a/templates/community_post_page.hbs
+++ b/templates/community_post_page.hbs
@@ -63,13 +63,13 @@
                   {{/link}}
                 </span>
 
-                <span class="community-badge community-badge-titles">
+                <ul  aria-label="{{t 'badges'}}" class="community-badge-titles">
                   {{#each (filter post.author.badges on="category_slug" equals="titles")}}
-                    <div class="community-badge community-badge-title" title="{{description}}" aria-label="{{name}}">
+                    <li class="community-badge community-badge-title" title="{{description}}" aria-label="{{name}}">
                       {{name}}
-                    </div>
+                    </li>
                   {{/each}}
-                </span>
+                </ul>
 
                 <div class="meta-group meta-group-opposite">
                   {{#if post.editor}}
@@ -79,22 +79,22 @@
                     <span class="meta-data">{{date post.created_at timeago=true}}</span>
                   {{/if}}
                 </div>
-                <div class="community-badge-container-achievements">
+                <ul aria-label="{{t 'badges'}}" class="community-badge-achievements">
                   {{#each (slice (filter post.author.badges on="category_slug" equals="achievements") 0 4)}}
-                    <div class="community-badge community-badge-achievements">
+                    <li class="community-badge community-badge-achievement">
                       <img src="{{icon_url}}" alt="{{name}}" title="{{name}} | {{description}}" />
-                    </div>
+                    </li>
                   {{/each}}
 
                   {{#if (compare (calc post.author.badges.length "-" 4) ">" 0)}}
-                    <div class="community-badge community-badge-achievements">
+                    <li class="community-badge community-badge-achievement">
                       <a href="{{page_path "user_profile" id=post.author.id filter_by="badges"}}" class="community-badge-achievements-rest"  aria-label="{{t 'more_awards_to' count=(calc post.author.badges.length "-" 4) name=post.author.name}}">
                         {{t 'plus_more' count=(calc post.author.badges.length "-" 4)}}
                       </a>
-                    </div>
+                    </li>
                   {{/if}}
 
-                </div>
+                </ul>
               </div>
 
               {{#if post.pending}}
@@ -221,13 +221,13 @@
                       {{/link}}
                     </span>
 
-                    <span aria-label="{{t 'badges'}}" class="community-badge community-badge-titles">
+                    <ul aria-label="{{t 'badges'}}" class="community-badge-titles">
                       {{#each (filter author.badges on="category_slug" equals="titles")}}
-                        <div class="community-badge community-badge-title" title="{{description}}" aria-label="{{name}}">
+                        <li class="community-badge community-badge-title" title="{{description}}" aria-label="{{name}}">
                           {{name}}
-                        </div>
+                        </li>
                       {{/each}}
-                    </span>
+                    </ul>
 
                     <div class="meta-group meta-group-opposite">
                       {{#if editor}}
@@ -238,21 +238,21 @@
                       {{/if}}
                     </div>
 
-                    <div aria-label="{{t 'badges'}}" class="community-badge-container-achievements">
+                    <ul aria-label="{{t 'badges'}}" class="community-badge-achievements">
                       {{#each (slice (filter author.badges on="category_slug" equals="achievements") 0 4)}}
-                        <div class="community-badge community-badge-achievements">
+                        <li class="community-badge community-badge-achievement">
                           <img src="{{icon_url}}" alt="{{name}}" title="{{name}} | {{description}}" />
-                        </div>
+                        </li>
                       {{/each}}
 
                       {{#if (compare (calc author.badges.length "-" 4) ">" 0)}}
-                        <div class="community-badge community-badge-achievements">
+                        <li class="community-badge community-badge-achievement">
                           <a href="{{page_path "user_profile" id=author.id filter_by="badges"}}" class="community-badge-achievements-rest"  aria-label="{{t 'more_awards_to' count=(calc author.badges.length "-" 4) name=author.name}}">
                             {{t 'plus_more' count=(calc author.badges.length "-" 4)}}
                           </a>
-                        </div>
+                        </li>
                       {{/if}}
-                    </div>
+                    </ul>
 
                   </div>
                   <div class="comment-labels">

--- a/templates/user_profile_page.hbs
+++ b/templates/user_profile_page.hbs
@@ -19,28 +19,29 @@
             {{/if}}
           </h1>
 
-          <div hidden="true" aria-label="{{t 'badges'}}"></div>
-          {{#each (filter user.badges on="category_slug" equals="titles")}}
-            <span class="community-badge community-badge-title" title="{{description}}" aria-label="{{name}}">
-              {{name}}
-            </span>
-          {{/each}}
+          <ul aria-label="{{t 'badges'}}" class="community-badge-titles">
+            {{#each (filter user.badges on="category_slug" equals="titles")}}
+              <li class="community-badge community-badge-title" title="{{description}}" aria-label="{{name}}">
+                {{name}}
+              </li>
+            {{/each}}
+          </ul>
         </div>
-        <div aria-label="{{t 'badges'}}" class="community-badge-container-achievements">
+        <ul aria-label="{{t 'badges'}}" class="community-badge-achievements">
           {{#each (slice (filter user.badges on="category_slug" equals="achievements") 0 4)}}
-            <div class="community-badge community-badge-achievements">
+            <li class="community-badge community-badge-achievement">
               <img src="{{icon_url}}" alt="{{name}}" title="{{name}} | {{description}}" />
-            </div>
+            </li>
           {{/each}}
 
           {{#if (compare (calc user.badges.length "-" 4) ">" 0)}}
-            <div class="community-badge community-badge-achievements">
+            <li class="community-badge community-badge-achievement">
               <a href="{{page_path "user_profile" id=user.id filter_by="badges"}}" class="community-badge-achievements-rest" aria-label="{{t 'more_awards_to' count=(calc user.badges.length "-" 4) name=user.name}}">
                 {{t 'plus_more' count=(calc user.badges.length "-" 4)}}
               </a>
-            </div>
+            </li>
           {{/if}}
-        </div>
+        </ul>
       </div>
       <div class="options">
         {{#if private_profile}}


### PR DESCRIPTION
## Description

Lighthouse reports the following a11y issue when rendering badges:

```
❌ aria-allowed-attr: `[aria-*]` attributes do not match their roles
Each ARIA `role` supports a specific subset of `aria-*` attributes. Mismatching these invalidates the `aria-*` attributes. [Learn more](https://web.dev/aria-allowed-attr/).

{
  url: 'https://***.zendesk.com/hc/en-us/articles/360010829359',
  selector: 'div.comment-info > div.comment-author > div.comment-meta > span.community-badge',
  snippet: '<span aria-label="Badges" class="community-badge community-badge-titles">'
}

Fix all of the following:
  aria-label attribute cannot be used on a span with no valid role attribute.
```

This PR:
- Updates user badges to be rendered as lists;
- Removes unused styles;
- Fixes rendering of user badges inside the comment list for smaller screens (see screenshots);

## Screenshots

<details>
<summary> Click here to see the before/after screenshots </summary>
<br>

### Article Comments (before)
<img width="1792" alt="Before - Article Page" src="https://user-images.githubusercontent.com/1172767/217014753-75340b8c-f303-481d-bdec-89774e881bcc.png">

### Article Comments (after)
<img width="1792" alt="After - Article Page" src="https://user-images.githubusercontent.com/1172767/217014781-e46627b5-6e19-49fa-ab45-5d521e930978.png">

### Post Comments (before)
<img width="1792" alt="Before - Post Page" src="https://user-images.githubusercontent.com/1172767/217014799-d3265052-060f-4f7e-94ae-93e08e396396.png">

### Post Comments (after)
<img width="1792" alt="After - Post Page" src="https://user-images.githubusercontent.com/1172767/217014857-aa182cdd-705d-499f-8864-260b95620803.png">

### Profile - multiple badges (before)
<img width="1792" alt="Before - Profile Page (many)" src="https://user-images.githubusercontent.com/1172767/217014919-c246ae86-ead1-4ecc-8d29-637669803f1a.png">


### Profile - multiple badges (after)
<img width="1792" alt="After - Profile Page (many)" src="https://user-images.githubusercontent.com/1172767/217014950-179146ef-8002-43f5-bc50-add43297fd59.png">

### Profile - one badge (before)
<img width="1792" alt="Before - Profile Page (one)" src="https://user-images.githubusercontent.com/1172767/217015019-e3326195-acc8-45c1-b5b6-69b0251a33a7.png">


### Profile - one badge (after)
<img width="1792" alt="After - Profile Page (one)" src="https://user-images.githubusercontent.com/1172767/217015059-4820eb80-19c4-4617-b483-c889d1de3610.png">


### Profile - no badges (before)
<img width="1792" alt="Before - Profile Page (none)" src="https://user-images.githubusercontent.com/1172767/217015094-dfc8b905-ca93-44b6-89d3-f721cfabaf1e.png">


### Profile - no badges (after)
<img width="1792" alt="After - Profile Page (none)" src="https://user-images.githubusercontent.com/1172767/217015123-f12df43c-62d1-4bec-a4ef-cbe68f7128d9.png">


### Comments - responsive (before)
<img width="450" alt="Before - Comments (responsive)" src="https://user-images.githubusercontent.com/1172767/217015157-129c6885-cd33-4eb8-bedc-3c1384f2fc7d.png">


### Comments - responsive (after)
<img width="458" alt="After - Comments (responsive)" src="https://user-images.githubusercontent.com/1172767/217015184-5a822108-41e7-457f-9d42-fe07ce56acca.png">


### Profile - responsive (before)
<img width="468" alt="Before - Profile (responsive)" src="https://user-images.githubusercontent.com/1172767/217015232-08d95a1a-3163-4576-97c9-306d000efc65.png">


### Profile - responsive (after)
<img width="461" alt="After - Profile (responsive)" src="https://user-images.githubusercontent.com/1172767/217015255-367f328c-2816-4cc9-badd-64c272a0a833.png">

### No badges - Voice Over (before)
<img width="994" alt="Before - Voice Over (no badges)" src="https://user-images.githubusercontent.com/1172767/217020041-d3d01dfb-afad-4835-8f41-7a9601436853.png">

### No badges - Voice Over (after)
<img width="1048" alt="After - Voice Over (no badges)" src="https://user-images.githubusercontent.com/1172767/217020089-d90131ad-f7ed-428a-9d2c-568de5ad3f31.png">


### Badges - Voice Over (before)
<img width="1241" alt="Before - Voice Over (badges)" src="https://user-images.githubusercontent.com/1172767/217020109-0ff075d2-6847-4737-9dce-4a2ecc528a16.png">


### Badges - Voice Over (after)
<img width="1006" alt="After - Voice Over (badges)" src="https://user-images.githubusercontent.com/1172767/217020150-5d2a50a4-274a-4e51-8fee-62526e910595.png">


</details>

## Checklist

- [x] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [x] :nail_care: SASS files are compiled
- [x] :arrow_left: changes are compatible with RTL direction
- [x] :wheelchair: changes are accessible
- [x] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [x] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->