### PR TITLE
fix: improve the accessibility of the breadcrumbs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,7 +9,6 @@
 ## Checklist
 
 - [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
-- [ ] :nail_care: SASS files are compiled
 - [ ] :arrow_left: changes are compatible with RTL direction
 - [ ] :wheelchair: changes are accessible and [tested locally](./../README.md#accessibility-testing)
 - [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge

--- a/styles/_breadcrumbs.scss
+++ b/styles/_breadcrumbs.scss
@@ -6,10 +6,10 @@
 
   margin: 0 0 15px 0;
   padding: 0;
+  display: flex;
 
   li {
     color: $secondary-text-color;
-    display: inline;
     font-size: $font-size-small;
     max-width: 450px;
     overflow: hidden;

--- a/styles/_search_results.scss
+++ b/styles/_search_results.scss
@@ -133,51 +133,7 @@
       &:first-child {
         border-top: 1px solid $low-contrast-border-color;
       }
-
-      h2 {
-        margin-bottom: 0;
-      }
     }
-  }
-
-  .meta-group {
-    display: block;
-    @include desktop { display: flex; }
-    align-items: center;
-    clear: both;
-    color: #666;
-
-    > span {
-      display: block;
-      @include desktop { display: inline }
-    }
-
-    span:first-child {
-      @include desktop { flex: 1; }
-    }
-
-    .meta-data {
-      color: inherit;
-
-      &:not(:last-child) {
-        [dir="ltr"] & {
-          margin-right: 20px;
-        }
-
-        [dir="rtl"] & {
-          margin-left: 20px;
-        }
-      }
-
-      &::after {
-        content: none;
-      }
-    }
-  }
-
-  &-description {
-    margin-top: 10px;
-    word-break: break-word;
   }
 
   .no-results {
@@ -202,10 +158,10 @@
       letter-spacing: -0.154px;
 
       a {
-        color: #1F73B7;
+        color: $link_color;
 
         &:visited {
-          color: #1F73B7;
+          color: $link_color;
         }
       }
     }
@@ -213,29 +169,21 @@
 }
 
 .search-result {
+  &-title-container {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
 
   &-title {
     font-size: $font-size-bigger;
-    display: inline-block;
-  }
-
-  &-icons {
-    [dir="ltr"] & {
-      float: right;
-    }
-
-    [dir="rtl"] & {
-      float: left;
-    }
+    margin-bottom: 0;
   }
 
   &-votes,
   &-meta-count {
     color: $secondary-text-color;
-    display: inline-block;
     font-size: $font-size-small;
-    padding: 4px 5px;
-    position: relative;
 
     &-icon {
       color: $brand_color;
@@ -245,31 +193,51 @@
     }
 
     [dir="ltr"] & {
-      margin-left: 5px;
-      &::before {
-        margin-right: 3px;
-      }
+      margin-left: 20px;
     }
 
     [dir="rtl"] & {
-      margin-right: 5px;
-      &::before {
-        margin-left: 3px;
+      margin-right: 20px;
+    }
+  }
+
+  &-meta-container {
+    color: #666;
+    display: flex;
+    flex-direction: column;
+
+    @include desktop {
+      flex-direction: row;
+      align-items: center;
+    }
+
+    nav {
+      @include desktop { flex: 1; }
+    }
+
+    .meta-data {
+      [dir="ltr"] & {
+        @include desktop { margin-left: 20px; }
+      }
+
+      [dir="rtl"] & {
+        @include desktop { margin-right: 20px; }
+      }
+
+      &::after {
+        content: none;
       }
     }
   }
 
-  .meta-group {
-    align-items: center;
+  &-breadcrumbs {
+    margin: 0;
   }
 
-  &-breadcrumbs {
-    @include desktop { display: table-row; }
-    margin: 0;
-
-    li {
-      @include desktop { display: table-cell; }
-    }
+  &-description {
+    margin-top: 10px;
+    margin-bottom: 0;
+    word-break: break-word;
   }
 }
 

--- a/templates/search_results.hbs
+++ b/templates/search_results.hbs
@@ -168,64 +168,68 @@
       {{#if results}}
         <ul class="search-results-list">
           {{#each results}}
-            <li class="search-result-list-item result-{{type}}">
-              <h2 class="search-result-title">
-                <a href="{{url}}" class="results-list-item-link"  {{#if is_external}} target="_blank" {{/if}}>
-                  {{title}}
-                  {{#if is_external}}
-                    <svg viewBox="0 0 12 12" height="12" id="zd-svg-icon-12-new-window-fill">
-                      <path fill="none" stroke="currentColor" stroke-linecap="round" d="M10.5 8.5V10c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V2c0-.28.22-.5.5-.5h1.5M6 6l4-4"></path>
-                      <path fill="currentColor" d="M10.5 6.5a.47.47 0 0 1-.35-.15l-4.5-4.5a.474.474 0 0 1-.11-.54C5.62 1.12 5.8 1 6 1h4c.55 0 1 .45 1 1v4c0 .2-.12.38-.31.46-.06.03-.13.04-.19.04z"></path>
-                    </svg>
-                  {{/if}}
-                </a>
-              </h2>
-              <div class="search-result-icons">
-                {{#if vote_sum}}
-                  <span class="search-result-votes">
-                    <span class="visibility-hidden">
-                      {{t 'votes_sum' count=vote_sum}}
-                    </span>
-                    <span aria-hidden="true">
-                      <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" focusable="false" viewBox="0 0 12 12" class="search-result-votes-icon">
-                        <g fill="none" stroke="currentColor">
-                          <path stroke-linejoin="round" d="M10.77 4.5a.73.73 0 01.73.73C11.43 7 11.21 11.5 10 11.5H5a.5.5 0 01-.5-.5V4.5s1-.5 1-3a1 1 0 012 0v3z"/>
-                          <rect width="2" height="7" x=".5" y="4.5" rx=".5" ry=".5"/>
-                        </g>
-                      </svg>
-                      {{vote_sum}}
-                    </span>
-                  </span>
-                {{/if}}
-                {{#if comment_count}}
-                  <span class="search-result-meta-count">
-                    <span class="visibility-hidden">
-                      {{t 'comments_count' count=comment_count}}
-                    </span>
-                    <span aria-hidden="true">
-                      <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" focusable="false" viewBox="0 0 12 12" class="search-result-meta-count-icon">
-                        <path fill="none" stroke="currentColor" d="M1 .5h10c.3 0 .5.2.5.5v7c0 .3-.2.5-.5.5H6l-2.6 2.6c-.3.3-.9.1-.9-.4V8.5H1C.7 8.5.5 8.3.5 8V1C.5.7.7.5 1 .5z"/>
-                      </svg>
-                      {{comment_count}}
-                    </span>
-                  </span>
-                {{/if}}
-              </div>
+            <li>
               <article>
-                <div class="meta-group">
-                  <span>
-                    <ol class="breadcrumbs search-result-breadcrumbs">
-                      {{#each path_steps}}
-                        <li title="{{name}}"><a href="{{url}}" target="{{target}}">{{name}}</a></li>
-                      {{/each}}
-                    </ol>
-                  </span>
-                  {{#unless is_external}}
-                    <span class="meta-data">{{author.name}}</span>
-                  {{/unless}}
-                  <span class="meta-data">{{date created_at}}</span>
-                </div>
-                <div class="search-results-description">{{text}}</div>
+                <header>
+                  <div class="search-result-title-container">
+                    <h2 class="search-result-title">
+                      <a href="{{url}}" {{#if is_external}} target="_blank" {{/if}}>
+                        {{title}}
+                        {{#if is_external}}
+                          <svg viewBox="0 0 12 12" height="12" id="zd-svg-icon-12-new-window-fill">
+                            <path fill="none" stroke="currentColor" stroke-linecap="round" d="M10.5 8.5V10c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V2c0-.28.22-.5.5-.5h1.5M6 6l4-4"></path>
+                            <path fill="currentColor" d="M10.5 6.5a.47.47 0 0 1-.35-.15l-4.5-4.5a.474.474 0 0 1-.11-.54C5.62 1.12 5.8 1 6 1h4c.55 0 1 .45 1 1v4c0 .2-.12.38-.31.46-.06.03-.13.04-.19.04z"></path>
+                          </svg>
+                        {{/if}}
+                      </a>
+                    </h2>
+                    <div class="search-result-icons">
+                      {{#if vote_sum}}
+                        <span class="search-result-votes">
+                          <span class="visibility-hidden">
+                            {{t 'votes_sum' count=vote_sum}}
+                          </span>
+                          <span aria-hidden="true">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" focusable="false" viewBox="0 0 12 12" class="search-result-votes-icon">
+                              <g fill="none" stroke="currentColor">
+                                <path stroke-linejoin="round" d="M10.77 4.5a.73.73 0 01.73.73C11.43 7 11.21 11.5 10 11.5H5a.5.5 0 01-.5-.5V4.5s1-.5 1-3a1 1 0 012 0v3z"/>
+                                <rect width="2" height="7" x=".5" y="4.5" rx=".5" ry=".5"/>
+                              </g>
+                            </svg>
+                            {{vote_sum}}
+                          </span>
+                        </span>
+                      {{/if}}
+                      {{#if comment_count}}
+                        <span class="search-result-meta-count">
+                          <span class="visibility-hidden">
+                            {{t 'comments_count' count=comment_count}}
+                          </span>
+                          <span aria-hidden="true">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" focusable="false" viewBox="0 0 12 12" class="search-result-meta-count-icon">
+                              <path fill="none" stroke="currentColor" d="M1 .5h10c.3 0 .5.2.5.5v7c0 .3-.2.5-.5.5H6l-2.6 2.6c-.3.3-.9.1-.9-.4V8.5H1C.7 8.5.5 8.3.5 8V1C.5.7.7.5 1 .5z"/>
+                            </svg>
+                            {{comment_count}}
+                          </span>
+                        </span>
+                      {{/if}}
+                    </div>
+                  </div>
+                  <div class="search-result-meta-container">
+                    <nav aria-label="Search result location">
+                      <ol class="breadcrumbs search-result-breadcrumbs">
+                        {{#each path_steps}}
+                          <li><a href="{{url}}" target="{{target}}">{{name}}</a></li>
+                        {{/each}}
+                      </ol>
+                    </nav>
+                    {{#unless is_external}}
+                      <span class="meta-data">{{author.name}}</span>
+                    {{/unless}}
+                    <span class="meta-data">{{date created_at}}</span>
+                  </div>
+                </header>
+                <p class="search-result-description">{{text}}</p>
               </article>
             </li>
           {{/each}}

--- a/templates/user_profile_page.hbs
+++ b/templates/user_profile_page.hbs
@@ -196,11 +196,13 @@
                         {{/if}}
                       </header>
 
-                      <ol class="breadcrumbs profile-contribution-breadcrumbs">
-                        {{#each path_steps}}
-                          <li title="{{name}}"><a href="{{url}}">{{name}}</a></li>
-                        {{/each}}
-                      </ol>
+                      <nav aria-label="Activity location">
+                        <ol class="breadcrumbs profile-contribution-breadcrumbs">
+                          {{#each path_steps}}
+                            <li><a href="{{url}}">{{name}}</a></li>
+                          {{/each}}
+                        </ol>
+                      </nav>
 
                       <p class="profile-contribution-body">{{excerpt body characters=200}}</p>
 
@@ -357,11 +359,13 @@
                       {{/if}}
                     </header>
 
-                    <ol class="breadcrumbs profile-contribution-breadcrumbs">
-                      {{#each path_steps}}
-                        <li title="{{name}}"><a href="{{url}}">{{name}}</a></li>
-                      {{/each}}
-                    </ol>
+                    <nav aria-label="Contribution location">
+                      <ol class="breadcrumbs profile-contribution-breadcrumbs">
+                        {{#each path_steps}}
+                          <li><a href="{{url}}">{{name}}</a></li>
+                        {{/each}}
+                      </ol>
+                    </nav>
 
                     <p class="profile-contribution-body">{{excerpt body characters=200}}</p>
 


### PR DESCRIPTION
## Description

This PR updates the breadcrumbs in the search and user profile pages:
- it wraps breadcrumbs in a `nav` element with an `aria-label` attribute (translation to follow);
- it removes the `title` attribute from each crumb;
- it updates the search result markup;
- it fixes breadcrumbs RTL by using flex;
- it cleans up the search result styles;
- it updates the PR template as a follow up to https://github.com/zendesk/copenhagen_theme/pull/356;

## Screenshots

<details>
<summary>Click here to see the before/after screenshots</summary>

### Search results - Voice Over (after)
<img width="1308" alt="Screenshot 2023-03-08 at 16 55 08" src="https://user-images.githubusercontent.com/1172767/223763210-3c82ecfb-4671-4ee3-91b7-d0c67a81f2a6.png">

### User Profile - Voice Over (after)
<img width="1364" alt="Screenshot 2023-03-08 at 16 55 58" src="https://user-images.githubusercontent.com/1172767/223763239-f163af21-fa40-4c1d-990f-d626376b6f84.png">

### Search results - Desktop (before)
<img width="2032" alt="Screenshot 2023-03-08 at 16 41 07" src="https://user-images.githubusercontent.com/1172767/223759330-a482069b-415a-4787-888d-40b8a37e7ce9.png">

### Search results - Desktop (after)
<img width="2032" alt="Screenshot 2023-03-08 at 16 24 33" src="https://user-images.githubusercontent.com/1172767/223758728-d9f77b23-42dd-41ae-97ee-94e892c40665.png">

### Search results - Mobile (before)
<img width="377" alt="Screenshot 2023-03-08 at 16 41 27" src="https://user-images.githubusercontent.com/1172767/223759368-4b1ff9d0-2a16-4e94-9552-91ad369966c7.png">

### Search results - Mobile (after)
<img width="375" alt="Screenshot 2023-03-08 at 16 25 04" src="https://user-images.githubusercontent.com/1172767/223758776-d1c1226f-f16f-4f89-a3f9-d32a4572e068.png">

### User profile - Desktop (before)
<img width="2032" alt="Screenshot 2023-03-08 at 16 41 50" src="https://user-images.githubusercontent.com/1172767/223759393-31025642-f3a7-4bbd-8bed-5671613e621a.png">

### User profile - Desktop (after)
<img width="2032" alt="Screenshot 2023-03-08 at 16 25 37" src="https://user-images.githubusercontent.com/1172767/223758833-4f5ab165-aafa-421d-9502-883ea3045496.png">

### User profile - Mobile (before)
<img width="378" alt="Screenshot 2023-03-08 at 16 42 20" src="https://user-images.githubusercontent.com/1172767/223759433-3f7e5ebb-75ce-4c96-a11e-6f41b7e39db2.png">

### User profile - Mobile (after)
<img width="389" alt="Screenshot 2023-03-08 at 16 26 49" src="https://user-images.githubusercontent.com/1172767/223758847-a381e6b9-06a0-4596-af56-757266678200.png">

</details>

## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :nail_care: SASS files are compiled
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: changes are accessible and [tested locally](./../README.md#accessibility-testing)
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->