### PR TITLE
Prevent tabbing to skip navigation link when modals are open

### DIFF
--- a/style.css
+++ b/style.css
@@ -861,7 +861,8 @@ ul {
   left: initial;
   right: auto;
 }
-.skip-navigation #zd-modal-container ~ .skip-navigation {
+
+#zd-modal-container ~ .skip-navigation {
   display: none;
 }
 

--- a/styles/_header.scss
+++ b/styles/_header.scss
@@ -253,9 +253,9 @@ $header-height: 71px;
     right: auto;
   }
   }
+}
 
-  // Disable the skip-navigation link when modals are open
-  #zd-modal-container ~ .skip-navigation {
-    display: none;
-  }
+// Disable the skip-navigation link when modals are open
+#zd-modal-container ~ .skip-navigation {
+  display: none;
 }


### PR DESCRIPTION
## Description
Fixed tabbing a11y issue where a user was previously able to focus elements behind an open modal. 

# References
https://zendesk.atlassian.net/browse/ULTRA-745

## Screenshots
### Before
When tabbing from the URL bar we are able to focus the skip navigation link
<img width="1023" alt="Screenshot 2023-06-21 at 14 35 09" src="https://github.com/zendesk/copenhagen_theme/assets/17469404/7a8002ad-51c6-4bb4-8d66-89367ccce3bd">


### After
You can see focus on the close button instead of the link behind the modal 
<img width="1024" alt="Screenshot 2023-06-21 at 14 31 44" src="https://github.com/zendesk/copenhagen_theme/assets/17469404/fa9bbe4f-a16b-4cd3-a7eb-43d0bfbfba2f">

## Checklist

- [x] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [x] :arrow_left: changes are compatible with RTL direction
- [x] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [x] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [x] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->