### PR TITLE
Specify a11y testing needs in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,7 +10,7 @@
 
 - [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
 - [ ] :arrow_left: changes are compatible with RTL direction
-- [ ] :wheelchair: changes are accessible and [tested locally](./../README.md#accessibility-testing)
+- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
 - [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
 - [ ] :iphone: changes are responsive and tested in mobile
 - [ ] :+1: PR is approved by @zendesk/vikings

--- a/README.md
+++ b/README.md
@@ -120,6 +120,9 @@ There are two ways of running the script:
 - **Development mode** - it runs the accessibility audits on the local theme preview, on a specific account. It requires `zat theme preview` to be running;
 - **CI mode** - it runs the accessibility audits on the live theme of a specific account.
 
+Depending on the scope of testing, some manual testing might be needed in addition to the above.
+Tools like [axe DevTools](https://www.deque.com/axe/devtools/), screen readers e.g. [VoiceOver](https://www.apple.com/voiceover/info/guide/_1121.html), [contrast checkers](https://webaim.org/resources/contrastchecker/) etc. can assist such testing.
+
 ## Development mode
 
 To run the accessibility audits while changing the theme, one must first preview the changes on a specific account and then run the audits on that preview. To do so:


### PR DESCRIPTION
## Description

Part of the 2023 a11y OKR is that all UI-related repos must have a11y testing guidelines in their PR template.
This repo's PR template already had a bullet point related to this 🎉  but here I'm adding some more context and a link to the generalized Guide a11y testing guidelines which will also be added in other repos' templates later on.

@zendesk/vikings 

## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: changes are accessible and [tested locally](./../README.md#accessibility-testing)
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->