### PR TITLE
feat: added Garden subject field in new request form

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@zendesk/zcli": "^1.0.0-beta.35",
     "@zendeskgarden/react-dropdowns.next": "^8.69.1",
+    "@zendeskgarden/react-forms": "^8.69.1",
     "@zendeskgarden/react-theming": "^8.69.1",
     "node-fetch": "2.6.9",
     "react": "^17.0.2",

--- a/src/modules/new-request-form/NewRequestForm.tsx
+++ b/src/modules/new-request-form/NewRequestForm.tsx
@@ -1,14 +1,24 @@
-import type { TicketForm } from "./data-types/TicketForm";
+import type { Field, TicketForm } from "./data-types";
+import { TextInput } from "./fields/TextInput";
 import { TicketFormField } from "./ticket-form-field/TicketFormField";
 
 export interface NewRequestFormProps {
   ticketForms: TicketForm[];
+  fields: Field[];
 }
 
-export function NewRequestForm({ ticketForms }: NewRequestFormProps) {
+export function NewRequestForm({ ticketForms, fields }: NewRequestFormProps) {
   return (
     <form>
       <TicketFormField ticketForms={ticketForms} />
+      {fields.map((field) => {
+        switch (field.type) {
+          case "subject":
+            return <TextInput field={field} />;
+          default:
+            return <></>;
+        }
+      })}
     </form>
   );
 }

--- a/src/modules/new-request-form/data-types/Field.ts
+++ b/src/modules/new-request-form/data-types/Field.ts
@@ -1,0 +1,10 @@
+export interface Field {
+  name: string;
+  value: string;
+  error: string;
+  label: string;
+  required: boolean;
+  description: string;
+  type: string;
+  id: string;
+}

--- a/src/modules/new-request-form/data-types/index.ts
+++ b/src/modules/new-request-form/data-types/index.ts
@@ -1,0 +1,2 @@
+export * from "./Field";
+export * from "./TicketForm";

--- a/src/modules/new-request-form/fields/TextInput.tsx
+++ b/src/modules/new-request-form/fields/TextInput.tsx
@@ -1,0 +1,29 @@
+import {
+  Field as GardenField,
+  Hint,
+  Input,
+  Label,
+  Message,
+} from "@zendeskgarden/react-forms";
+import type { Field } from "../data-types";
+
+interface TextInputProps {
+  field: Field;
+}
+
+export function TextInput({ field }: TextInputProps): JSX.Element {
+  const { label, error, value, name, required, description } = field;
+  return (
+    <GardenField>
+      <Label>{label}</Label>
+      {description && <Hint>{description}</Hint>}
+      <Input
+        name={name}
+        value={value}
+        validation={error ? "error" : undefined}
+        required={required}
+      />
+      {error && <Message validation="error">{error}</Message>}
+    </GardenField>
+  );
+}

--- a/templates/new_request_page.hbs
+++ b/templates/new_request_page.hbs
@@ -51,6 +51,13 @@
   import { renderNewRequestForm } from "new-request-form";
 
   var ticketForms = [];
+  var fields = [];
+
+  {{#with request_form}}
+  {{#each fields}}
+    fields.push({ name: "{{name}}", value: "{{value}}", error: "{{error}}", label: {{ json_stringify label }}, required: {{required}}, description: "{{description}}", type: "{{type}}", id: "{{id}}" })
+  {{/each}}
+  {{/with}}
   
   {{#each ticket_forms}}
     ticketForms.push({ id:
@@ -58,6 +65,6 @@
   {{/each}}
 
   const container = document.getElementById("new-request-form");
-  const props = { ticketForms };
+  const props = { ticketForms, fields };
   renderNewRequestForm(props, container);
 </script>


### PR DESCRIPTION
## Description

This PR adds the Subject field rendered with Garden components in the New Request Form. This is a first implementation, we still need to improve the JSON serialization of some values and hide the ticket form selector when a ticket form is already selected

## Screenshots

<img width="560" alt="Screenshot 2023-07-25 at 12 54 40" src="https://github.com/zendesk/copenhagen_theme/assets/13420283/8f15d01b-2e93-4f58-b092-b697c0d777b0">


## Checklist

- [x] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->