### PR TITLE
Build request form using data helpers

### DIFF
--- a/templates/new_request_page.hbs
+++ b/templates/new_request_page.hbs
@@ -19,6 +19,13 @@
   </h1>
 
   <div id="main-content" class="form">
-    {{request_form wysiwyg=true}}
+    <form data-form action="{{request_form_data.action}}" method="{{request_form_data.http_method}}" accept-charset="{{request_form_data.accept_charset}}">
+      {{#if request_form_data.errors}}
+        <p>
+          {{request_form_data.errors}}
+        </p>
+      {{/if}}
+      <input type="submit" value="Submit">
+    </form>
   </div>
 </div>

--- a/templates/new_request_page.hbs
+++ b/templates/new_request_page.hbs
@@ -1,7 +1,6 @@
 <div class="container-divider"></div>
 <div class="container">
   <nav class="sub-nav">
-    {{breadcrumbs}}
     <div class="search-container">
       <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" focusable="false" viewBox="0 0 12 12" class="search-icon" aria-hidden="true">
         <circle cx="4.5" cy="4.5" r="4" fill="none" stroke="currentColor"/>
@@ -13,9 +12,6 @@
 
   <h1>
     {{t 'submit_a_request'}}
-    <span class="follow-up-hint">
-      {{follow_up}}
-    </span>
   </h1>
 
   <div id="main-content" class="form">

--- a/templates/new_request_page.hbs
+++ b/templates/new_request_page.hbs
@@ -19,13 +19,13 @@
   </h1>
 
   <div id="main-content" class="form">
-    <form data-form action="{{request_form_data.action}}" method="{{request_form_data.http_method}}" accept-charset="{{request_form_data.accept_charset}}">
-      {{#if request_form_data.errors}}
-        <p>
-          {{request_form_data.errors}}
-        </p>
-      {{/if}}
-      <input type="submit" value="Submit">
-    </form>
+    {{#with request_form}}
+      <form data-form action="{{action}}" method="{{http_method}}" accept-charset="{{accept_charset}}">
+        {{#if errors}}
+          <p>{{errors}}</p>
+        {{/if}}
+        <input type="submit" value="Submit">
+      </form>
+    {{/with}}
   </div>
 </div>


### PR DESCRIPTION
## Description

The `new_request_page` template contains now a simple form (with the submit button and potentially an error text) and uses data from `request_form_data` helper.

## Screenshots

<img width="491" alt="Screenshot 2023-07-10 at 09 44 54" src="https://github.com/zendesk/copenhagen_theme/assets/25595674/b1be8084-bc33-47ea-9bb4-aeb732f585f8">
<img width="535" alt="Screenshot 2023-07-10 at 09 44 40" src="https://github.com/zendesk/copenhagen_theme/assets/25595674/35fddcc9-cdba-4519-aef6-367068ef40af">


## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->