### PR TITLE
fix: remove role attribute from vote helper

### DIFF
--- a/templates/article_page.hbs
+++ b/templates/article_page.hbs
@@ -150,8 +150,8 @@
           <div class="article-votes">
             <span class="article-votes-question" id="article-votes-label">{{t 'was_this_article_helpful'}}</span>
             <div class="article-votes-controls" role="group" aria-labelledby="article-votes-label">
-              {{vote 'up' role='radio' class='button article-vote article-vote-up' selected_class="button-primary"}}
-              {{vote 'down' role='radio' class='button article-vote article-vote-down' selected_class="button-primary"}}
+              {{vote 'up' class='button article-vote article-vote-up' selected_class="button-primary"}}
+              {{vote 'down' class='button article-vote article-vote-down' selected_class="button-primary"}}
             </div>
             <small class="article-votes-count">
               {{vote 'label' class='article-vote-label'}}

--- a/templates/community_post_page.hbs
+++ b/templates/community_post_page.hbs
@@ -273,13 +273,13 @@
               <div class="comment-actions-container">
                 {{#unless official}}
                   <div class="comment-vote vote" role="group">
-                    {{#vote 'up' role='radio' class='vote-up' selected_class='vote-voted' aria-describedby=(concat anchor "-author " anchor "-body")}}
+                    {{#vote 'up' class='vote-up' selected_class='vote-voted' aria-describedby=(concat anchor "-author " anchor "-body")}}
                     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" focusable="false" viewBox="0 0 16 16">
                       <path fill="none" stroke="currentColor" stroke-linecap="round" stroke-width="2" d="M4 6.5l3.6 3.6c.2.2.5.2.7 0L12 6.5"/>
                     </svg>
                     {{/vote}}
                     {{vote 'sum' class='vote-sum'}}
-                    {{#vote 'down' role='radio' class='vote-down' selected_class='vote-voted' aria-describedby=(concat anchor "-author " anchor "-body")}}
+                    {{#vote 'down' class='vote-down' selected_class='vote-voted' aria-describedby=(concat anchor "-author " anchor "-body")}}
                     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" focusable="false" viewBox="0 0 16 16">
                       <path fill="none" stroke="currentColor" stroke-linecap="round" stroke-width="2" d="M4 6.5l3.6 3.6c.2.2.5.2.7 0L12 6.5"/>
                     </svg>


### PR DESCRIPTION
## Description

This PR removed the usage of the `role` attribute in the `vote` helper, which is actually not used in Templating API v2.

## Checklist

- [x] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [x] :arrow_left: changes are compatible with RTL direction
- [x] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [x] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [x] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->