### PR TITLE
fix: ellipsis for very long titles

### DIFF
--- a/style.css
+++ b/style.css
@@ -1422,6 +1422,8 @@ ul {
 }
 .recent-activity-item-link {
   font-size: 14px;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 .recent-activity-item-meta {
   color: $text_color;
@@ -1498,6 +1500,7 @@ ul {
 }
 .category-content {
   flex: 1;
+  max-width: 100%;
 }
 @media (min-width: 1024px) {
   .category-content {
@@ -1518,6 +1521,7 @@ ul {
 }
 .section-tree .section {
   flex: initial;
+  max-width: 100%;
 }
 @media (min-width: 768px) {
   .section-tree .section {
@@ -1540,6 +1544,8 @@ ul {
 .article-list-item {
   font-size: 16px;
   padding: 15px 0;
+  text-overflow: ellipsis;
+  overflow: hidden;
 }
 .article-list-item a {
   color: $text_color;
@@ -1557,6 +1563,7 @@ ul {
 }
 .section-content {
   flex: 1;
+  max-width: 100%;
 }
 @media (min-width: 1024px) {
   .section-content {
@@ -1639,9 +1646,14 @@ ul {
 .article-author {
   margin-bottom: 10px;
 }
+.article-title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
 @media (min-width: 768px) {
   .article-title {
     flex-basis: 100%; /* Take entire row */
+    max-width: 100%;
   }
 }
 .article-title .icon-lock {
@@ -1811,6 +1823,7 @@ ul {
     border: 0;
     flex: 0 0 17%;
     height: auto;
+    max-width: 17%;
   }
 }
 .article-relatives {
@@ -1899,6 +1912,8 @@ ul {
   display: block;
   margin-top: 10px;
   margin-bottom: 16px;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .recent-articles li,

--- a/style.css
+++ b/style.css
@@ -1649,11 +1649,11 @@ ul {
 .article-title {
   overflow: hidden;
   text-overflow: ellipsis;
+  max-width: 100%;
 }
 @media (min-width: 768px) {
   .article-title {
     flex-basis: 100%; /* Take entire row */
-    max-width: 100%;
   }
 }
 .article-title .icon-lock {

--- a/styles/_article.scss
+++ b/styles/_article.scss
@@ -49,10 +49,10 @@
   &-title {
     overflow: hidden;
     text-overflow: ellipsis;
+    max-width: 100%;
 
     @include tablet {
       flex-basis: 100%; /* Take entire row */
-      max-width: 100%;
     }
 
     .icon-lock {

--- a/styles/_article.scss
+++ b/styles/_article.scss
@@ -47,8 +47,12 @@
   }
 
   &-title {
+    overflow: hidden;
+    text-overflow: ellipsis;
+
     @include tablet {
       flex-basis: 100%; /* Take entire row */
+      max-width: 100%;
     }
 
     .icon-lock {

--- a/styles/_article.scss
+++ b/styles/_article.scss
@@ -115,6 +115,7 @@
       border: 0;
       flex: 0 0 17%;
       height: auto;
+      max-width: 17%;
     }
 
     border-bottom: 1px solid $low-contrast-border-color;
@@ -220,6 +221,8 @@
     display: block;
     margin-top: 10px;
     margin-bottom: 16px;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 }
 

--- a/styles/_category.scss
+++ b/styles/_category.scss
@@ -11,6 +11,7 @@
     }
 
     flex: 1;
+    max-width: 100%;
   }
 }
 
@@ -24,6 +25,7 @@
   .section {
     @include tablet { flex: 0 0 45%; /* Two columns for tablet and desktop. Leaving 5% separation between columns */ }
     flex: initial;
+    max-width: 100%;
   }
 
   &-title {
@@ -44,6 +46,8 @@
   &-item {
     font-size: $font-size-bigger;
     padding: 15px 0;
+    text-overflow: ellipsis;
+    overflow: hidden;
 
     a { color: $text_color; }
   }

--- a/styles/_recent-activity.scss
+++ b/styles/_recent-activity.scss
@@ -37,6 +37,8 @@
 
   &-item-link {
     font-size: 14px;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 
   &-item-meta {

--- a/styles/_section.scss
+++ b/styles/_section.scss
@@ -10,6 +10,7 @@
       flex: 0 0 80%;
     }
     flex: 1;
+    max-width: 100%
   }
 
   &-subscribe button {


### PR DESCRIPTION
## Description

When having a very long title without spaces, it is causing the title to overflow in different locations.

## Screenshots

### Before
<img width="1475" alt="Screenshot 2023-07-18 at 11 40 42" src="https://github.com/zendesk/copenhagen_theme/assets/649667/c1526735-9dec-49f1-92d1-7a7ee4985595">

### After
<img width="1434" alt="Screenshot 2023-07-18 at 11 40 37" src="https://github.com/zendesk/copenhagen_theme/assets/649667/30c25b5d-e8ab-4b8b-b596-0e59cb78adaf">

### Before
<img width="1987" alt="Screenshot 2023-07-18 at 12 16 32" src="https://github.com/zendesk/copenhagen_theme/assets/649667/2f66b7b1-ff9c-4d97-9b5f-ca885cdc9afc">

### After
<img width="1249" alt="Screenshot 2023-07-18 at 11 39 30" src="https://github.com/zendesk/copenhagen_theme/assets/649667/220cd42f-d0c6-42c9-b94f-08c3c5d82c48">

### Before
<img width="1986" alt="Screenshot 2023-07-18 at 12 16 26" src="https://github.com/zendesk/copenhagen_theme/assets/649667/7ec796a6-4aba-41b0-9128-a375d6411d65">

### After
<img width="1249" alt="Screenshot 2023-07-18 at 11 39 30" src="https://github.com/zendesk/copenhagen_theme/assets/649667/220cd42f-d0c6-42c9-b94f-08c3c5d82c48">

### Before

<img width="1984" alt="Screenshot 2023-07-18 at 12 16 13" src="https://github.com/zendesk/copenhagen_theme/assets/649667/5a5183f3-c87c-40f2-a6a1-535266b02614">

### After

<img width="1346" alt="Screenshot 2023-07-18 at 11 57 41" src="https://github.com/zendesk/copenhagen_theme/assets/649667/a7a84b4b-93d8-43cf-87ef-5e31ec2c6d26">

### Before
<img width="1988" alt="Screenshot 2023-07-18 at 12 16 19" src="https://github.com/zendesk/copenhagen_theme/assets/649667/aab1ae79-d89e-4e72-9d5f-e53157ce582f">

### After
<img width="1989" alt="Screenshot 2023-07-18 at 12 18 30" src="https://github.com/zendesk/copenhagen_theme/assets/649667/0e12481a-a1ed-4798-8e38-2d685fb3c47b">

## Checklist

- [x] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [x] :arrow_left: changes are compatible with RTL direction
- [x] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [x] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [x] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->