### PR TITLE
fix: disable skip-navigation link when modals show

### DIFF
--- a/styles/_header.scss
+++ b/styles/_header.scss
@@ -253,4 +253,9 @@ $header-height: 71px;
     right: auto;
   }
   }
+
+  // Disable the skip-navigation link when modals are open
+  #zd-modal-container ~ .skip-navigation {
+    display: none;
+  }
 }


### PR DESCRIPTION
## Description

Whenever modal dialogs are showing we should not display the "skip navigation" button, since this will direct browser focus onto the page content behind the modal instead of the modal contents itself.

## Screenshots

<img width="315" alt="Screenshot 2023-05-11 at 19 47 15" src="https://github.com/zendesk/copenhagen_theme/assets/6997051/90a108f3-8f1a-4235-9eb3-20b8f4a0ab54">

## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->