### PR TITLE
Hide generated files instead of ignoring

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+script.js linguist-generated
+style.css linguist-generated
+assets/** linguist-generated

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,4 @@
 style.css.map
 node_modules/
 .zat
-script.js
-style.css
-assets/
 *.DS_Store


### PR DESCRIPTION
## Description

Compiled assets are regenerated upon every release. However, for side-running branches, or simply to be able to import a themes containing the latest changes, it's easier to not ignore compiled files.
This PR moves them to `.gitattributes` and set them as `generated` so they're always hidden by default in PRs.

## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->