### PR TITLE
fix: update breadcrumbs aria-label to use translated strings

### DIFF
--- a/templates/search_results.hbs
+++ b/templates/search_results.hbs
@@ -216,7 +216,11 @@
                     </div>
                   </div>
                   <div class="search-result-meta-container">
-                    <nav aria-label="Search result location">
+                    <nav 
+                      {{#is type 'article'}}aria-label='{{t 'article_location_with_title' title=title}}'{{/is}}
+                      {{#is type 'community_post'}}aria-label='{{t 'post_location_with_title' title=title}}'{{/is}}
+                      {{#is type 'external_content_record'}}aria-label='{{t 'external_content_location_with_title' title=title}}'{{/is}}
+                    >
                       <ol class="breadcrumbs search-result-breadcrumbs">
                         {{#each path_steps}}
                           <li><a href="{{url}}" target="{{target}}">{{name}}</a></li>

--- a/templates/user_profile_page.hbs
+++ b/templates/user_profile_page.hbs
@@ -195,8 +195,11 @@
                           <span class="status-label status-label-official">{{t 'official_comment'}}</span>
                         {{/if}}
                       </header>
-
-                      <nav aria-label="Activity location">
+                      <nav
+                        {{#is object_type 'article'}}aria-label='{{t 'article_location_with_title' title=title}}'{{/is}}
+                        {{#is object_type 'post'}}aria-label='{{t 'post_location_with_title' title=title}}'{{/is}}
+                        {{#is object_type 'comment'}}aria-label='{{t 'comment_location_with_author_name' author_name=author.name}}'{{/is}}
+                      >
                         <ol class="breadcrumbs profile-contribution-breadcrumbs">
                           {{#each path_steps}}
                             <li><a href="{{url}}">{{name}}</a></li>
@@ -358,8 +361,11 @@
                         <span class="status-label status-label-official">{{t 'official_comment'}}</span>
                       {{/if}}
                     </header>
-
-                    <nav aria-label="Contribution location">
+                    <nav
+                      {{#is object_type 'article'}}aria-label='{{t 'article_location_with_title' title=title}}'{{/is}}
+                      {{#is object_type 'post'}}aria-label='{{t 'post_location_with_title' title=title}}'{{/is}}
+                      {{#is object_type 'comment'}}aria-label='{{t 'comment_location_with_author_name' author_name=author.name}}'{{/is}}
+                    >
                       <ol class="breadcrumbs profile-contribution-breadcrumbs">
                         {{#each path_steps}}
                           <li><a href="{{url}}">{{name}}</a></li>


### PR DESCRIPTION
## Description

Follow up to https://github.com/zendesk/copenhagen_theme/pull/357.

This PR updates the breadcrumbs in the user profile and search results page to use translated strings in the `aria-label`.

## Screenshots

<img width="765" alt="Screenshot 2023-06-07 at 18 50 22" src="https://github.com/zendesk/copenhagen_theme/assets/1172767/fbd2457b-0db0-481d-bc61-909a7e869011">

<!-- (optional) when applicable, please include some screenshots or gifs that illustrate the changes -->

## Checklist

- [x] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [x] :arrow_left: changes are compatible with RTL direction
- [x] :wheelchair: changes are accessible and [tested locally](./../README.md#accessibility-testing)
- [x] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [x] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->