### PR TITLE
Remove aria-expanded attribute from section tag in search result page

### DIFF
--- a/src/navigation.js
+++ b/src/navigation.js
@@ -2,12 +2,10 @@ import { ESCAPE } from "./Keys";
 
 function toggleNavigation(toggle, menu) {
   const isExpanded = menu.getAttribute("aria-expanded") === "true";
-  menu.setAttribute("aria-expanded", !isExpanded);
   toggle.setAttribute("aria-expanded", !isExpanded);
 }
 
-function closeNavigation(toggle, menu) {
-  menu.setAttribute("aria-expanded", false);
+function closeNavigation(toggle) {
   toggle.setAttribute("aria-expanded", false);
   toggle.focus();
 }
@@ -26,7 +24,7 @@ window.addEventListener("DOMContentLoaded", () => {
   menuList.addEventListener("keyup", (event) => {
     if (event.keyCode === ESCAPE) {
       event.stopPropagation();
-      closeNavigation(menuButton, menuList);
+      closeNavigation(menuButton);
     }
   });
 
@@ -47,7 +45,7 @@ window.addEventListener("DOMContentLoaded", () => {
     element.addEventListener("keyup", (event) => {
       console.log("escape");
       if (event.keyCode === ESCAPE) {
-        closeNavigation(toggle, element);
+        closeNavigation(toggle);
       }
     });
   });


### PR DESCRIPTION
## Description

This is reported by accessibility team to remove `aria-expanded` from section tag. This attribute applies to the button in the sidebar for mobile view and we don't need to have it for section. 

[Jira issue
](https://zendesk.atlassian.net/browse/GS-2334?atlOrigin=eyJpIjoiM2MyZTExODM1NWNmNDA1MDkzNWQ1MGVjYTU5MGNmZjkiLCJwIjoiamlyYS1zbGFjay1pbnQifQ)

## Checklist

- [x] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [x] :arrow_left: changes are compatible with RTL direction
- [x] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->