### PR TITLE
feat: improved Ticket Form selector

### DIFF
--- a/assets/new-request-form.js
+++ b/assets/new-request-form.js
@@ -16,18 +16,24 @@ function DropDown({ field }) {
     return (jsxRuntimeExports.jsxs(Field$1, { children: [jsxRuntimeExports.jsx(Label, { children: label }), description && jsxRuntimeExports.jsx(Hint$1, { children: description }), jsxRuntimeExports.jsx(Combobox, { inputProps: { name, required }, isEditable: false, validation: error ? "error" : undefined, children: options.map((option) => (jsxRuntimeExports.jsx(Option, { value: option.value, isSelected: option.value === value, children: option.name }, option.value))) }), error && jsxRuntimeExports.jsx(Message$1, { validation: "error", children: error })] }));
 }
 
-function TicketFormField({ ticketForms }) {
+function TicketFormField({ label, ticketFormField, ticketForms, }) {
     const handleChange = ({ selectionValue }) => {
         if (selectionValue && typeof selectionValue === "string") {
-            window.location.href = selectionValue;
+            const newUrl = new URL(window.location.origin + selectionValue);
+            const currentSearchParams = new URLSearchParams(window.location.search);
+            currentSearchParams.delete("ticket_form_id");
+            for (const [key, value] of currentSearchParams) {
+                newUrl.searchParams.append(key, value);
+            }
+            window.location.href = newUrl.toString();
         }
     };
-    return (jsxRuntimeExports.jsxs(Field$1, { children: [jsxRuntimeExports.jsx(Label, { children: "Please choose your issue below" }), jsxRuntimeExports.jsx(Combobox, { isEditable: false, onChange: handleChange, children: ticketForms.map(({ id, url, display_name }) => (jsxRuntimeExports.jsx(Option, { value: url, label: display_name, children: name }, id))) })] }));
+    return (jsxRuntimeExports.jsxs(jsxRuntimeExports.Fragment, { children: [jsxRuntimeExports.jsx("input", { type: "hidden", name: ticketFormField.name, value: ticketFormField.value }), ticketForms.length > 1 && (jsxRuntimeExports.jsxs(Field$1, { children: [jsxRuntimeExports.jsx(Label, { children: label }), jsxRuntimeExports.jsx(Combobox, { isEditable: false, onChange: handleChange, children: ticketForms.map(({ id, url, display_name }) => (jsxRuntimeExports.jsx(Option, { value: url, label: display_name, isSelected: ticketFormField.value === id, children: display_name }, id))) })] }))] }));
 }
 
 function NewRequestForm({ ticketForms, requestForm, }) {
-    const { fields, action, http_method, accept_charset } = requestForm;
-    return (jsxRuntimeExports.jsxs("form", { action: action, method: http_method, acceptCharset: accept_charset, children: [jsxRuntimeExports.jsx(TicketFormField, { ticketForms: ticketForms }), fields.map((field) => {
+    const { fields, action, http_method, accept_charset, ticket_form_field, ticket_forms_instructions, } = requestForm;
+    return (jsxRuntimeExports.jsxs("form", { action: action, method: http_method, acceptCharset: accept_charset, children: [jsxRuntimeExports.jsx(TicketFormField, { label: ticket_forms_instructions, ticketFormField: ticket_form_field, ticketForms: ticketForms }), fields.map((field) => {
                 switch (field.type) {
                     case "anonymous_requester_email":
                     case "subject":

--- a/assets/vendor.js
+++ b/assets/vendor.js
@@ -157,17 +157,17 @@ var l=requireObjectAssign(),n=60103,p=60106;react_production_min.Fragment=60107;
 	return react_production_min;
 }
 
-{
-  react.exports = requireReact_production_min();
+var hasRequiredReact;
+
+function requireReact () {
+	if (hasRequiredReact) return react.exports;
+	hasRequiredReact = 1;
+
+	{
+	  react.exports = requireReact_production_min();
+	}
+	return react.exports;
 }
-
-var reactExports = react.exports;
-var React__default = /*@__PURE__*/getDefaultExportFromCjs(reactExports);
-
-var React = /*#__PURE__*/_mergeNamespaces({
-	__proto__: null,
-	default: React__default
-}, [reactExports]);
 
 /** @license React v17.0.2
  * react-jsx-runtime.production.min.js
@@ -183,7 +183,7 @@ var hasRequiredReactJsxRuntime_production_min;
 function requireReactJsxRuntime_production_min () {
 	if (hasRequiredReactJsxRuntime_production_min) return reactJsxRuntime_production_min;
 	hasRequiredReactJsxRuntime_production_min = 1;
-requireObjectAssign();var f=reactExports,g=60103;reactJsxRuntime_production_min.Fragment=60107;if("function"===typeof Symbol&&Symbol.for){var h=Symbol.for;g=h("react.element");reactJsxRuntime_production_min.Fragment=h("react.fragment");}var m=f.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.ReactCurrentOwner,n=Object.prototype.hasOwnProperty,p={key:!0,ref:!0,__self:!0,__source:!0};
+requireObjectAssign();var f=requireReact(),g=60103;reactJsxRuntime_production_min.Fragment=60107;if("function"===typeof Symbol&&Symbol.for){var h=Symbol.for;g=h("react.element");reactJsxRuntime_production_min.Fragment=h("react.fragment");}var m=f.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.ReactCurrentOwner,n=Object.prototype.hasOwnProperty,p={key:!0,ref:!0,__self:!0,__source:!0};
 	function q(c,a,k){var b,d={},e=null,l=null;void 0!==k&&(e=""+k);void 0!==a.key&&(e=""+a.key);void 0!==a.ref&&(l=a.ref);for(b in a)n.call(a,b)&&!p.hasOwnProperty(b)&&(d[b]=a[b]);if(c&&c.defaultProps)for(b in a=c.defaultProps,a)void 0===d[b]&&(d[b]=a[b]);return {$$typeof:g,type:c,key:e,ref:l,props:d,_owner:m.current}}reactJsxRuntime_production_min.jsx=q;reactJsxRuntime_production_min.jsxs=q;
 	return reactJsxRuntime_production_min;
 }
@@ -259,7 +259,7 @@ var hasRequiredReactDom_production_min;
 function requireReactDom_production_min () {
 	if (hasRequiredReactDom_production_min) return reactDom_production_min;
 	hasRequiredReactDom_production_min = 1;
-var aa=reactExports,m=requireObjectAssign(),r=requireScheduler();function y(a){for(var b="https://reactjs.org/docs/error-decoder.html?invariant="+a,c=1;c<arguments.length;c++)b+="&args[]="+encodeURIComponent(arguments[c]);return "Minified React error #"+a+"; visit "+b+" for the full message or use the non-minified dev environment for full errors and additional helpful warnings."}if(!aa)throw Error(y(227));var ba=new Set,ca={};function da(a,b){ea(a,b);ea(a+"Capture",b);}
+var aa=requireReact(),m=requireObjectAssign(),r=requireScheduler();function y(a){for(var b="https://reactjs.org/docs/error-decoder.html?invariant="+a,c=1;c<arguments.length;c++)b+="&args[]="+encodeURIComponent(arguments[c]);return "Minified React error #"+a+"; visit "+b+" for the full message or use the non-minified dev environment for full errors and additional helpful warnings."}if(!aa)throw Error(y(227));var ba=new Set,ca={};function da(a,b){ea(a,b);ea(a+"Capture",b);}
 	function ea(a,b){ca[a]=b;for(a=0;a<b.length;a++)ba.add(b[a]);}
 	var fa=!("undefined"===typeof window||"undefined"===typeof window.document||"undefined"===typeof window.document.createElement),ha=/^[:A-Z_a-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD][:A-Z_a-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD\-.0-9\u00B7\u0300-\u036F\u203F-\u2040]*$/,ia=Object.prototype.hasOwnProperty,
 	ja={},ka={};function la(a){if(ia.call(ka,a))return !0;if(ia.call(ja,a))return !1;if(ha.test(a))return ka[a]=!0;ja[a]=!0;return !1}function ma(a,b,c,d){if(null!==c&&0===c.type)return !1;switch(typeof b){case "function":case "symbol":return !0;case "boolean":if(d)return !1;if(null!==c)return !c.acceptsBooleans;a=a.toLowerCase().slice(0,5);return "data-"!==a&&"aria-"!==a;default:return !1}}
@@ -574,6 +574,14 @@ function checkDCE() {
 }
 
 var reactDomExports = reactDom.exports;
+
+var reactExports = requireReact();
+var React__default = /*@__PURE__*/getDefaultExportFromCjs(reactExports);
+
+var React = /*#__PURE__*/_mergeNamespaces({
+	__proto__: null,
+	default: React__default
+}, [reactExports]);
 
 var reactIs$2 = {exports: {}};
 
@@ -16514,7 +16522,7 @@ implementation.exports;
 
 	exports.__esModule = true;
 
-	var _react = reactExports;
+	var _react = requireReact();
 
 	_interopRequireDefault(_react);
 
@@ -16713,7 +16721,7 @@ lib.exports;
 
 	exports.__esModule = true;
 
-	var _react = reactExports;
+	var _react = requireReact();
 
 	var _react2 = _interopRequireDefault(_react);
 

--- a/src/modules/new-request-form/NewRequestForm.tsx
+++ b/src/modules/new-request-form/NewRequestForm.tsx
@@ -13,11 +13,22 @@ export function NewRequestForm({
   ticketForms,
   requestForm,
 }: NewRequestFormProps) {
-  const { fields, action, http_method, accept_charset } = requestForm;
+  const {
+    fields,
+    action,
+    http_method,
+    accept_charset,
+    ticket_form_field,
+    ticket_forms_instructions,
+  } = requestForm;
 
   return (
     <form action={action} method={http_method} acceptCharset={accept_charset}>
-      <TicketFormField ticketForms={ticketForms} />
+      <TicketFormField
+        label={ticket_forms_instructions}
+        ticketFormField={ticket_form_field}
+        ticketForms={ticketForms}
+      />
       {fields.map((field) => {
         switch (field.type) {
           case "anonymous_requester_email":

--- a/src/modules/new-request-form/data-types/RequestForm.tsx
+++ b/src/modules/new-request-form/data-types/RequestForm.tsx
@@ -6,5 +6,6 @@ export interface RequestForm {
   http_method: string;
   errors: string | null;
   ticket_forms_instructions: string;
+  ticket_form_field: Field;
   fields: Field[];
 }

--- a/src/modules/new-request-form/ticket-form-field/TicketFormField.tsx
+++ b/src/modules/new-request-form/ticket-form-field/TicketFormField.tsx
@@ -1,33 +1,63 @@
 import type { IComboboxProps } from "@zendeskgarden/react-dropdowns.next";
 import {
   Combobox,
-  Field,
+  Field as GardenField,
   Label,
   Option,
 } from "@zendeskgarden/react-dropdowns.next";
 import type { TicketForm } from "../data-types/TicketForm";
+import type { Field } from "../data-types";
 
 interface TicketFormFieldProps {
+  label: string;
+  ticketFormField: Field;
   ticketForms: TicketForm[];
 }
 
-export function TicketFormField({ ticketForms }: TicketFormFieldProps) {
+export function TicketFormField({
+  label,
+  ticketFormField,
+  ticketForms,
+}: TicketFormFieldProps) {
   const handleChange: IComboboxProps["onChange"] = ({ selectionValue }) => {
     if (selectionValue && typeof selectionValue === "string") {
-      window.location.href = selectionValue;
+      const newUrl = new URL(window.location.origin + selectionValue);
+
+      const currentSearchParams = new URLSearchParams(window.location.search);
+      currentSearchParams.delete("ticket_form_id");
+
+      for (const [key, value] of currentSearchParams) {
+        newUrl.searchParams.append(key, value);
+      }
+
+      window.location.href = newUrl.toString();
     }
   };
 
   return (
-    <Field>
-      <Label>Please choose your issue below</Label>
-      <Combobox isEditable={false} onChange={handleChange}>
-        {ticketForms.map(({ id, url, display_name }) => (
-          <Option key={id} value={url} label={display_name}>
-            {name}
-          </Option>
-        ))}
-      </Combobox>
-    </Field>
+    <>
+      <input
+        type="hidden"
+        name={ticketFormField.name}
+        value={ticketFormField.value}
+      />
+      {ticketForms.length > 1 && (
+        <GardenField>
+          <Label>{label}</Label>
+          <Combobox isEditable={false} onChange={handleChange}>
+            {ticketForms.map(({ id, url, display_name }) => (
+              <Option
+                key={id}
+                value={url}
+                label={display_name}
+                isSelected={ticketFormField.value === id}
+              >
+                {display_name}
+              </Option>
+            ))}
+          </Combobox>
+        </GardenField>
+      )}
+    </>
   );
 }


### PR DESCRIPTION
## Description

This PR properly implements the Ticket Form Selector:
- the label is now read from `ticket_forms_instructions`
- the form selector is hidden when there is only one ticket form
- `ticket_form_field` is used to insert a hidden field to pass the selected form in the submit
- additional URL params are now preserved when a new ticket form is selected

## Checklist

- [x] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->