### PR TITLE
Fix styling of long header

### DIFF
--- a/style.css
+++ b/style.css
@@ -1155,6 +1155,8 @@ ul {
   .page-header {
     align-items: baseline;
     flex-direction: row;
+    flex-wrap: nowrap;
+    gap: 16px;
     margin: 0;
   }
 }

--- a/styles/_page_header.scss
+++ b/styles/_page_header.scss
@@ -4,6 +4,8 @@
   @include tablet {
     align-items: baseline;
     flex-direction: row;
+    flex-wrap: nowrap;
+    gap: 16px;
     margin: 0;
   }
 


### PR DESCRIPTION
## Description
One of our customers reported that when they added a new topic with a longer title,  the `New post` button was displayed under the topic, instead of inline. This behavior was confusing and unexpected.
The new style fixes this behavior.

## Reference
- https://zendesk.atlassian.net/browse/ULTRA-850

## Screenshots

### Before 
The new post button is displayed on the next row instead of inline when the title of a new topic is very long
![z3ncriss zendesk com_hc_en-us_community_topics_5841168930586-New-topic-with-a-very-long-title-so-so-long-that-it-pushes-the-post-button-under-Yes-(iPad Mini) (1)](https://github.com/zendesk/copenhagen_theme/assets/17469404/8dc2f06f-bf83-4607-8c77-bc5b2df49bd2)

### After
The new styling shows the header and button on the same row
![z3ncriss zendesk com_hc_en-us_community_topics_5841168930586-New-topic-with-a-very-long-title-so-so-long-that-it-pushes-the-post-button-under-Yes-(iPad Mini)](https://github.com/zendesk/copenhagen_theme/assets/17469404/91761dc5-481f-444c-a0c7-778236491ef3)

## Checklist

- [x] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [x] :arrow_left: changes are compatible with RTL direction
- [x] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [x] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [x] :iphone: changes are responsive and tested in mobile
- [x] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->