### PR TITLE
feat: added form submission and global form errors handling

### DIFF
--- a/assets/new-request-form.js
+++ b/assets/new-request-form.js
@@ -1,4 +1,4 @@
-import { j as jsxRuntimeExports, F as Field, L as Label$1, H as Hint, I as Input, M as Message, T as Textarea, a as Field$1, b as Label, c as Hint$1, C as Combobox, O as Option, d as Message$1, s as styled, A as Alert, B as Button, r as reactDomExports } from 'vendor';
+import { j as jsxRuntimeExports, F as Field, L as Label$1, H as Hint, I as Input, M as Message, T as Textarea, a as Field$1, b as Label, c as Hint$1, C as Combobox, O as Option, d as Message$1, r as reactExports, s as styled, A as Alert, B as Button, e as reactDomExports } from 'vendor';
 import { ComponentProviders } from 'shared';
 
 function TextInput({ field }) {
@@ -31,7 +31,40 @@ function TicketFormField({ label, ticketFormField, ticketForms, }) {
     return (jsxRuntimeExports.jsxs(jsxRuntimeExports.Fragment, { children: [jsxRuntimeExports.jsx("input", { type: "hidden", name: ticketFormField.name, value: ticketFormField.value }), ticketForms.length > 1 && (jsxRuntimeExports.jsxs(Field$1, { children: [jsxRuntimeExports.jsx(Label, { children: label }), jsxRuntimeExports.jsx(Combobox, { isEditable: false, onChange: handleChange, children: ticketForms.map(({ id, url, display_name }) => (jsxRuntimeExports.jsx(Option, { value: url, label: display_name, isSelected: ticketFormField.value === id, children: display_name }, id))) })] }))] }));
 }
 
-const StyledForm = styled.form `
+// NOTE: This is a temporary handling of the CSRF token
+const fetchCsrfToken = async () => {
+    const response = await fetch("/hc/api/internal/csrf_token.json");
+    const { current_session } = await response.json();
+    return current_session.csrf_token;
+};
+/**
+ * This hook creates an event handler for form submits, fetching the CSRF token
+ * from the backend and appending it to the form
+ * @returns a Submit Event Handler function
+ */
+function useSubmitHandler() {
+    const isSubmitting = reactExports.useRef(false);
+    return async (e) => {
+        e.preventDefault();
+        /* We are performing an async call to fetch the CSRF token and for this reason
+           the submit is not immediate, and the user can click the submit button multiple times.
+           We don't want to disable the submit button for A11Y, so we use the isSubmitting ref
+           to stop subsequent submits after the first one. */
+        if (isSubmitting.current === false) {
+            isSubmitting.current = true;
+            const form = e.target;
+            const token = await fetchCsrfToken();
+            const hiddenInput = document.createElement("input");
+            hiddenInput.type = "hidden";
+            hiddenInput.name = "authenticity_token";
+            hiddenInput.value = token;
+            form.appendChild(hiddenInput);
+            form.submit();
+        }
+    };
+}
+
+const Form = styled.form `
   display: flex;
   flex-direction: column;
   gap: ${(props) => props.theme.space.md};
@@ -41,26 +74,8 @@ const Footer = styled.div `
 `;
 function NewRequestForm({ ticketForms, requestForm, }) {
     const { fields, action, http_method, accept_charset, errors, ticket_form_field, ticket_forms_instructions, } = requestForm;
-    // NOTE: This is a temporary handling of the CSRF token
-    const fetchCsrfToken = async () => {
-        const response = await fetch("/hc/api/internal/csrf_token.json");
-        const { current_session } = await response.json();
-        return current_session.csrf_token;
-    };
-    const handleSubmit = (e) => {
-        e.preventDefault();
-        const form = e.target;
-        fetchCsrfToken().then((token) => {
-            const hiddenInput = document.createElement("input");
-            hiddenInput.type = "hidden";
-            hiddenInput.name = "authenticity_token";
-            hiddenInput.value = token;
-            form.appendChild(hiddenInput);
-            form.submit();
-            form.removeChild(hiddenInput);
-        });
-    };
-    return (jsxRuntimeExports.jsxs(StyledForm, { action: action, method: http_method, acceptCharset: accept_charset, noValidate: true, onSubmit: handleSubmit, children: [errors && jsxRuntimeExports.jsx(Alert, { type: "error", children: errors }), jsxRuntimeExports.jsx(TicketFormField, { label: ticket_forms_instructions, ticketFormField: ticket_form_field, ticketForms: ticketForms }), fields.map((field) => {
+    const handleSubmit = useSubmitHandler();
+    return (jsxRuntimeExports.jsxs(Form, { action: action, method: http_method, acceptCharset: accept_charset, noValidate: true, onSubmit: handleSubmit, children: [errors && jsxRuntimeExports.jsx(Alert, { type: "error", children: errors }), jsxRuntimeExports.jsx(TicketFormField, { label: ticket_forms_instructions, ticketFormField: ticket_form_field, ticketForms: ticketForms }), fields.map((field) => {
                 switch (field.type) {
                     case "anonymous_requester_email":
                     case "subject":

--- a/assets/new-request-form.js
+++ b/assets/new-request-form.js
@@ -1,14 +1,14 @@
-import { j as jsxRuntimeExports, F as Field, L as Label$1, H as Hint, I as Input, M as Message, T as Textarea, a as Field$1, b as Label, c as Hint$1, C as Combobox, O as Option, d as Message$1, r as reactDomExports } from 'vendor';
+import { j as jsxRuntimeExports, F as Field, L as Label$1, H as Hint, I as Input, M as Message, T as Textarea, a as Field$1, b as Label, c as Hint$1, C as Combobox, O as Option, d as Message$1, s as styled, A as Alert, B as Button, r as reactDomExports } from 'vendor';
 import { ComponentProviders } from 'shared';
 
 function TextInput({ field }) {
     const { label, error, value, name, required, description } = field;
-    return (jsxRuntimeExports.jsxs(Field, { children: [jsxRuntimeExports.jsx(Label$1, { children: label }), description && jsxRuntimeExports.jsx(Hint, { children: description }), jsxRuntimeExports.jsx(Input, { name: name, value: value, validation: error ? "error" : undefined, required: required }), error && jsxRuntimeExports.jsx(Message, { validation: "error", children: error })] }));
+    return (jsxRuntimeExports.jsxs(Field, { children: [jsxRuntimeExports.jsx(Label$1, { children: label }), description && jsxRuntimeExports.jsx(Hint, { children: description }), jsxRuntimeExports.jsx(Input, { name: name, defaultValue: value, validation: error ? "error" : undefined, required: required }), error && jsxRuntimeExports.jsx(Message, { validation: "error", children: error })] }));
 }
 
 function TextArea({ field }) {
     const { label, error, value, name, required, description } = field;
-    return (jsxRuntimeExports.jsxs(Field, { children: [jsxRuntimeExports.jsx(Label$1, { children: label }), description && jsxRuntimeExports.jsx(Hint, { children: description }), jsxRuntimeExports.jsx(Textarea, { name: name, value: value, validation: error ? "error" : undefined, required: required }), error && jsxRuntimeExports.jsx(Message, { validation: "error", children: error })] }));
+    return (jsxRuntimeExports.jsxs(Field, { children: [jsxRuntimeExports.jsx(Label$1, { children: label }), description && jsxRuntimeExports.jsx(Hint, { children: description }), jsxRuntimeExports.jsx(Textarea, { name: name, defaultValue: value, validation: error ? "error" : undefined, required: required }), error && jsxRuntimeExports.jsx(Message, { validation: "error", children: error })] }));
 }
 
 function DropDown({ field }) {
@@ -31,9 +31,36 @@ function TicketFormField({ label, ticketFormField, ticketForms, }) {
     return (jsxRuntimeExports.jsxs(jsxRuntimeExports.Fragment, { children: [jsxRuntimeExports.jsx("input", { type: "hidden", name: ticketFormField.name, value: ticketFormField.value }), ticketForms.length > 1 && (jsxRuntimeExports.jsxs(Field$1, { children: [jsxRuntimeExports.jsx(Label, { children: label }), jsxRuntimeExports.jsx(Combobox, { isEditable: false, onChange: handleChange, children: ticketForms.map(({ id, url, display_name }) => (jsxRuntimeExports.jsx(Option, { value: url, label: display_name, isSelected: ticketFormField.value === id, children: display_name }, id))) })] }))] }));
 }
 
+const StyledForm = styled.form `
+  display: flex;
+  flex-direction: column;
+  gap: ${(props) => props.theme.space.md};
+`;
+const Footer = styled.div `
+  margin-top: ${(props) => props.theme.space.md};
+`;
 function NewRequestForm({ ticketForms, requestForm, }) {
-    const { fields, action, http_method, accept_charset, ticket_form_field, ticket_forms_instructions, } = requestForm;
-    return (jsxRuntimeExports.jsxs("form", { action: action, method: http_method, acceptCharset: accept_charset, children: [jsxRuntimeExports.jsx(TicketFormField, { label: ticket_forms_instructions, ticketFormField: ticket_form_field, ticketForms: ticketForms }), fields.map((field) => {
+    const { fields, action, http_method, accept_charset, errors, ticket_form_field, ticket_forms_instructions, } = requestForm;
+    // NOTE: This is a temporary handling of the CSRF token
+    const fetchCsrfToken = async () => {
+        const response = await fetch("/hc/api/internal/csrf_token.json");
+        const { current_session } = await response.json();
+        return current_session.csrf_token;
+    };
+    const handleSubmit = (e) => {
+        e.preventDefault();
+        const form = e.target;
+        fetchCsrfToken().then((token) => {
+            const hiddenInput = document.createElement("input");
+            hiddenInput.type = "hidden";
+            hiddenInput.name = "authenticity_token";
+            hiddenInput.value = token;
+            form.appendChild(hiddenInput);
+            form.submit();
+            form.removeChild(hiddenInput);
+        });
+    };
+    return (jsxRuntimeExports.jsxs(StyledForm, { action: action, method: http_method, acceptCharset: accept_charset, noValidate: true, onSubmit: handleSubmit, children: [errors && jsxRuntimeExports.jsx(Alert, { type: "error", children: errors }), jsxRuntimeExports.jsx(TicketFormField, { label: ticket_forms_instructions, ticketFormField: ticket_form_field, ticketForms: ticketForms }), fields.map((field) => {
                 switch (field.type) {
                     case "anonymous_requester_email":
                     case "subject":
@@ -46,7 +73,7 @@ function NewRequestForm({ ticketForms, requestForm, }) {
                     default:
                         return jsxRuntimeExports.jsx(jsxRuntimeExports.Fragment, {});
                 }
-            })] }));
+            }), jsxRuntimeExports.jsx(Footer, { children: ticket_form_field.value && (jsxRuntimeExports.jsx(Button, { isPrimary: true, type: "submit", children: "Submit" })) })] }));
 }
 
 function renderNewRequestForm(props, container) {

--- a/assets/shared.js
+++ b/assets/shared.js
@@ -1,4 +1,4 @@
-import { D as DEFAULT_THEME, j as jsxRuntimeExports, e as ThemeProvider } from 'vendor';
+import { D as DEFAULT_THEME, j as jsxRuntimeExports, f as ThemeProvider } from 'vendor';
 
 let theme = DEFAULT_THEME;
 function setupGardenTheme(callback) {

--- a/assets/vendor.js
+++ b/assets/vendor.js
@@ -1436,7 +1436,7 @@ var hoistNonReactStatics_cjs = hoistNonReactStatics;
 
 var f = /*@__PURE__*/getDefaultExportFromCjs(hoistNonReactStatics_cjs);
 
-function m(){return (m=Object.assign||function(e){for(var t=1;t<arguments.length;t++){var n=arguments[t];for(var r in n)Object.prototype.hasOwnProperty.call(n,r)&&(e[r]=n[r]);}return e}).apply(this,arguments)}var y=function(e,t){for(var n=[e[0]],r=0,o=t.length;r<o;r+=1)n.push(t[r],e[r+1]);return n},v=function(t){return null!==t&&"object"==typeof t&&"[object Object]"===(t.toString?t.toString():Object.prototype.toString.call(t))&&!reactIsExports$1.typeOf(t)},g=Object.freeze([]),S=Object.freeze({});function w(e){return "function"==typeof e}function E(e){return e.displayName||e.name||"Component"}function b(e){return e&&"string"==typeof e.styledComponentId}var _="undefined"!=typeof process&&void 0!==process.env&&(process.env.REACT_APP_SC_ATTR||process.env.SC_ATTR)||"data-styled",A="undefined"!=typeof window&&"HTMLElement"in window,C=Boolean("boolean"==typeof SC_DISABLE_SPEEDY?SC_DISABLE_SPEEDY:"undefined"!=typeof process&&void 0!==process.env&&(void 0!==process.env.REACT_APP_SC_DISABLE_SPEEDY&&""!==process.env.REACT_APP_SC_DISABLE_SPEEDY?"false"!==process.env.REACT_APP_SC_DISABLE_SPEEDY&&process.env.REACT_APP_SC_DISABLE_SPEEDY:void 0!==process.env.SC_DISABLE_SPEEDY&&""!==process.env.SC_DISABLE_SPEEDY?"false"!==process.env.SC_DISABLE_SPEEDY&&process.env.SC_DISABLE_SPEEDY:"production"!=="production"));function R(e){for(var t=arguments.length,n=new Array(t>1?t-1:0),r=1;r<t;r++)n[r-1]=arguments[r];throw new Error("An error occurred. See https://git.io/JUIaE#"+e+" for more information."+(n.length>0?" Args: "+n.join(", "):""))}var D=function(){function e(e){this.groupSizes=new Uint32Array(512),this.length=512,this.tag=e;}var t=e.prototype;return t.indexOfGroup=function(e){for(var t=0,n=0;n<e;n++)t+=this.groupSizes[n];return t},t.insertRules=function(e,t){if(e>=this.groupSizes.length){for(var n=this.groupSizes,r=n.length,o=r;e>=o;)(o<<=1)<0&&R(16,""+e);this.groupSizes=new Uint32Array(o),this.groupSizes.set(n),this.length=o;for(var s=r;s<o;s++)this.groupSizes[s]=0;}for(var i=this.indexOfGroup(e+1),a=0,c=t.length;a<c;a++)this.tag.insertRule(i,t[a])&&(this.groupSizes[e]++,i++);},t.clearGroup=function(e){if(e<this.length){var t=this.groupSizes[e],n=this.indexOfGroup(e),r=n+t;this.groupSizes[e]=0;for(var o=n;o<r;o++)this.tag.deleteRule(n);}},t.getGroup=function(e){var t="";if(e>=this.length||0===this.groupSizes[e])return t;for(var n=this.groupSizes[e],r=this.indexOfGroup(e),o=r+n,s=r;s<o;s++)t+=this.tag.getRule(s)+"/*!sc*/\n";return t},e}(),j=new Map,T=new Map,x=1,k=function(e){if(j.has(e))return j.get(e);for(;T.has(x);)x++;var t=x++;return j.set(e,t),T.set(t,e),t},V=function(e){return T.get(e)},z=function(e,t){t>=x&&(x=t+1),j.set(e,t),T.set(t,e);},B="style["+_+'][data-styled-version="5.3.11"]',M=new RegExp("^"+_+'\\.g(\\d+)\\[id="([\\w\\d-]+)"\\].*?"([^"]*)'),G=function(e,t,n){for(var r,o=n.split(","),s=0,i=o.length;s<i;s++)(r=o[s])&&e.registerName(t,r);},L=function(e,t){for(var n=(t.textContent||"").split("/*!sc*/\n"),r=[],o=0,s=n.length;o<s;o++){var i=n[o].trim();if(i){var a=i.match(M);if(a){var c=0|parseInt(a[1],10),u=a[2];0!==c&&(z(u,c),G(e,u,a[3]),e.getTag().insertRules(c,r)),r.length=0;}else r.push(i);}}},F=function(){return "undefined"!=typeof __webpack_nonce__?__webpack_nonce__:null},Y=function(e){var t=document.head,n=e||t,r=document.createElement("style"),o=function(e){for(var t=e.childNodes,n=t.length;n>=0;n--){var r=t[n];if(r&&1===r.nodeType&&r.hasAttribute(_))return r}}(n),s=void 0!==o?o.nextSibling:null;r.setAttribute(_,"active"),r.setAttribute("data-styled-version","5.3.11");var i=F();return i&&r.setAttribute("nonce",i),n.insertBefore(r,s),r},q=function(){function e(e){var t=this.element=Y(e);t.appendChild(document.createTextNode("")),this.sheet=function(e){if(e.sheet)return e.sheet;for(var t=document.styleSheets,n=0,r=t.length;n<r;n++){var o=t[n];if(o.ownerNode===e)return o}R(17);}(t),this.length=0;}var t=e.prototype;return t.insertRule=function(e,t){try{return this.sheet.insertRule(t,e),this.length++,!0}catch(e){return !1}},t.deleteRule=function(e){this.sheet.deleteRule(e),this.length--;},t.getRule=function(e){var t=this.sheet.cssRules[e];return void 0!==t&&"string"==typeof t.cssText?t.cssText:""},e}(),H=function(){function e(e){var t=this.element=Y(e);this.nodes=t.childNodes,this.length=0;}var t=e.prototype;return t.insertRule=function(e,t){if(e<=this.length&&e>=0){var n=document.createTextNode(t),r=this.nodes[e];return this.element.insertBefore(n,r||null),this.length++,!0}return !1},t.deleteRule=function(e){this.element.removeChild(this.nodes[e]),this.length--;},t.getRule=function(e){return e<this.length?this.nodes[e].textContent:""},e}(),$=function(){function e(e){this.rules=[],this.length=0;}var t=e.prototype;return t.insertRule=function(e,t){return e<=this.length&&(this.rules.splice(e,0,t),this.length++,!0)},t.deleteRule=function(e){this.rules.splice(e,1),this.length--;},t.getRule=function(e){return e<this.length?this.rules[e]:""},e}(),W=A,U={isServer:!A,useCSSOMInjection:!C},J=function(){function e(e,t,n){void 0===e&&(e=S),void 0===t&&(t={}),this.options=m({},U,{},e),this.gs=t,this.names=new Map(n),this.server=!!e.isServer,!this.server&&A&&W&&(W=!1,function(e){for(var t=document.querySelectorAll(B),n=0,r=t.length;n<r;n++){var o=t[n];o&&"active"!==o.getAttribute(_)&&(L(e,o),o.parentNode&&o.parentNode.removeChild(o));}}(this));}e.registerId=function(e){return k(e)};var t=e.prototype;return t.reconstructWithOptions=function(t,n){return void 0===n&&(n=!0),new e(m({},this.options,{},t),this.gs,n&&this.names||void 0)},t.allocateGSInstance=function(e){return this.gs[e]=(this.gs[e]||0)+1},t.getTag=function(){return this.tag||(this.tag=(n=(t=this.options).isServer,r=t.useCSSOMInjection,o=t.target,e=n?new $(o):r?new q(o):new H(o),new D(e)));var e,t,n,r,o;},t.hasNameForId=function(e,t){return this.names.has(e)&&this.names.get(e).has(t)},t.registerName=function(e,t){if(k(e),this.names.has(e))this.names.get(e).add(t);else {var n=new Set;n.add(t),this.names.set(e,n);}},t.insertRules=function(e,t,n){this.registerName(e,t),this.getTag().insertRules(k(e),n);},t.clearNames=function(e){this.names.has(e)&&this.names.get(e).clear();},t.clearRules=function(e){this.getTag().clearGroup(k(e)),this.clearNames(e);},t.clearTag=function(){this.tag=void 0;},t.toString=function(){return function(e){for(var t=e.getTag(),n=t.length,r="",o=0;o<n;o++){var s=V(o);if(void 0!==s){var i=e.names.get(s),a=t.getGroup(o);if(i&&a&&i.size){var c=_+".g"+o+'[id="'+s+'"]',u="";void 0!==i&&i.forEach((function(e){e.length>0&&(u+=e+",");})),r+=""+a+c+'{content:"'+u+'"}/*!sc*/\n';}}}return r}(this)},e}(),X=/(a)(d)/gi,Z=function(e){return String.fromCharCode(e+(e>25?39:97))};function K(e){var t,n="";for(t=Math.abs(e);t>52;t=t/52|0)n=Z(t%52)+n;return (Z(t%52)+n).replace(X,"$1-$2")}var Q=function(e,t){for(var n=t.length;n;)e=33*e^t.charCodeAt(--n);return e},ee=function(e){return Q(5381,e)};function te(e){for(var t=0;t<e.length;t+=1){var n=e[t];if(w(n)&&!b(n))return !1}return !0}var ne=ee("5.3.11"),re=function(){function e(e,t,n){this.rules=e,this.staticRulesId="",this.isStatic=(void 0===n||n.isStatic)&&te(e),this.componentId=t,this.baseHash=Q(ne,t),this.baseStyle=n,J.registerId(t);}return e.prototype.generateAndInjectStyles=function(e,t,n){var r=this.componentId,o=[];if(this.baseStyle&&o.push(this.baseStyle.generateAndInjectStyles(e,t,n)),this.isStatic&&!n.hash)if(this.staticRulesId&&t.hasNameForId(r,this.staticRulesId))o.push(this.staticRulesId);else {var s=be(this.rules,e,t,n).join(""),i=K(Q(this.baseHash,s)>>>0);if(!t.hasNameForId(r,i)){var a=n(s,"."+i,void 0,r);t.insertRules(r,i,a);}o.push(i),this.staticRulesId=i;}else {for(var c=this.rules.length,u=Q(this.baseHash,n.hash),l="",d=0;d<c;d++){var h=this.rules[d];if("string"==typeof h)l+=h;else if(h){var p=be(h,e,t,n),f=Array.isArray(p)?p.join(""):p;u=Q(u,f+d),l+=f;}}if(l){var m=K(u>>>0);if(!t.hasNameForId(r,m)){var y=n(l,"."+m,void 0,r);t.insertRules(r,m,y);}o.push(m);}}return o.join(" ")},e}(),oe=/^\s*\/\/.*$/gm,se=[":","[",".","#"];function ie(e){var t,n,r,o,s=void 0===e?S:e,i=s.options,a=void 0===i?S:i,c=s.plugins,u=void 0===c?g:c,l=new stylis_min(a),h=[],p=function(e){function t(t){if(t)try{e(t+"}");}catch(e){}}return function(n,r,o,s,i,a,c,u,l,d){switch(n){case 1:if(0===l&&64===r.charCodeAt(0))return e(r+";"),"";break;case 2:if(0===u)return r+"/*|*/";break;case 3:switch(u){case 102:case 112:return e(o[0]+r),"";default:return r+(0===d?"/*|*/":"")}case-2:r.split("/*|*/}").forEach(t);}}}((function(e){h.push(e);})),f=function(e,r,s){return 0===r&&-1!==se.indexOf(s[n.length])||s.match(o)?e:"."+t};function m(e,s,i,a){void 0===a&&(a="&");var c=e.replace(oe,""),u=s&&i?i+" "+s+" { "+c+" }":c;return t=a,n=s,r=new RegExp("\\"+n+"\\b","g"),o=new RegExp("(\\"+n+"\\b){2,}"),l(i||!s?"":s,u)}return l.use([].concat(u,[function(e,t,o){2===e&&o.length&&o[0].lastIndexOf(n)>0&&(o[0]=o[0].replace(r,f));},p,function(e){if(-2===e){var t=h;return h=[],t}}])),m.hash=u.length?u.reduce((function(e,t){return t.name||R(15),Q(e,t.name)}),5381).toString():"",m}var ae=React__default.createContext();ae.Consumer;var ue=React__default.createContext(),le=(ue.Consumer,new J),de=ie();function he(){return reactExports.useContext(ae)||le}function pe(){return reactExports.useContext(ue)||de}var me=function(){function e(e,t){var n=this;this.inject=function(e,t){void 0===t&&(t=de);var r=n.name+t.hash;e.hasNameForId(n.id,r)||e.insertRules(n.id,r,t(n.rules,r,"@keyframes"));},this.toString=function(){return R(12,String(n.name))},this.name=e,this.id="sc-keyframes-"+e,this.rules=t;}return e.prototype.getName=function(e){return void 0===e&&(e=de),this.name+e.hash},e}(),ye=/([A-Z])/,ve=/([A-Z])/g,ge=/^ms-/,Se=function(e){return "-"+e.toLowerCase()};function we(e){return ye.test(e)?e.replace(ve,Se).replace(ge,"-ms-"):e}var Ee=function(e){return null==e||!1===e||""===e};function be(e,n,r,o){if(Array.isArray(e)){for(var s,i=[],a=0,c=e.length;a<c;a+=1)""!==(s=be(e[a],n,r,o))&&(Array.isArray(s)?i.push.apply(i,s):i.push(s));return i}if(Ee(e))return "";if(b(e))return "."+e.styledComponentId;if(w(e)){if("function"!=typeof(l=e)||l.prototype&&l.prototype.isReactComponent||!n)return e;var u=e(n);return be(u,n,r,o)}var l;return e instanceof me?r?(e.inject(r,o),e.getName(o)):e:v(e)?function e(t,n){var r,o,s=[];for(var i in t)t.hasOwnProperty(i)&&!Ee(t[i])&&(Array.isArray(t[i])&&t[i].isCss||w(t[i])?s.push(we(i)+":",t[i],";"):v(t[i])?s.push.apply(s,e(t[i],i)):s.push(we(i)+": "+(r=i,null==(o=t[i])||"boolean"==typeof o||""===o?"":"number"!=typeof o||0===o||r in unitlessKeys||r.startsWith("--")?String(o).trim():o+"px")+";"));return n?[n+" {"].concat(s,["}"]):s}(e):e.toString()}var _e=function(e){return Array.isArray(e)&&(e.isCss=!0),e};function Ne(e){for(var t=arguments.length,n=new Array(t>1?t-1:0),r=1;r<t;r++)n[r-1]=arguments[r];return w(e)||v(e)?_e(be(y(g,[e].concat(n)))):0===n.length&&1===e.length&&"string"==typeof e[0]?e:_e(be(y(e,n)))}var Pe=function(e,t,n){return void 0===n&&(n=S),e.theme!==n.theme&&e.theme||t||n.theme},Oe=/[!"#$%&'()*+,./:;<=>?@[\\\]^`{|}~-]+/g,Re=/(^-|-$)/g;function De(e){return e.replace(Oe,"-").replace(Re,"")}var je=function(e){return K(ee(e)>>>0)};function Te(e){return "string"==typeof e&&("production"==="production")}var xe=function(e){return "function"==typeof e||"object"==typeof e&&null!==e&&!Array.isArray(e)},ke=function(e){return "__proto__"!==e&&"constructor"!==e&&"prototype"!==e};function Ve(e,t,n){var r=e[n];xe(t)&&xe(r)?ze(r,t):e[n]=t;}function ze(e){for(var t=arguments.length,n=new Array(t>1?t-1:0),r=1;r<t;r++)n[r-1]=arguments[r];for(var o=0,s=n;o<s.length;o++){var i=s[o];if(xe(i))for(var a in i)ke(a)&&Ve(e,i[a],a);}return e}var Be=React__default.createContext();Be.Consumer;function Ge(e){var t=reactExports.useContext(Be),n=reactExports.useMemo((function(){return function(e,t){if(!e)return R(14);if(w(e)){var n=e(t);return n}return Array.isArray(e)||"object"!=typeof e?R(8):t?m({},t,{},e):e}(e.theme,t)}),[e.theme,t]);return e.children?React__default.createElement(Be.Provider,{value:n},e.children):null}var Le={};function Fe(e,t,n){var o=b(e),i=!Te(e),a=t.attrs,c=void 0===a?g:a,l=t.componentId,d=void 0===l?function(e,t){var n="string"!=typeof e?"sc":De(e);Le[n]=(Le[n]||0)+1;var r=n+"-"+je("5.3.11"+n+Le[n]);return t?t+"-"+r:r}(t.displayName,t.parentComponentId):l,h=t.displayName,y=void 0===h?function(e){return Te(e)?"styled."+e:"Styled("+E(e)+")"}(e):h,v=t.displayName&&t.componentId?De(t.displayName)+"-"+t.componentId:t.componentId||d,_=o&&e.attrs?Array.prototype.concat(e.attrs,c).filter(Boolean):c,N=t.shouldForwardProp;o&&e.shouldForwardProp&&(N=t.shouldForwardProp?function(n,r,o){return e.shouldForwardProp(n,r,o)&&t.shouldForwardProp(n,r,o)}:e.shouldForwardProp);var A,C=new re(n,v,o?e.componentStyle:void 0),I=C.isStatic&&0===c.length,P=function(e,t){return function(e,t,n,r){var o=e.attrs,i=e.componentStyle,a=e.defaultProps,c=e.foldedComponentIds,l=e.shouldForwardProp,d=e.styledComponentId,h=e.target,f=function(e,t,n){void 0===e&&(e=S);var r=m({},t,{theme:e}),o={};return n.forEach((function(e){var t,n,s,i=e;for(t in w(i)&&(i=i(r)),i)r[t]=o[t]="className"===t?(n=o[t],s=i[t],n&&s?n+" "+s:n||s):i[t];})),[r,o]}(Pe(t,reactExports.useContext(Be),a)||S,t,o),y=f[0],v=f[1],g=function(e,t,n,r){var o=he(),s=pe(),i=t?e.generateAndInjectStyles(S,o,s):e.generateAndInjectStyles(n,o,s);return i}(i,r,y),E=n,b=v.$as||t.$as||v.as||t.as||h,_=Te(b),N=v!==t?m({},t,{},v):t,A={};for(var C in N)"$"!==C[0]&&"as"!==C&&("forwardedAs"===C?A.as=N[C]:(l?l(C,isPropValid,b):!_||isPropValid(C))&&(A[C]=N[C]));return t.style&&v.style!==t.style&&(A.style=m({},t.style,{},v.style)),A.className=Array.prototype.concat(c,d,g!==d?g:null,t.className,v.className).filter(Boolean).join(" "),A.ref=E,reactExports.createElement(b,A)}(A,e,t,I)};return P.displayName=y,(A=React__default.forwardRef(P)).attrs=_,A.componentStyle=C,A.displayName=y,A.shouldForwardProp=N,A.foldedComponentIds=o?Array.prototype.concat(e.foldedComponentIds,e.styledComponentId):g,A.styledComponentId=v,A.target=o?e.target:e,A.withComponent=function(e){var r=t.componentId,o=function(e,t){if(null==e)return {};var n,r,o={},s=Object.keys(e);for(r=0;r<s.length;r++)n=s[r],t.indexOf(n)>=0||(o[n]=e[n]);return o}(t,["componentId"]),s=r&&r+"-"+(Te(e)?e:De(E(e)));return Fe(e,m({},o,{attrs:_,componentId:s}),n)},Object.defineProperty(A,"defaultProps",{get:function(){return this._foldedDefaultProps},set:function(t){this._foldedDefaultProps=o?ze({},e.defaultProps,t):t;}}),Object.defineProperty(A,"toString",{value:function(){return "."+A.styledComponentId}}),i&&f(A,e,{attrs:!0,componentStyle:!0,displayName:!0,foldedComponentIds:!0,shouldForwardProp:!0,styledComponentId:!0,target:!0,withComponent:!0}),A}var Ye=function(e){return function e(t,r,o){if(void 0===o&&(o=S),!reactIsExports$1.isValidElementType(r))return R(1,String(r));var s=function(){return t(r,o,Ne.apply(void 0,arguments))};return s.withConfig=function(n){return e(t,r,m({},o,{},n))},s.attrs=function(n){return e(t,r,m({},o,{attrs:Array.prototype.concat(o.attrs,n).filter(Boolean)}))},s}(Fe,e)};["a","abbr","address","area","article","aside","audio","b","base","bdi","bdo","big","blockquote","body","br","button","canvas","caption","cite","code","col","colgroup","data","datalist","dd","del","details","dfn","dialog","div","dl","dt","em","embed","fieldset","figcaption","figure","footer","form","h1","h2","h3","h4","h5","h6","head","header","hgroup","hr","html","i","iframe","img","input","ins","kbd","keygen","label","legend","li","link","main","map","mark","marquee","menu","menuitem","meta","meter","nav","noscript","object","ol","optgroup","option","output","p","param","picture","pre","progress","q","rp","rt","ruby","s","samp","script","section","select","small","source","span","strong","style","sub","summary","sup","table","tbody","td","textarea","tfoot","th","thead","time","title","tr","track","u","ul","var","video","wbr","circle","clipPath","defs","ellipse","foreignObject","g","image","line","linearGradient","marker","mask","path","pattern","polygon","polyline","radialGradient","rect","stop","svg","text","textPath","tspan"].forEach((function(e){Ye[e]=Ye(e);}));function $e(e){for(var t=arguments.length,n=new Array(t>1?t-1:0),r=1;r<t;r++)n[r-1]=arguments[r];var o=Ne.apply(void 0,[e].concat(n)).join(""),s=je(o);return new me(s,o)}
+function m(){return (m=Object.assign||function(e){for(var t=1;t<arguments.length;t++){var n=arguments[t];for(var r in n)Object.prototype.hasOwnProperty.call(n,r)&&(e[r]=n[r]);}return e}).apply(this,arguments)}var y=function(e,t){for(var n=[e[0]],r=0,o=t.length;r<o;r+=1)n.push(t[r],e[r+1]);return n},v=function(t){return null!==t&&"object"==typeof t&&"[object Object]"===(t.toString?t.toString():Object.prototype.toString.call(t))&&!reactIsExports$1.typeOf(t)},g=Object.freeze([]),S=Object.freeze({});function w(e){return "function"==typeof e}function E(e){return e.displayName||e.name||"Component"}function b(e){return e&&"string"==typeof e.styledComponentId}var _="undefined"!=typeof process&&void 0!==process.env&&(process.env.REACT_APP_SC_ATTR||process.env.SC_ATTR)||"data-styled",A="undefined"!=typeof window&&"HTMLElement"in window,C=Boolean("boolean"==typeof SC_DISABLE_SPEEDY?SC_DISABLE_SPEEDY:"undefined"!=typeof process&&void 0!==process.env&&(void 0!==process.env.REACT_APP_SC_DISABLE_SPEEDY&&""!==process.env.REACT_APP_SC_DISABLE_SPEEDY?"false"!==process.env.REACT_APP_SC_DISABLE_SPEEDY&&process.env.REACT_APP_SC_DISABLE_SPEEDY:void 0!==process.env.SC_DISABLE_SPEEDY&&""!==process.env.SC_DISABLE_SPEEDY?"false"!==process.env.SC_DISABLE_SPEEDY&&process.env.SC_DISABLE_SPEEDY:"production"!=="production"));function R(e){for(var t=arguments.length,n=new Array(t>1?t-1:0),r=1;r<t;r++)n[r-1]=arguments[r];throw new Error("An error occurred. See https://git.io/JUIaE#"+e+" for more information."+(n.length>0?" Args: "+n.join(", "):""))}var D=function(){function e(e){this.groupSizes=new Uint32Array(512),this.length=512,this.tag=e;}var t=e.prototype;return t.indexOfGroup=function(e){for(var t=0,n=0;n<e;n++)t+=this.groupSizes[n];return t},t.insertRules=function(e,t){if(e>=this.groupSizes.length){for(var n=this.groupSizes,r=n.length,o=r;e>=o;)(o<<=1)<0&&R(16,""+e);this.groupSizes=new Uint32Array(o),this.groupSizes.set(n),this.length=o;for(var s=r;s<o;s++)this.groupSizes[s]=0;}for(var i=this.indexOfGroup(e+1),a=0,c=t.length;a<c;a++)this.tag.insertRule(i,t[a])&&(this.groupSizes[e]++,i++);},t.clearGroup=function(e){if(e<this.length){var t=this.groupSizes[e],n=this.indexOfGroup(e),r=n+t;this.groupSizes[e]=0;for(var o=n;o<r;o++)this.tag.deleteRule(n);}},t.getGroup=function(e){var t="";if(e>=this.length||0===this.groupSizes[e])return t;for(var n=this.groupSizes[e],r=this.indexOfGroup(e),o=r+n,s=r;s<o;s++)t+=this.tag.getRule(s)+"/*!sc*/\n";return t},e}(),j=new Map,T=new Map,x=1,k=function(e){if(j.has(e))return j.get(e);for(;T.has(x);)x++;var t=x++;return j.set(e,t),T.set(t,e),t},V=function(e){return T.get(e)},z=function(e,t){t>=x&&(x=t+1),j.set(e,t),T.set(t,e);},B="style["+_+'][data-styled-version="5.3.11"]',M=new RegExp("^"+_+'\\.g(\\d+)\\[id="([\\w\\d-]+)"\\].*?"([^"]*)'),G=function(e,t,n){for(var r,o=n.split(","),s=0,i=o.length;s<i;s++)(r=o[s])&&e.registerName(t,r);},L=function(e,t){for(var n=(t.textContent||"").split("/*!sc*/\n"),r=[],o=0,s=n.length;o<s;o++){var i=n[o].trim();if(i){var a=i.match(M);if(a){var c=0|parseInt(a[1],10),u=a[2];0!==c&&(z(u,c),G(e,u,a[3]),e.getTag().insertRules(c,r)),r.length=0;}else r.push(i);}}},F=function(){return "undefined"!=typeof __webpack_nonce__?__webpack_nonce__:null},Y=function(e){var t=document.head,n=e||t,r=document.createElement("style"),o=function(e){for(var t=e.childNodes,n=t.length;n>=0;n--){var r=t[n];if(r&&1===r.nodeType&&r.hasAttribute(_))return r}}(n),s=void 0!==o?o.nextSibling:null;r.setAttribute(_,"active"),r.setAttribute("data-styled-version","5.3.11");var i=F();return i&&r.setAttribute("nonce",i),n.insertBefore(r,s),r},q=function(){function e(e){var t=this.element=Y(e);t.appendChild(document.createTextNode("")),this.sheet=function(e){if(e.sheet)return e.sheet;for(var t=document.styleSheets,n=0,r=t.length;n<r;n++){var o=t[n];if(o.ownerNode===e)return o}R(17);}(t),this.length=0;}var t=e.prototype;return t.insertRule=function(e,t){try{return this.sheet.insertRule(t,e),this.length++,!0}catch(e){return !1}},t.deleteRule=function(e){this.sheet.deleteRule(e),this.length--;},t.getRule=function(e){var t=this.sheet.cssRules[e];return void 0!==t&&"string"==typeof t.cssText?t.cssText:""},e}(),H=function(){function e(e){var t=this.element=Y(e);this.nodes=t.childNodes,this.length=0;}var t=e.prototype;return t.insertRule=function(e,t){if(e<=this.length&&e>=0){var n=document.createTextNode(t),r=this.nodes[e];return this.element.insertBefore(n,r||null),this.length++,!0}return !1},t.deleteRule=function(e){this.element.removeChild(this.nodes[e]),this.length--;},t.getRule=function(e){return e<this.length?this.nodes[e].textContent:""},e}(),$=function(){function e(e){this.rules=[],this.length=0;}var t=e.prototype;return t.insertRule=function(e,t){return e<=this.length&&(this.rules.splice(e,0,t),this.length++,!0)},t.deleteRule=function(e){this.rules.splice(e,1),this.length--;},t.getRule=function(e){return e<this.length?this.rules[e]:""},e}(),W=A,U={isServer:!A,useCSSOMInjection:!C},J=function(){function e(e,t,n){void 0===e&&(e=S),void 0===t&&(t={}),this.options=m({},U,{},e),this.gs=t,this.names=new Map(n),this.server=!!e.isServer,!this.server&&A&&W&&(W=!1,function(e){for(var t=document.querySelectorAll(B),n=0,r=t.length;n<r;n++){var o=t[n];o&&"active"!==o.getAttribute(_)&&(L(e,o),o.parentNode&&o.parentNode.removeChild(o));}}(this));}e.registerId=function(e){return k(e)};var t=e.prototype;return t.reconstructWithOptions=function(t,n){return void 0===n&&(n=!0),new e(m({},this.options,{},t),this.gs,n&&this.names||void 0)},t.allocateGSInstance=function(e){return this.gs[e]=(this.gs[e]||0)+1},t.getTag=function(){return this.tag||(this.tag=(n=(t=this.options).isServer,r=t.useCSSOMInjection,o=t.target,e=n?new $(o):r?new q(o):new H(o),new D(e)));var e,t,n,r,o;},t.hasNameForId=function(e,t){return this.names.has(e)&&this.names.get(e).has(t)},t.registerName=function(e,t){if(k(e),this.names.has(e))this.names.get(e).add(t);else {var n=new Set;n.add(t),this.names.set(e,n);}},t.insertRules=function(e,t,n){this.registerName(e,t),this.getTag().insertRules(k(e),n);},t.clearNames=function(e){this.names.has(e)&&this.names.get(e).clear();},t.clearRules=function(e){this.getTag().clearGroup(k(e)),this.clearNames(e);},t.clearTag=function(){this.tag=void 0;},t.toString=function(){return function(e){for(var t=e.getTag(),n=t.length,r="",o=0;o<n;o++){var s=V(o);if(void 0!==s){var i=e.names.get(s),a=t.getGroup(o);if(i&&a&&i.size){var c=_+".g"+o+'[id="'+s+'"]',u="";void 0!==i&&i.forEach((function(e){e.length>0&&(u+=e+",");})),r+=""+a+c+'{content:"'+u+'"}/*!sc*/\n';}}}return r}(this)},e}(),X=/(a)(d)/gi,Z=function(e){return String.fromCharCode(e+(e>25?39:97))};function K(e){var t,n="";for(t=Math.abs(e);t>52;t=t/52|0)n=Z(t%52)+n;return (Z(t%52)+n).replace(X,"$1-$2")}var Q=function(e,t){for(var n=t.length;n;)e=33*e^t.charCodeAt(--n);return e},ee=function(e){return Q(5381,e)};function te(e){for(var t=0;t<e.length;t+=1){var n=e[t];if(w(n)&&!b(n))return !1}return !0}var ne=ee("5.3.11"),re=function(){function e(e,t,n){this.rules=e,this.staticRulesId="",this.isStatic=(void 0===n||n.isStatic)&&te(e),this.componentId=t,this.baseHash=Q(ne,t),this.baseStyle=n,J.registerId(t);}return e.prototype.generateAndInjectStyles=function(e,t,n){var r=this.componentId,o=[];if(this.baseStyle&&o.push(this.baseStyle.generateAndInjectStyles(e,t,n)),this.isStatic&&!n.hash)if(this.staticRulesId&&t.hasNameForId(r,this.staticRulesId))o.push(this.staticRulesId);else {var s=be(this.rules,e,t,n).join(""),i=K(Q(this.baseHash,s)>>>0);if(!t.hasNameForId(r,i)){var a=n(s,"."+i,void 0,r);t.insertRules(r,i,a);}o.push(i),this.staticRulesId=i;}else {for(var c=this.rules.length,u=Q(this.baseHash,n.hash),l="",d=0;d<c;d++){var h=this.rules[d];if("string"==typeof h)l+=h;else if(h){var p=be(h,e,t,n),f=Array.isArray(p)?p.join(""):p;u=Q(u,f+d),l+=f;}}if(l){var m=K(u>>>0);if(!t.hasNameForId(r,m)){var y=n(l,"."+m,void 0,r);t.insertRules(r,m,y);}o.push(m);}}return o.join(" ")},e}(),oe=/^\s*\/\/.*$/gm,se=[":","[",".","#"];function ie(e){var t,n,r,o,s=void 0===e?S:e,i=s.options,a=void 0===i?S:i,c=s.plugins,u=void 0===c?g:c,l=new stylis_min(a),h=[],p=function(e){function t(t){if(t)try{e(t+"}");}catch(e){}}return function(n,r,o,s,i,a,c,u,l,d){switch(n){case 1:if(0===l&&64===r.charCodeAt(0))return e(r+";"),"";break;case 2:if(0===u)return r+"/*|*/";break;case 3:switch(u){case 102:case 112:return e(o[0]+r),"";default:return r+(0===d?"/*|*/":"")}case-2:r.split("/*|*/}").forEach(t);}}}((function(e){h.push(e);})),f=function(e,r,s){return 0===r&&-1!==se.indexOf(s[n.length])||s.match(o)?e:"."+t};function m(e,s,i,a){void 0===a&&(a="&");var c=e.replace(oe,""),u=s&&i?i+" "+s+" { "+c+" }":c;return t=a,n=s,r=new RegExp("\\"+n+"\\b","g"),o=new RegExp("(\\"+n+"\\b){2,}"),l(i||!s?"":s,u)}return l.use([].concat(u,[function(e,t,o){2===e&&o.length&&o[0].lastIndexOf(n)>0&&(o[0]=o[0].replace(r,f));},p,function(e){if(-2===e){var t=h;return h=[],t}}])),m.hash=u.length?u.reduce((function(e,t){return t.name||R(15),Q(e,t.name)}),5381).toString():"",m}var ae=React__default.createContext();ae.Consumer;var ue=React__default.createContext(),le=(ue.Consumer,new J),de=ie();function he(){return reactExports.useContext(ae)||le}function pe(){return reactExports.useContext(ue)||de}var me=function(){function e(e,t){var n=this;this.inject=function(e,t){void 0===t&&(t=de);var r=n.name+t.hash;e.hasNameForId(n.id,r)||e.insertRules(n.id,r,t(n.rules,r,"@keyframes"));},this.toString=function(){return R(12,String(n.name))},this.name=e,this.id="sc-keyframes-"+e,this.rules=t;}return e.prototype.getName=function(e){return void 0===e&&(e=de),this.name+e.hash},e}(),ye=/([A-Z])/,ve=/([A-Z])/g,ge=/^ms-/,Se=function(e){return "-"+e.toLowerCase()};function we(e){return ye.test(e)?e.replace(ve,Se).replace(ge,"-ms-"):e}var Ee=function(e){return null==e||!1===e||""===e};function be(e,n,r,o){if(Array.isArray(e)){for(var s,i=[],a=0,c=e.length;a<c;a+=1)""!==(s=be(e[a],n,r,o))&&(Array.isArray(s)?i.push.apply(i,s):i.push(s));return i}if(Ee(e))return "";if(b(e))return "."+e.styledComponentId;if(w(e)){if("function"!=typeof(l=e)||l.prototype&&l.prototype.isReactComponent||!n)return e;var u=e(n);return be(u,n,r,o)}var l;return e instanceof me?r?(e.inject(r,o),e.getName(o)):e:v(e)?function e(t,n){var r,o,s=[];for(var i in t)t.hasOwnProperty(i)&&!Ee(t[i])&&(Array.isArray(t[i])&&t[i].isCss||w(t[i])?s.push(we(i)+":",t[i],";"):v(t[i])?s.push.apply(s,e(t[i],i)):s.push(we(i)+": "+(r=i,null==(o=t[i])||"boolean"==typeof o||""===o?"":"number"!=typeof o||0===o||r in unitlessKeys||r.startsWith("--")?String(o).trim():o+"px")+";"));return n?[n+" {"].concat(s,["}"]):s}(e):e.toString()}var _e=function(e){return Array.isArray(e)&&(e.isCss=!0),e};function Ne(e){for(var t=arguments.length,n=new Array(t>1?t-1:0),r=1;r<t;r++)n[r-1]=arguments[r];return w(e)||v(e)?_e(be(y(g,[e].concat(n)))):0===n.length&&1===e.length&&"string"==typeof e[0]?e:_e(be(y(e,n)))}var Pe=function(e,t,n){return void 0===n&&(n=S),e.theme!==n.theme&&e.theme||t||n.theme},Oe=/[!"#$%&'()*+,./:;<=>?@[\\\]^`{|}~-]+/g,Re=/(^-|-$)/g;function De(e){return e.replace(Oe,"-").replace(Re,"")}var je=function(e){return K(ee(e)>>>0)};function Te(e){return "string"==typeof e&&("production"==="production")}var xe=function(e){return "function"==typeof e||"object"==typeof e&&null!==e&&!Array.isArray(e)},ke=function(e){return "__proto__"!==e&&"constructor"!==e&&"prototype"!==e};function Ve(e,t,n){var r=e[n];xe(t)&&xe(r)?ze(r,t):e[n]=t;}function ze(e){for(var t=arguments.length,n=new Array(t>1?t-1:0),r=1;r<t;r++)n[r-1]=arguments[r];for(var o=0,s=n;o<s.length;o++){var i=s[o];if(xe(i))for(var a in i)ke(a)&&Ve(e,i[a],a);}return e}var Be=React__default.createContext();Be.Consumer;function Ge(e){var t=reactExports.useContext(Be),n=reactExports.useMemo((function(){return function(e,t){if(!e)return R(14);if(w(e)){var n=e(t);return n}return Array.isArray(e)||"object"!=typeof e?R(8):t?m({},t,{},e):e}(e.theme,t)}),[e.theme,t]);return e.children?React__default.createElement(Be.Provider,{value:n},e.children):null}var Le={};function Fe(e,t,n){var o=b(e),i=!Te(e),a=t.attrs,c=void 0===a?g:a,l=t.componentId,d=void 0===l?function(e,t){var n="string"!=typeof e?"sc":De(e);Le[n]=(Le[n]||0)+1;var r=n+"-"+je("5.3.11"+n+Le[n]);return t?t+"-"+r:r}(t.displayName,t.parentComponentId):l,h=t.displayName,y=void 0===h?function(e){return Te(e)?"styled."+e:"Styled("+E(e)+")"}(e):h,v=t.displayName&&t.componentId?De(t.displayName)+"-"+t.componentId:t.componentId||d,_=o&&e.attrs?Array.prototype.concat(e.attrs,c).filter(Boolean):c,N=t.shouldForwardProp;o&&e.shouldForwardProp&&(N=t.shouldForwardProp?function(n,r,o){return e.shouldForwardProp(n,r,o)&&t.shouldForwardProp(n,r,o)}:e.shouldForwardProp);var A,C=new re(n,v,o?e.componentStyle:void 0),I=C.isStatic&&0===c.length,P=function(e,t){return function(e,t,n,r){var o=e.attrs,i=e.componentStyle,a=e.defaultProps,c=e.foldedComponentIds,l=e.shouldForwardProp,d=e.styledComponentId,h=e.target,f=function(e,t,n){void 0===e&&(e=S);var r=m({},t,{theme:e}),o={};return n.forEach((function(e){var t,n,s,i=e;for(t in w(i)&&(i=i(r)),i)r[t]=o[t]="className"===t?(n=o[t],s=i[t],n&&s?n+" "+s:n||s):i[t];})),[r,o]}(Pe(t,reactExports.useContext(Be),a)||S,t,o),y=f[0],v=f[1],g=function(e,t,n,r){var o=he(),s=pe(),i=t?e.generateAndInjectStyles(S,o,s):e.generateAndInjectStyles(n,o,s);return i}(i,r,y),E=n,b=v.$as||t.$as||v.as||t.as||h,_=Te(b),N=v!==t?m({},t,{},v):t,A={};for(var C in N)"$"!==C[0]&&"as"!==C&&("forwardedAs"===C?A.as=N[C]:(l?l(C,isPropValid,b):!_||isPropValid(C))&&(A[C]=N[C]));return t.style&&v.style!==t.style&&(A.style=m({},t.style,{},v.style)),A.className=Array.prototype.concat(c,d,g!==d?g:null,t.className,v.className).filter(Boolean).join(" "),A.ref=E,reactExports.createElement(b,A)}(A,e,t,I)};return P.displayName=y,(A=React__default.forwardRef(P)).attrs=_,A.componentStyle=C,A.displayName=y,A.shouldForwardProp=N,A.foldedComponentIds=o?Array.prototype.concat(e.foldedComponentIds,e.styledComponentId):g,A.styledComponentId=v,A.target=o?e.target:e,A.withComponent=function(e){var r=t.componentId,o=function(e,t){if(null==e)return {};var n,r,o={},s=Object.keys(e);for(r=0;r<s.length;r++)n=s[r],t.indexOf(n)>=0||(o[n]=e[n]);return o}(t,["componentId"]),s=r&&r+"-"+(Te(e)?e:De(E(e)));return Fe(e,m({},o,{attrs:_,componentId:s}),n)},Object.defineProperty(A,"defaultProps",{get:function(){return this._foldedDefaultProps},set:function(t){this._foldedDefaultProps=o?ze({},e.defaultProps,t):t;}}),Object.defineProperty(A,"toString",{value:function(){return "."+A.styledComponentId}}),i&&f(A,e,{attrs:!0,componentStyle:!0,displayName:!0,foldedComponentIds:!0,shouldForwardProp:!0,styledComponentId:!0,target:!0,withComponent:!0}),A}var Ye=function(e){return function e(t,r,o){if(void 0===o&&(o=S),!reactIsExports$1.isValidElementType(r))return R(1,String(r));var s=function(){return t(r,o,Ne.apply(void 0,arguments))};return s.withConfig=function(n){return e(t,r,m({},o,{},n))},s.attrs=function(n){return e(t,r,m({},o,{attrs:Array.prototype.concat(o.attrs,n).filter(Boolean)}))},s}(Fe,e)};["a","abbr","address","area","article","aside","audio","b","base","bdi","bdo","big","blockquote","body","br","button","canvas","caption","cite","code","col","colgroup","data","datalist","dd","del","details","dfn","dialog","div","dl","dt","em","embed","fieldset","figcaption","figure","footer","form","h1","h2","h3","h4","h5","h6","head","header","hgroup","hr","html","i","iframe","img","input","ins","kbd","keygen","label","legend","li","link","main","map","mark","marquee","menu","menuitem","meta","meter","nav","noscript","object","ol","optgroup","option","output","p","param","picture","pre","progress","q","rp","rt","ruby","s","samp","script","section","select","small","source","span","strong","style","sub","summary","sup","table","tbody","td","textarea","tfoot","th","thead","time","title","tr","track","u","ul","var","video","wbr","circle","clipPath","defs","ellipse","foreignObject","g","image","line","linearGradient","marker","mask","path","pattern","polygon","polyline","radialGradient","rect","stop","svg","text","textPath","tspan"].forEach((function(e){Ye[e]=Ye(e);}));function $e(e){for(var t=arguments.length,n=new Array(t>1?t-1:0),r=1;r<t;r++)n[r-1]=arguments[r];var o=Ne.apply(void 0,[e].concat(n)).join(""),s=je(o);return new me(s,o)}var styled = Ye;
 
 var propTypes = {exports: {}};
 
@@ -1780,7 +1780,7 @@ function useId(providedId) {
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-function composeEventHandlers$1() {
+function composeEventHandlers$2() {
   for (var _len = arguments.length, fns = new Array(_len), _key = 0; _key < _len; _key++) {
     fns[_key] = arguments[_key];
   }
@@ -1795,7 +1795,7 @@ function composeEventHandlers$1() {
   };
 }
 
-function getControlledValue() {
+function getControlledValue$1() {
   for (var _len = arguments.length, values = new Array(_len), _key = 0; _key < _len; _key++) {
     values[_key] = arguments[_key];
   }
@@ -1834,7 +1834,7 @@ const KEY_CODES = {
   TAB: 9,
   UP: 38
 };
-const KEYS$1 = {
+const KEYS$2 = {
   ALT: 'Alt',
   ASTERISK: '*',
   BACKSPACE: 'Backspace',
@@ -1863,7 +1863,7 @@ const KEYS$1 = {
   UP: 'ArrowUp'
 };
 
-var DocumentPosition$1;
+var DocumentPosition$2;
 (function (DocumentPosition) {
   DocumentPosition[DocumentPosition["DISCONNECTED"] = 1] = "DISCONNECTED";
   DocumentPosition[DocumentPosition["PRECEDING"] = 2] = "PRECEDING";
@@ -1871,7 +1871,7 @@ var DocumentPosition$1;
   DocumentPosition[DocumentPosition["CONTAINS"] = 8] = "CONTAINS";
   DocumentPosition[DocumentPosition["CONTAINED_BY"] = 16] = "CONTAINED_BY";
   DocumentPosition[DocumentPosition["IMPLEMENTATION_SPECIFIC"] = 32] = "IMPLEMENTATION_SPECIFIC";
-})(DocumentPosition$1 || (DocumentPosition$1 = {}));
+})(DocumentPosition$2 || (DocumentPosition$2 = {}));
 
 function _extends$w() {
   _extends$w = Object.assign ? Object.assign.bind() : function (target) {
@@ -4353,7 +4353,7 @@ const ThemeProvider = _ref => {
   } = _ref;
   const scopeRef = reactExports.useRef(null);
   const relativeDocument = useDocument(theme);
-  const controlledScopeRef = focusVisibleRef === null ? React__default.createRef() : getControlledValue(focusVisibleRef, scopeRef);
+  const controlledScopeRef = focusVisibleRef === null ? React__default.createRef() : getControlledValue$1(focusVisibleRef, scopeRef);
   useFocusVisible({
     scope: controlledScopeRef,
     relativeDocument
@@ -5169,7 +5169,7 @@ var debounce$3 = /*@__PURE__*/getDefaultExportFromCjs(lodash_debounce);
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-function composeEventHandlers() {
+function composeEventHandlers$1() {
   for (var _len = arguments.length, fns = new Array(_len), _key = 0; _key < _len; _key++) {
     fns[_key] = arguments[_key];
   }
@@ -5183,7 +5183,7 @@ function composeEventHandlers() {
     });
   };
 }
-const KEYS = {
+const KEYS$1 = {
   ALT: 'Alt',
   ASTERISK: '*',
   BACKSPACE: 'Backspace',
@@ -5211,7 +5211,7 @@ const KEYS = {
   UNIDENTIFIED: 'Unidentified',
   UP: 'ArrowUp'
 };
-var DocumentPosition;
+var DocumentPosition$1;
 (function (DocumentPosition) {
   DocumentPosition[DocumentPosition["DISCONNECTED"] = 1] = "DISCONNECTED";
   DocumentPosition[DocumentPosition["PRECEDING"] = 2] = "PRECEDING";
@@ -5219,7 +5219,7 @@ var DocumentPosition;
   DocumentPosition[DocumentPosition["CONTAINS"] = 8] = "CONTAINS";
   DocumentPosition[DocumentPosition["CONTAINED_BY"] = 16] = "CONTAINED_BY";
   DocumentPosition[DocumentPosition["IMPLEMENTATION_SPECIFIC"] = 32] = "IMPLEMENTATION_SPECIFIC";
-})(DocumentPosition || (DocumentPosition = {}));
+})(DocumentPosition$1 || (DocumentPosition$1 = {}));
 
 const SLIDER_MIN = 0;
 const SLIDER_MAX = 100;
@@ -5348,7 +5348,7 @@ function useSlider(_ref) {
       'data-garden-container-id': 'containers.slider.track',
       'data-garden-container-version': '0.1.6',
       'aria-disabled': disabled,
-      onMouseDown: composeEventHandlers(onMouseDown, handleMouseDown),
+      onMouseDown: composeEventHandlers$1(onMouseDown, handleMouseDown),
       ...other
     };
   }, [disabled, getTrackPosition, maxThumbRef, minThumbRef, position.maxValue, position.minValue, setThumbPosition]);
@@ -5363,28 +5363,28 @@ function useSlider(_ref) {
       if (!disabled) {
         let value;
         switch (event.key) {
-          case KEYS.RIGHT:
+          case KEYS$1.RIGHT:
             value = (thumb === 'min' ? position.minValue : position.maxValue) + (rtl ? -step : step);
             break;
-          case KEYS.UP:
+          case KEYS$1.UP:
             value = (thumb === 'min' ? position.minValue : position.maxValue) + step;
             break;
-          case KEYS.LEFT:
+          case KEYS$1.LEFT:
             value = (thumb === 'min' ? position.minValue : position.maxValue) - (rtl ? -step : step);
             break;
-          case KEYS.DOWN:
+          case KEYS$1.DOWN:
             value = (thumb === 'min' ? position.minValue : position.maxValue) - step;
             break;
-          case KEYS.PAGE_UP:
+          case KEYS$1.PAGE_UP:
             value = (thumb === 'min' ? position.minValue : position.maxValue) + jump;
             break;
-          case KEYS.PAGE_DOWN:
+          case KEYS$1.PAGE_DOWN:
             value = (thumb === 'min' ? position.minValue : position.maxValue) - jump;
             break;
-          case KEYS.HOME:
+          case KEYS$1.HOME:
             value = min;
             break;
-          case KEYS.END:
+          case KEYS$1.END:
             value = max;
             break;
         }
@@ -5439,9 +5439,9 @@ function useSlider(_ref) {
       'aria-valuemin': thumb === 'min' ? min : position.minValue,
       'aria-valuemax': thumb === 'min' ? position.maxValue : max,
       'aria-valuenow': thumb === 'min' ? position.minValue : position.maxValue,
-      onKeyDown: composeEventHandlers(onKeyDown, handleKeyDown),
-      onMouseDown: composeEventHandlers(onMouseDown, handleMouseDown),
-      onTouchStart: composeEventHandlers(onTouchStart, handleTouchStart),
+      onKeyDown: composeEventHandlers$1(onKeyDown, handleKeyDown),
+      onMouseDown: composeEventHandlers$1(onMouseDown, handleMouseDown),
+      onTouchStart: composeEventHandlers$1(onTouchStart, handleTouchStart),
       ...other
     };
   }, [doc, disabled, getTrackPosition, jump, max, min, position.maxValue, position.minValue, rtl, step, setThumbPosition]);
@@ -5503,7 +5503,7 @@ const useFieldContext$1 = () => {
 };
 
 const COMPONENT_ID$K = 'forms.field';
-const StyledField$1 = Ye.div.attrs({
+const StyledField$1 = styled.div.attrs({
   'data-garden-id': COMPONENT_ID$K,
   'data-garden-version': '8.69.1'
 }).withConfig({
@@ -5515,7 +5515,7 @@ StyledField$1.defaultProps = {
 };
 
 const COMPONENT_ID$J = 'forms.fieldset';
-const StyledFieldset = Ye(StyledField$1).attrs({
+const StyledFieldset = styled(StyledField$1).attrs({
   as: 'fieldset',
   'data-garden-id': COMPONENT_ID$J,
   'data-garden-version': '8.69.1'
@@ -5528,7 +5528,7 @@ StyledFieldset.defaultProps = {
 };
 
 const COMPONENT_ID$I = 'forms.input_label';
-const StyledLabel$1 = Ye.label.attrs({
+const StyledLabel$1 = styled.label.attrs({
   'data-garden-id': COMPONENT_ID$I,
   'data-garden-version': '8.69.1'
 }).withConfig({
@@ -5540,7 +5540,7 @@ StyledLabel$1.defaultProps = {
 };
 
 const COMPONENT_ID$H = 'forms.fieldset_legend';
-const StyledLegend = Ye(StyledLabel$1).attrs({
+const StyledLegend = styled(StyledLabel$1).attrs({
   as: 'legend',
   'data-garden-id': COMPONENT_ID$H,
   'data-garden-version': '8.69.1'
@@ -5553,7 +5553,7 @@ StyledLegend.defaultProps = {
 };
 
 const COMPONENT_ID$G = 'forms.input_hint';
-const StyledHint$1 = Ye.div.attrs({
+const StyledHint$1 = styled.div.attrs({
   'data-garden-id': COMPONENT_ID$G,
   'data-garden-version': '8.69.1'
 }).withConfig({
@@ -5564,9 +5564,9 @@ StyledHint$1.defaultProps = {
   theme: DEFAULT_THEME
 };
 
-var _g$2, _circle$5;
+var _g$2$1, _circle$5;
 function _extends$s() { _extends$s = Object.assign ? Object.assign.bind() : function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends$s.apply(this, arguments); }
-var SvgAlertErrorStroke = function SvgAlertErrorStroke(props) {
+var SvgAlertErrorStroke$1 = function SvgAlertErrorStroke(props) {
   return /*#__PURE__*/reactExports.createElement("svg", _extends$s({
     xmlns: "http://www.w3.org/2000/svg",
     width: 16,
@@ -5574,7 +5574,7 @@ var SvgAlertErrorStroke = function SvgAlertErrorStroke(props) {
     focusable: "false",
     viewBox: "0 0 16 16",
     "aria-hidden": "true"
-  }, props), _g$2 || (_g$2 = /*#__PURE__*/reactExports.createElement("g", {
+  }, props), _g$2$1 || (_g$2$1 = /*#__PURE__*/reactExports.createElement("g", {
     fill: "none",
     stroke: "currentColor"
   }, /*#__PURE__*/reactExports.createElement("circle", {
@@ -5594,7 +5594,7 @@ var SvgAlertErrorStroke = function SvgAlertErrorStroke(props) {
 
 var _path$n, _circle$4;
 function _extends$r() { _extends$r = Object.assign ? Object.assign.bind() : function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends$r.apply(this, arguments); }
-var SvgAlertWarningStroke = function SvgAlertWarningStroke(props) {
+var SvgAlertWarningStroke$1 = function SvgAlertWarningStroke(props) {
   return /*#__PURE__*/reactExports.createElement("svg", _extends$r({
     xmlns: "http://www.w3.org/2000/svg",
     width: 16,
@@ -5615,7 +5615,7 @@ var SvgAlertWarningStroke = function SvgAlertWarningStroke(props) {
   })));
 };
 
-var _g$1;
+var _g$1$1;
 function _extends$q() { _extends$q = Object.assign ? Object.assign.bind() : function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends$q.apply(this, arguments); }
 var SvgCheckCircleStroke$1 = function SvgCheckCircleStroke(props) {
   return /*#__PURE__*/reactExports.createElement("svg", _extends$q({
@@ -5625,7 +5625,7 @@ var SvgCheckCircleStroke$1 = function SvgCheckCircleStroke(props) {
     focusable: "false",
     viewBox: "0 0 16 16",
     "aria-hidden": "true"
-  }, props), _g$1 || (_g$1 = /*#__PURE__*/reactExports.createElement("g", {
+  }, props), _g$1$1 || (_g$1$1 = /*#__PURE__*/reactExports.createElement("g", {
     fill: "none",
     stroke: "currentColor"
   }, /*#__PURE__*/reactExports.createElement("path", {
@@ -5647,18 +5647,18 @@ const MessageIcon = _ref => {
   } = _ref;
   let retVal;
   if (validation === 'error') {
-    retVal = React__default.createElement(SvgAlertErrorStroke, props);
+    retVal = React__default.createElement(SvgAlertErrorStroke$1, props);
   } else if (validation === 'success') {
     retVal = React__default.createElement(SvgCheckCircleStroke$1, props);
   } else if (validation === 'warning') {
-    retVal = React__default.createElement(SvgAlertWarningStroke, props);
+    retVal = React__default.createElement(SvgAlertWarningStroke$1, props);
   } else {
     retVal = React__default.cloneElement(reactExports.Children.only(children));
   }
   return retVal;
 };
 const COMPONENT_ID$F = 'forms.input_message_icon';
-const StyledMessageIcon = Ye(MessageIcon).attrs({
+const StyledMessageIcon = styled(MessageIcon).attrs({
   'data-garden-id': COMPONENT_ID$F,
   'data-garden-version': '8.69.1',
   'aria-hidden': null
@@ -5686,7 +5686,7 @@ const validationStyles = props => {
   return Ne(["padding-", ":", ";color:", ";"], rtl ? 'right' : 'left', props.validation && padding, color);
 };
 const COMPONENT_ID$E = 'forms.input_message';
-const StyledMessage$1 = Ye.div.attrs({
+const StyledMessage$1 = styled.div.attrs({
   'data-garden-id': COMPONENT_ID$E,
   'data-garden-version': '8.69.1'
 }).withConfig({
@@ -5776,7 +5776,7 @@ const sizeStyles$f = props => {
   const swatchMarginHorizontal = math(`${paddingVertical} + ${swatchMarginVertical} - ${paddingHorizontal}`);
   return Ne(["padding:", ";min-height:", ";line-height:", ";font-size:", ";&::-ms-browse{font-size:", ";}&[type='date'],&[type='datetime-local'],&[type='file'],&[type='month'],&[type='time'],&[type='week']{max-height:", ";}&[type='file']{line-height:1;}@supports (-ms-ime-align:auto){&[type='color']{padding:", ";}}&::-moz-color-swatch{margin-top:", ";margin-left:", ";width:calc(100% + ", ");height:", ";}&::-webkit-color-swatch{margin:", " ", ";}", ":not([hidden]) + &&,", " + &&,", " + &&,&& + ", ",&& + ", "{margin-top:", "px;}"], padding, props.isBare ? '1em' : height, getLineHeight(lineHeight, fontSize), fontSize, browseFontSize, height, props.isCompact ? '0 2px' : '1px 3px', swatchMarginVertical, swatchMarginHorizontal, math(`${swatchMarginHorizontal} * -2`), swatchHeight, swatchMarginVertical, swatchMarginHorizontal, StyledLabel$1, StyledHint$1, StyledMessage$1, StyledHint$1, StyledMessage$1, props.theme.space.base * (props.isCompact ? 1 : 2));
 };
-const StyledTextInput = Ye.input.attrs(props => ({
+const StyledTextInput = styled.input.attrs(props => ({
   'data-garden-id': COMPONENT_ID$D,
   'data-garden-version': '8.69.1',
   'aria-invalid': isInvalid(props.validation)
@@ -5798,7 +5798,7 @@ const hiddenStyles = `
   left: 0;
   transform: translateZ(0);
 `;
-const StyledTextarea = Ye(StyledTextInput).attrs({
+const StyledTextarea = styled(StyledTextInput).attrs({
   as: 'textarea',
   'data-garden-id': COMPONENT_ID$C,
   'data-garden-version': '8.69.1'
@@ -5811,7 +5811,7 @@ StyledTextarea.defaultProps = {
 };
 
 const COMPONENT_ID$B = 'forms.media_figure';
-const colorStyles$b = props => {
+const colorStyles$b$1 = props => {
   let shade = 600;
   if (props.isDisabled) {
     shade = 400;
@@ -5832,7 +5832,7 @@ const sizeStyles$e = props => {
   }
   return Ne(["margin:", ";width:", ";height:", ";"], margin, size, size);
 };
-const StyledTextMediaFigure = Ye(
+const StyledTextMediaFigure = styled(
 _ref => {
   let {
     children,
@@ -5851,7 +5851,7 @@ _ref => {
 }).withConfig({
   displayName: "StyledTextMediaFigure",
   componentId: "sc-1qepknj-0"
-})(["transform:", ";transition:transform 0.25s ease-in-out,color 0.25s ease-in-out;", ";", " ", ";"], props => props.isRotated && `rotate(${props.theme.rtl ? '-' : '+'}180deg)`, props => colorStyles$b(props), props => sizeStyles$e(props), props => retrieveComponentStyles(COMPONENT_ID$B, props));
+})(["transform:", ";transition:transform 0.25s ease-in-out,color 0.25s ease-in-out;", ";", " ", ";"], props => props.isRotated && `rotate(${props.theme.rtl ? '-' : '+'}180deg)`, props => colorStyles$b$1(props), props => sizeStyles$e(props), props => retrieveComponentStyles(COMPONENT_ID$B, props));
 StyledTextMediaFigure.defaultProps = {
   theme: DEFAULT_THEME
 };
@@ -5889,7 +5889,7 @@ const colorStyles$a$1 = props => {
     }
   }));
 };
-const StyledTextFauxInput = Ye(StyledTextInput).attrs(props => ({
+const StyledTextFauxInput = styled(StyledTextInput).attrs(props => ({
   as: 'div',
   'aria-readonly': props.isReadOnly,
   'aria-disabled': props.isDisabled,
@@ -5904,7 +5904,7 @@ StyledTextFauxInput.defaultProps = {
 };
 
 const COMPONENT_ID$z = 'forms.media_input';
-const StyledTextMediaInput = Ye(StyledTextInput).attrs({
+const StyledTextMediaInput = styled(StyledTextInput).attrs({
   'data-garden-id': COMPONENT_ID$z,
   'data-garden-version': '8.69.1',
   isBare: true
@@ -5926,7 +5926,7 @@ const itemStyles = props => {
   const endDirection = props.theme.rtl ? 'left' : 'right';
   return Ne(["& > *{z-index:-1;}& > ", "{z-index:0;}& > ", ":disabled{z-index:-2;}& > ", ":hover,& > button:hover,& > ", ":focus-visible,& > button:focus-visible,& > ", "[data-garden-focus-visible],& > button[data-garden-focus-visible],& > ", ":active,& > button:active{z-index:1;}& > button:disabled{border-top-width:0;border-bottom-width:0;}& > *:not(:first-child){margin-", ":-", ";}& > *:first-child:not(:last-child){border-top-", "-radius:0;border-bottom-", "-radius:0;}& > *:last-child:not(:first-child){border-top-", "-radius:0;border-bottom-", "-radius:0;}& > *:not(:first-child):not(:last-child){border-radius:0;}"], StyledTextInput, StyledTextInput, StyledTextInput, StyledTextInput, StyledTextInput, StyledTextInput, startDirection, props.theme.borderWidths.sm, endDirection, endDirection, startDirection, startDirection);
 };
-const StyledInputGroup$1 = Ye.div.attrs({
+const StyledInputGroup$1 = styled.div.attrs({
   'data-garden-id': COMPONENT_ID$y,
   'data-garden-version': '8.69.1'
 }).withConfig({
@@ -5938,26 +5938,26 @@ StyledInputGroup$1.defaultProps = {
 };
 
 const COMPONENT_ID$x = 'forms.radio_label';
-const sizeStyles$d = props => {
+const sizeStyles$d$1 = props => {
   const size = props.theme.space.base * 4;
   const padding = size + props.theme.space.base * 2;
   const lineHeight = props.theme.space.base * 5;
   return Ne(["padding-", ":", "px;&[hidden]{padding-", ":", "px;line-height:", "px;}"], props.theme.rtl ? 'right' : 'left', padding, props.theme.rtl ? 'right' : 'left', size, lineHeight);
 };
-const StyledRadioLabel = Ye(StyledLabel$1).attrs({
+const StyledRadioLabel = styled(StyledLabel$1).attrs({
   'data-garden-id': COMPONENT_ID$x,
   'data-garden-version': '8.69.1',
   isRadio: true
 }).withConfig({
   displayName: "StyledRadioLabel",
   componentId: "sc-1aq2e5t-0"
-})(["display:inline-block;position:relative;cursor:pointer;", ";", ";"], props => sizeStyles$d(props), props => retrieveComponentStyles(COMPONENT_ID$x, props));
+})(["display:inline-block;position:relative;cursor:pointer;", ";", ";"], props => sizeStyles$d$1(props), props => retrieveComponentStyles(COMPONENT_ID$x, props));
 StyledRadioLabel.defaultProps = {
   theme: DEFAULT_THEME
 };
 
 const COMPONENT_ID$w = 'forms.checkbox_label';
-const StyledCheckLabel = Ye(StyledRadioLabel).attrs({
+const StyledCheckLabel = styled(StyledRadioLabel).attrs({
   'data-garden-id': COMPONENT_ID$w,
   'data-garden-version': '8.69.1'
 }).withConfig({
@@ -5969,7 +5969,7 @@ StyledCheckLabel.defaultProps = {
 };
 
 const COMPONENT_ID$v = 'forms.radio_hint';
-const StyledRadioHint = Ye(StyledHint$1).attrs({
+const StyledRadioHint = styled(StyledHint$1).attrs({
   'data-garden-id': COMPONENT_ID$v,
   'data-garden-version': '8.69.1'
 }).withConfig({
@@ -5981,7 +5981,7 @@ StyledRadioHint.defaultProps = {
 };
 
 const COMPONENT_ID$u = 'forms.checkbox_hint';
-const StyledCheckHint = Ye(StyledRadioHint).attrs({
+const StyledCheckHint = styled(StyledRadioHint).attrs({
   'data-garden-id': COMPONENT_ID$u,
   'data-garden-version': '8.69.1'
 }).withConfig({
@@ -6028,7 +6028,7 @@ const sizeStyles$c$1 = props => {
   const marginTop = `${props.theme.space.base * (props.isCompact ? 1 : 2)}px`;
   return Ne(["top:", ";width:", ";height:", ";& ~ ", "::before{top:", ";background-size:", ";width:", ";height:", ";box-sizing:border-box;}& ~ ", " > svg{top:", ";", ":", ";width:", ";height:", ";}&& ~ ", " ~ ", "{margin-top:", ";}"], top, size, size, StyledRadioLabel, top, props.theme.iconSizes.sm, size, size, StyledRadioLabel, iconTop, props.theme.rtl ? 'right' : 'left', iconPosition, iconSize, iconSize, StyledRadioLabel, StyledMessage$1, marginTop);
 };
-const StyledRadioInput = Ye.input.attrs({
+const StyledRadioInput = styled.input.attrs({
   'data-garden-id': COMPONENT_ID$t,
   'data-garden-version': '8.69.1',
   type: 'radio'
@@ -6050,7 +6050,7 @@ const colorStyles$8$1 = props => {
   const indeterminateDisabledBackgroundColor = getColor('neutralHue', SHADE - 400, props.theme);
   return Ne(["&:indeterminate ~ ", "::before{border-color:", ";background-color:", ";}&:enabled:indeterminate ~ ", ":active::before{border-color:", ";background-color:", ";}&:disabled:indeterminate ~ ", "::before{border-color:transparent;background-color:", ";}"], StyledCheckLabel, indeterminateBorderColor, indeterminateBackgroundColor, StyledCheckLabel, indeterminateActiveBorderColor, indeterminateActiveBackgroundColor, StyledCheckLabel, indeterminateDisabledBackgroundColor);
 };
-const StyledCheckInput = Ye(StyledRadioInput).attrs({
+const StyledCheckInput = styled(StyledRadioInput).attrs({
   'data-garden-id': COMPONENT_ID$s,
   'data-garden-version': '8.69.1',
   type: 'checkbox'
@@ -6063,7 +6063,7 @@ StyledCheckInput.defaultProps = {
 };
 
 const COMPONENT_ID$r = 'forms.radio_message';
-const StyledRadioMessage = Ye(StyledMessage$1).attrs({
+const StyledRadioMessage = styled(StyledMessage$1).attrs({
   'data-garden-id': COMPONENT_ID$r,
   'data-garden-version': '8.69.1'
 }).withConfig({
@@ -6075,7 +6075,7 @@ StyledRadioMessage.defaultProps = {
 };
 
 const COMPONENT_ID$q = 'forms.checkbox_message';
-const StyledCheckMessage = Ye(StyledRadioMessage).attrs({
+const StyledCheckMessage = styled(StyledRadioMessage).attrs({
   'data-garden-id': COMPONENT_ID$q,
   'data-garden-version': '8.69.1'
 }).withConfig({
@@ -6107,7 +6107,7 @@ var SvgCheckSmFill = function SvgCheckSmFill(props) {
 };
 
 const COMPONENT_ID$p = 'forms.check_svg';
-const StyledCheckSvg = Ye(SvgCheckSmFill).attrs({
+const StyledCheckSvg = styled(SvgCheckSmFill).attrs({
   'data-garden-id': COMPONENT_ID$p,
   'data-garden-version': '8.69.1'
 }).withConfig({
@@ -6136,20 +6136,20 @@ var SvgDashFill = function SvgDashFill(props) {
   })));
 };
 
-const COMPONENT_ID$o = 'forms.dash_svg';
-const StyledDashSvg = Ye(SvgDashFill).attrs({
-  'data-garden-id': COMPONENT_ID$o,
+const COMPONENT_ID$o$1 = 'forms.dash_svg';
+const StyledDashSvg = styled(SvgDashFill).attrs({
+  'data-garden-id': COMPONENT_ID$o$1,
   'data-garden-version': '8.69.1'
 }).withConfig({
   displayName: "StyledDashSvg",
   componentId: "sc-z3vq71-0"
-})(["transition:opacity 0.25 ease-in-out;opacity:0;pointer-events:none;", ":indeterminate ~ ", " > &{opacity:1;}", ";"], StyledCheckInput, StyledCheckLabel, props => retrieveComponentStyles(COMPONENT_ID$o, props));
+})(["transition:opacity 0.25 ease-in-out;opacity:0;pointer-events:none;", ":indeterminate ~ ", " > &{opacity:1;}", ";"], StyledCheckInput, StyledCheckLabel, props => retrieveComponentStyles(COMPONENT_ID$o$1, props));
 StyledDashSvg.defaultProps = {
   theme: DEFAULT_THEME
 };
 
 const COMPONENT_ID$n$1 = 'forms.file_upload';
-const colorStyles$7$1 = props => {
+const colorStyles$7$2 = props => {
   const baseColor = getColor('primaryHue', 600, props.theme);
   const hoverColor = getColor('primaryHue', 700, props.theme);
   const activeColor = getColor('primaryHue', 800, props.theme);
@@ -6168,19 +6168,19 @@ const sizeStyles$b$1 = props => {
   const lineHeight = getLineHeight(props.theme.space.base * 5, fontSize);
   return Ne(["padding:", " ", ";min-width:4em;line-height:", ";font-size:", ";", ":not([hidden]) + &&,", " + &&,", " + &&,&& + ", ",&& + ", "{margin-top:", ";}"], paddingVertical, paddingHorizontal, lineHeight, fontSize, StyledLabel$1, StyledHint$1, StyledMessage$1, StyledHint$1, StyledMessage$1, marginTop);
 };
-const StyledFileUpload = Ye.div.attrs({
+const StyledFileUpload = styled.div.attrs({
   'data-garden-id': COMPONENT_ID$n$1,
   'data-garden-version': '8.69.1'
 }).withConfig({
   displayName: "StyledFileUpload",
   componentId: "sc-1rodjgn-0"
-})(["display:flex;align-items:center;justify-content:center;box-sizing:border-box;direction:", ";transition:border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;border:dashed ", ";border-radius:", ";cursor:pointer;text-align:center;user-select:none;", ";&[aria-disabled='true']{cursor:default;}", ";", ";"], props => props.theme.rtl ? 'rtl' : 'ltr', props => props.theme.borderWidths.sm, props => props.theme.borderRadii.md, sizeStyles$b$1, colorStyles$7$1, props => retrieveComponentStyles(COMPONENT_ID$n$1, props));
+})(["display:flex;align-items:center;justify-content:center;box-sizing:border-box;direction:", ";transition:border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;border:dashed ", ";border-radius:", ";cursor:pointer;text-align:center;user-select:none;", ";&[aria-disabled='true']{cursor:default;}", ";", ";"], props => props.theme.rtl ? 'rtl' : 'ltr', props => props.theme.borderWidths.sm, props => props.theme.borderRadii.md, sizeStyles$b$1, colorStyles$7$2, props => retrieveComponentStyles(COMPONENT_ID$n$1, props));
 StyledFileUpload.defaultProps = {
   theme: DEFAULT_THEME
 };
 
 const COMPONENT_ID$m$1 = 'forms.file.close';
-const StyledFileClose = Ye.button.attrs({
+const StyledFileClose = styled.button.attrs({
   'data-garden-id': COMPONENT_ID$m$1,
   'data-garden-version': '8.69.1'
 }).withConfig({
@@ -6192,7 +6192,7 @@ StyledFileClose.defaultProps = {
 };
 
 const COMPONENT_ID$l$1 = 'forms.file';
-const colorStyles$6$1 = props => {
+const colorStyles$6$2 = props => {
   let borderColor;
   let focusBorderColor;
   let foregroundColor;
@@ -6243,19 +6243,19 @@ const sizeStyles$a$1 = props => {
     }
   `;
 };
-const StyledFile = Ye.div.attrs({
+const StyledFile = styled.div.attrs({
   'data-garden-id': COMPONENT_ID$l$1,
   'data-garden-version': '8.69.1'
 }).withConfig({
   displayName: "StyledFile",
   componentId: "sc-195lzp1-0"
-})(["display:flex;position:relative;flex-wrap:nowrap;align-items:center;transition:box-shadow 0.1s ease-in-out;", ";", ";& > span{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}& > [role='progressbar']{position:absolute;bottom:0;left:0;transition:opacity 0.2s ease-in-out;margin:0;border-top-left-radius:0;border-top-right-radius:0;width:100%;& > div{border-top-", "-radius:0;}}& > [role='progressbar'][aria-valuenow='0'],& > [role='progressbar'][aria-valuenow='100']{opacity:0;}", ";"], sizeStyles$a$1, colorStyles$6$1, props => props.theme.rtl ? 'right' : 'left', props => retrieveComponentStyles(COMPONENT_ID$l$1, props));
+})(["display:flex;position:relative;flex-wrap:nowrap;align-items:center;transition:box-shadow 0.1s ease-in-out;", ";", ";& > span{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}& > [role='progressbar']{position:absolute;bottom:0;left:0;transition:opacity 0.2s ease-in-out;margin:0;border-top-left-radius:0;border-top-right-radius:0;width:100%;& > div{border-top-", "-radius:0;}}& > [role='progressbar'][aria-valuenow='0'],& > [role='progressbar'][aria-valuenow='100']{opacity:0;}", ";"], sizeStyles$a$1, colorStyles$6$2, props => props.theme.rtl ? 'right' : 'left', props => retrieveComponentStyles(COMPONENT_ID$l$1, props));
 StyledFile.defaultProps = {
   theme: DEFAULT_THEME
 };
 
 const COMPONENT_ID$k$1 = 'forms.file.delete';
-const StyledFileDelete = Ye(StyledFileClose).attrs({
+const StyledFileDelete = styled(StyledFileClose).attrs({
   'data-garden-id': COMPONENT_ID$k$1,
   'data-garden-version': '8.69.1'
 }).withConfig({
@@ -6267,7 +6267,7 @@ StyledFileDelete.defaultProps = {
 };
 
 const COMPONENT_ID$j$1 = 'forms.file.icon';
-const StyledFileIcon = Ye(_ref => {
+const StyledFileIcon = styled(_ref => {
   let {
     children,
     isCompact,
@@ -6287,7 +6287,7 @@ StyledFileIcon.defaultProps = {
 };
 
 const COMPONENT_ID$i$1 = 'forms.file_list';
-const StyledFileList = Ye.ul.attrs({
+const StyledFileList = styled.ul.attrs({
   'data-garden-id': COMPONENT_ID$i$1,
   'data-garden-version': '8.69.1'
 }).withConfig({
@@ -6299,7 +6299,7 @@ StyledFileList.defaultProps = {
 };
 
 const COMPONENT_ID$h$1 = 'forms.file_list.item';
-const StyledFileListItem = Ye.li.attrs({
+const StyledFileListItem = styled.li.attrs({
   'data-garden-id': COMPONENT_ID$h$1,
   'data-garden-version': '8.69.1'
 }).withConfig({
@@ -6329,7 +6329,7 @@ var SvgCircleSmFill$1 = function SvgCircleSmFill(props) {
 };
 
 const COMPONENT_ID$g$1 = 'forms.radio_svg';
-const StyledRadioSvg = Ye(SvgCircleSmFill$1).attrs({
+const StyledRadioSvg = styled(SvgCircleSmFill$1).attrs({
   'data-garden-id': COMPONENT_ID$g$1,
   'data-garden-version': '8.69.1'
 }).withConfig({
@@ -6346,7 +6346,7 @@ const sizeStyles$9$1 = props => {
   const padding = size + props.theme.space.base * 2;
   return Ne(["padding-", ":", "px;&[hidden]{padding-", ":", "px;}"], props.theme.rtl ? 'right' : 'left', padding, props.theme.rtl ? 'right' : 'left', size);
 };
-const StyledToggleLabel = Ye(StyledCheckLabel).attrs({
+const StyledToggleLabel = styled(StyledCheckLabel).attrs({
   'data-garden-id': COMPONENT_ID$f$1,
   'data-garden-version': '8.69.1'
 }).withConfig({
@@ -6358,7 +6358,7 @@ StyledToggleLabel.defaultProps = {
 };
 
 const COMPONENT_ID$e$1 = 'forms.toggle_hint';
-const StyledToggleHint = Ye(StyledHint$1).attrs({
+const StyledToggleHint = styled(StyledHint$1).attrs({
   'data-garden-id': COMPONENT_ID$e$1,
   'data-garden-version': '8.69.1'
 }).withConfig({
@@ -6370,7 +6370,7 @@ StyledToggleHint.defaultProps = {
 };
 
 const COMPONENT_ID$d$1 = 'forms.toggle';
-const colorStyles$5$1 = props => {
+const colorStyles$5$2 = props => {
   const SHADE = 600;
   const backgroundColor = getColor('neutralHue', SHADE - 100, props.theme);
   const hoverBackgroundColor = getColor('neutralHue', SHADE, props.theme);
@@ -6385,30 +6385,30 @@ const sizeStyles$8$1 = props => {
   const checkedIconPosition = math(`${width} - ${iconSize} - ${iconPosition}`);
   return Ne(["top:0;width:", ";height:", ";& ~ ", "::before{width:", ";height:", ";}& ~ ", " > svg{top:", ";", ":", ";width:", ";height:", ";}&:checked ~ ", " > svg{", ":", ";}"], width, height, StyledToggleLabel, width, height, StyledToggleLabel, iconPosition, props.theme.rtl ? 'right' : 'left', iconPosition, iconSize, iconSize, StyledToggleLabel, props.theme.rtl ? 'right' : 'left', checkedIconPosition);
 };
-const StyledToggleInput = Ye(StyledCheckInput).attrs({
+const StyledToggleInput = styled(StyledCheckInput).attrs({
   'data-garden-id': COMPONENT_ID$d$1,
   'data-garden-version': '8.69.1'
 }).withConfig({
   displayName: "StyledToggleInput",
   componentId: "sc-sgp47s-0"
-})(["& ~ ", "::before{top:0;transition:box-shadow .1s ease-in-out,background-color .15s ease-in-out,color .25s ease-in-out;border:none;border-radius:100px;}", ";", ";", ";"], StyledToggleLabel, props => sizeStyles$8$1(props), props => colorStyles$5$1(props), props => retrieveComponentStyles(COMPONENT_ID$d$1, props));
+})(["& ~ ", "::before{top:0;transition:box-shadow .1s ease-in-out,background-color .15s ease-in-out,color .25s ease-in-out;border:none;border-radius:100px;}", ";", ";", ";"], StyledToggleLabel, props => sizeStyles$8$1(props), props => colorStyles$5$2(props), props => retrieveComponentStyles(COMPONENT_ID$d$1, props));
 StyledToggleInput.defaultProps = {
   theme: DEFAULT_THEME
 };
 
-const COMPONENT_ID$c$1 = 'forms.toggle_message';
-const StyledToggleMessage = Ye(StyledMessage$1).attrs({
-  'data-garden-id': COMPONENT_ID$c$1,
+const COMPONENT_ID$c$2 = 'forms.toggle_message';
+const StyledToggleMessage = styled(StyledMessage$1).attrs({
+  'data-garden-id': COMPONENT_ID$c$2,
   'data-garden-version': '8.69.1'
 }).withConfig({
   displayName: "StyledToggleMessage",
   componentId: "sc-13vuvl1-0"
-})(["padding-", ":", ";& ", "{", ":", ";}", ";"], props => props.theme.rtl ? 'right' : 'left', props => math(`${props.theme.space.base} * 12px`), StyledMessageIcon, props => props.theme.rtl ? 'right' : 'left', props => math(`${props.theme.space.base} * 10px - ${props.theme.iconSizes.md}`), props => retrieveComponentStyles(COMPONENT_ID$c$1, props));
+})(["padding-", ":", ";& ", "{", ":", ";}", ";"], props => props.theme.rtl ? 'right' : 'left', props => math(`${props.theme.space.base} * 12px`), StyledMessageIcon, props => props.theme.rtl ? 'right' : 'left', props => math(`${props.theme.space.base} * 10px - ${props.theme.iconSizes.md}`), props => retrieveComponentStyles(COMPONENT_ID$c$2, props));
 StyledToggleMessage.defaultProps = {
   theme: DEFAULT_THEME
 };
 
-var _circle$2;
+var _circle$2$1;
 function _extends$m() { _extends$m = Object.assign ? Object.assign.bind() : function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends$m.apply(this, arguments); }
 var SvgCircleSmFill = function SvgCircleSmFill(props) {
   return /*#__PURE__*/reactExports.createElement("svg", _extends$m({
@@ -6418,7 +6418,7 @@ var SvgCircleSmFill = function SvgCircleSmFill(props) {
     focusable: "false",
     viewBox: "0 0 16 16",
     "aria-hidden": "true"
-  }, props), _circle$2 || (_circle$2 = /*#__PURE__*/reactExports.createElement("circle", {
+  }, props), _circle$2$1 || (_circle$2$1 = /*#__PURE__*/reactExports.createElement("circle", {
     cx: 8,
     cy: 8,
     r: 6,
@@ -6426,20 +6426,20 @@ var SvgCircleSmFill = function SvgCircleSmFill(props) {
   })));
 };
 
-const COMPONENT_ID$b$1 = 'forms.toggle_svg';
-const StyledToggleSvg = Ye(SvgCircleSmFill).attrs({
-  'data-garden-id': COMPONENT_ID$b$1,
+const COMPONENT_ID$b$2 = 'forms.toggle_svg';
+const StyledToggleSvg = styled(SvgCircleSmFill).attrs({
+  'data-garden-id': COMPONENT_ID$b$2,
   'data-garden-version': '8.69.1'
 }).withConfig({
   displayName: "StyledToggleSvg",
   componentId: "sc-162xbyx-0"
-})(["transition:all 0.15s ease-in-out;", ";"], props => retrieveComponentStyles(COMPONENT_ID$b$1, props));
+})(["transition:all 0.15s ease-in-out;", ";"], props => retrieveComponentStyles(COMPONENT_ID$b$2, props));
 StyledToggleSvg.defaultProps = {
   theme: DEFAULT_THEME
 };
 
-const COMPONENT_ID$a$1 = 'forms.select';
-const colorStyles$4$1 = props => {
+const COMPONENT_ID$a$2 = 'forms.select';
+const colorStyles$4$2 = props => {
   const color = getColor('neutralHue', 700, props.theme);
   return Ne(["&:hover + ", ",&:focus + ", ",&:focus-visible + ", ",&[data-garden-focus-visible='true'] + ", "{color:", ";}"], StyledTextMediaFigure, StyledTextMediaFigure, StyledTextMediaFigure, StyledTextMediaFigure, color);
 };
@@ -6449,21 +6449,21 @@ const sizeStyles$7$1 = props => {
   const iconHorizontalPosition = `${props.theme.space.base * 3}px`;
   return Ne(["padding-", ":", ";& + ", "{top:", ";", ":", ";}"], props.theme.rtl ? 'left' : 'right', !props.isBare && padding, StyledTextMediaFigure, iconVerticalPosition, props.theme.rtl ? 'left' : 'right', iconHorizontalPosition);
 };
-const StyledSelect = Ye(StyledTextInput).attrs({
-  'data-garden-id': COMPONENT_ID$a$1,
+const StyledSelect = styled(StyledTextInput).attrs({
+  'data-garden-id': COMPONENT_ID$a$2,
   'data-garden-version': '8.69.1',
   as: 'select'
 }).withConfig({
   displayName: "StyledSelect",
   componentId: "sc-8xdxpt-0"
-})(["cursor:pointer;text-overflow:ellipsis;", ";", ";&::-ms-expand{display:none;}&::-ms-value{background-color:transparent;color:inherit;}&:-moz-focusring{transition:none;text-shadow:0 0 0 ", ";color:transparent;}& + ", "{position:absolute;pointer-events:none;}"], props => sizeStyles$7$1(props), props => colorStyles$4$1(props), props => props.theme.colors.foreground, StyledTextMediaFigure);
+})(["cursor:pointer;text-overflow:ellipsis;", ";", ";&::-ms-expand{display:none;}&::-ms-value{background-color:transparent;color:inherit;}&:-moz-focusring{transition:none;text-shadow:0 0 0 ", ";color:transparent;}& + ", "{position:absolute;pointer-events:none;}"], props => sizeStyles$7$1(props), props => colorStyles$4$2(props), props => props.theme.colors.foreground, StyledTextMediaFigure);
 StyledSelect.defaultProps = {
   theme: DEFAULT_THEME
 };
 
-const COMPONENT_ID$9$1 = 'forms.select_wrapper';
-const StyledSelectWrapper = Ye(StyledTextFauxInput).attrs({
-  'data-garden-id': COMPONENT_ID$9$1,
+const COMPONENT_ID$9$2 = 'forms.select_wrapper';
+const StyledSelectWrapper = styled(StyledTextFauxInput).attrs({
+  'data-garden-id': COMPONENT_ID$9$2,
   'data-garden-version': '8.69.1'
 }).withConfig({
   displayName: "StyledSelectWrapper",
@@ -6473,7 +6473,7 @@ StyledSelectWrapper.defaultProps = {
   theme: DEFAULT_THEME
 };
 
-const COMPONENT_ID$8$1 = 'forms.range';
+const COMPONENT_ID$8$2 = 'forms.range';
 const thumbStyles = function (styles) {
   let modifier = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : '';
   return `
@@ -6518,7 +6518,7 @@ const trackLowerStyles = function (styles) {
     }
   `;
 };
-const colorStyles$3$1 = props => {
+const colorStyles$3$2 = props => {
   const SHADE = 600;
   const thumbBackgroundColor = getColor('primaryHue', SHADE, props.theme);
   const thumbBorderColor = thumbBackgroundColor;
@@ -6587,8 +6587,8 @@ const sizeStyles$6$1 = props => {
       height: ${trackHeight};
     `));
 };
-const StyledRangeInput = Ye.input.attrs(props => ({
-  'data-garden-id': COMPONENT_ID$8$1,
+const StyledRangeInput = styled.input.attrs(props => ({
+  'data-garden-id': COMPONENT_ID$8$2,
   'data-garden-version': '8.69.1',
   type: 'range',
   style: {
@@ -6612,27 +6612,27 @@ const StyledRangeInput = Ye.input.attrs(props => ({
       border: ${props.theme.borders.md};
       border-radius: 100%;
       box-sizing: border-box;
-    `), props => colorStyles$3$1(props), props => retrieveComponentStyles(COMPONENT_ID$8$1, props));
+    `), props => colorStyles$3$2(props), props => retrieveComponentStyles(COMPONENT_ID$8$2, props));
 StyledRangeInput.defaultProps = {
   backgroundSize: '0%',
   hasLowerTrack: true,
   theme: DEFAULT_THEME
 };
 
-const COMPONENT_ID$7$1 = 'forms.slider';
-const StyledSlider = Ye.div.attrs({
-  'data-garden-id': COMPONENT_ID$7$1,
+const COMPONENT_ID$7$2 = 'forms.slider';
+const StyledSlider = styled.div.attrs({
+  'data-garden-id': COMPONENT_ID$7$2,
   'data-garden-version': '8.69.1'
 }).withConfig({
   displayName: "StyledSlider",
   componentId: "sc-1di437a-0"
-})(["display:block;position:relative;z-index:0;cursor:pointer;height:", ";&[aria-disabled='true']{cursor:default;}", ":not([hidden]) + &,", " + &,", " + &,& + ", ",& + ", "{margin-top:", ";}", ";"], props => math(`(${props.theme.space.base} * 5px) + (${props.theme.shadowWidths.md} * 2)`), StyledLabel$1, StyledHint$1, StyledMessage$1, StyledHint$1, StyledMessage$1, props => math(`${props.theme.space.base} * 2px`), props => retrieveComponentStyles(COMPONENT_ID$7$1, props));
+})(["display:block;position:relative;z-index:0;cursor:pointer;height:", ";&[aria-disabled='true']{cursor:default;}", ":not([hidden]) + &,", " + &,", " + &,& + ", ",& + ", "{margin-top:", ";}", ";"], props => math(`(${props.theme.space.base} * 5px) + (${props.theme.shadowWidths.md} * 2)`), StyledLabel$1, StyledHint$1, StyledMessage$1, StyledHint$1, StyledMessage$1, props => math(`${props.theme.space.base} * 2px`), props => retrieveComponentStyles(COMPONENT_ID$7$2, props));
 StyledSlider.defaultProps = {
   theme: DEFAULT_THEME
 };
 
-const COMPONENT_ID$6$1 = 'forms.slider_thumb';
-const colorStyles$2$1 = props => {
+const COMPONENT_ID$6$2 = 'forms.slider_thumb';
+const colorStyles$2$2 = props => {
   const SHADE = 600;
   const backgroundColor = getColor('primaryHue', SHADE, props.theme);
   const borderColor = backgroundColor;
@@ -6652,28 +6652,28 @@ const sizeStyles$5$1 = props => {
   const marginTop = math(`${size} / -2`);
   return Ne(["margin-top:", ";width:", ";height:", ";"], marginTop, size, size);
 };
-const StyledSliderThumb = Ye.div.attrs(props => ({
-  'data-garden-id': COMPONENT_ID$6$1,
+const StyledSliderThumb = styled.div.attrs(props => ({
+  'data-garden-id': COMPONENT_ID$6$2,
   'data-garden-version': '8.69.1',
   'aria-disabled': props.isDisabled
 })).withConfig({
   displayName: "StyledSliderThumb",
   componentId: "sc-yspbwa-0"
-})(["appearance:none;position:absolute;top:50%;", ":", ";transition:border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out;z-index:1;border:", ";border-radius:100%;cursor:inherit;box-sizing:border-box;font-size:0;", ";", ";", ";"], props => props.theme.rtl ? 'right' : 'left', props => math(`${props.position} * 1px`), props => props.theme.borders.md, props => sizeStyles$5$1(props), props => colorStyles$2$1(props), props => retrieveComponentStyles(COMPONENT_ID$6$1, props));
+})(["appearance:none;position:absolute;top:50%;", ":", ";transition:border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out;z-index:1;border:", ";border-radius:100%;cursor:inherit;box-sizing:border-box;font-size:0;", ";", ";", ";"], props => props.theme.rtl ? 'right' : 'left', props => math(`${props.position} * 1px`), props => props.theme.borders.md, props => sizeStyles$5$1(props), props => colorStyles$2$2(props), props => retrieveComponentStyles(COMPONENT_ID$6$2, props));
 StyledSliderThumb.defaultProps = {
   position: 0,
   theme: DEFAULT_THEME
 };
 
-const COMPONENT_ID$5$1 = 'forms.slider_track';
-const colorStyles$1$1 = props => {
+const COMPONENT_ID$5$3 = 'forms.slider_track';
+const colorStyles$1$2 = props => {
   const SHADE = 600;
   const backgroundColor = getColor('neutralHue', SHADE - 400, props.theme);
   const backgroundImageColor = getColor('primaryHue', SHADE, props.theme);
   const disabledBackgroundColor = getColor('neutralHue', SHADE - 300, props.theme);
   return Ne(["background-color:", ";background-image:linear-gradient(", ",", ");&[aria-disabled='true']{background-image:linear-gradient(", ",", ");}"], backgroundColor, backgroundImageColor, backgroundImageColor, disabledBackgroundColor, disabledBackgroundColor);
 };
-const sizeStyles$4$1 = props => {
+const sizeStyles$4$2 = props => {
   const height = math(`${props.theme.space.base} * 1.5px`);
   const backgroundPosition = math(`${props.backgroundPosition} * 1px`);
   const backgroundSize = math(`${props.backgroundSize} * 1px`);
@@ -6682,39 +6682,39 @@ const sizeStyles$4$1 = props => {
   const padding = math(`${props.theme.space.base} * 2.5px`);
   return Ne(["margin-top:", ";border-radius:", ";background-position:", ";background-size:", ";padding:0 ", ";"], marginTop, borderRadius, backgroundPosition, backgroundSize, padding);
 };
-const StyledSliderTrack = Ye.div.attrs(props => ({
-  'data-garden-id': COMPONENT_ID$5$1,
+const StyledSliderTrack = styled.div.attrs(props => ({
+  'data-garden-id': COMPONENT_ID$5$3,
   'data-garden-version': '8.69.1',
   'aria-disabled': props.isDisabled
 })).withConfig({
   displayName: "StyledSliderTrack",
   componentId: "sc-aw5m6g-0"
-})(["position:absolute;top:50%;box-sizing:border-box;background-origin:content-box;background-repeat:repeat-y;width:100%;", ";", ";", ";"], props => sizeStyles$4$1(props), props => colorStyles$1$1(props), props => retrieveComponentStyles(COMPONENT_ID$5$1, props));
+})(["position:absolute;top:50%;box-sizing:border-box;background-origin:content-box;background-repeat:repeat-y;width:100%;", ";", ";", ";"], props => sizeStyles$4$2(props), props => colorStyles$1$2(props), props => retrieveComponentStyles(COMPONENT_ID$5$3, props));
 StyledSliderTrack.defaultProps = {
   backgroundSize: 0,
   backgroundPosition: 0,
   theme: DEFAULT_THEME
 };
 
-const COMPONENT_ID$4$1 = 'forms.slider_track_rail';
-const sizeStyles$3$1 = props => {
+const COMPONENT_ID$4$3 = 'forms.slider_track_rail';
+const sizeStyles$3$2 = props => {
   const height = math(`${props.theme.space.base} * 1.5px`);
   const margin = math(`${props.theme.space.base} * 2.5px`);
   return Ne(["margin:0 ", " 0 ", ";height:", ";"], props.theme.rtl ? `-${margin}` : margin, props.theme.rtl ? margin : `-${margin}`, height);
 };
-const StyledSliderTrackRail = Ye.div.attrs({
-  'data-garden-id': COMPONENT_ID$4$1,
+const StyledSliderTrackRail = styled.div.attrs({
+  'data-garden-id': COMPONENT_ID$4$3,
   'data-garden-version': '8.69.1'
 }).withConfig({
   displayName: "StyledSliderTrackRail",
   componentId: "sc-1o5owbd-0"
-})(["position:relative;", ";", ";"], props => sizeStyles$3$1(props), props => retrieveComponentStyles(COMPONENT_ID$4$1, props));
+})(["position:relative;", ";", ";"], props => sizeStyles$3$2(props), props => retrieveComponentStyles(COMPONENT_ID$4$3, props));
 StyledSliderTrackRail.defaultProps = {
   theme: DEFAULT_THEME
 };
 
-const COMPONENT_ID$3$1 = 'forms.tile_icon';
-const sizeStyles$2$1 = props => {
+const COMPONENT_ID$3$3 = 'forms.tile_icon';
+const sizeStyles$2$2 = props => {
   const iconSize = math(`${props.theme.iconSizes.md} * 2`);
   let position;
   let top;
@@ -6729,18 +6729,18 @@ const sizeStyles$2$1 = props => {
   }
   return Ne(["position:", ";top:", ";", ";& > *{width:", ";height:", ";}"], position, top, horizontalValue, iconSize, iconSize);
 };
-const StyledTileIcon = Ye.span.attrs({
-  'data-garden-id': COMPONENT_ID$3$1,
+const StyledTileIcon = styled.span.attrs({
+  'data-garden-id': COMPONENT_ID$3$3,
   'data-garden-version': '8.69.1'
 }).withConfig({
   displayName: "StyledTileIcon",
   componentId: "sc-1wazhg4-0"
-})(["display:block;transition:color 0.25s ease-in-out;text-align:center;line-height:0;", ";", ";"], props => sizeStyles$2$1(props), props => retrieveComponentStyles(COMPONENT_ID$3$1, props));
+})(["display:block;transition:color 0.25s ease-in-out;text-align:center;line-height:0;", ";", ";"], props => sizeStyles$2$2(props), props => retrieveComponentStyles(COMPONENT_ID$3$3, props));
 StyledTileIcon.defaultProps = {
   theme: DEFAULT_THEME
 };
 
-const COMPONENT_ID$2$3 = 'forms.tile';
+const COMPONENT_ID$2$5 = 'forms.tile';
 const colorStyles$d = props => {
   const SHADE = 600;
   const iconColor = getColor('neutralHue', SHADE, props.theme);
@@ -6770,20 +6770,20 @@ const colorStyles$d = props => {
     selector: `&:focus-within`
   }), activeBorderColor, activeBackgroundColor, StyledTileIcon, color, selectedBorderColor, selectedBackgroundColor, props.theme.colors.background, StyledTileIcon, props.theme.colors.background, selectedHoverBorderColor, selectedHoverBackgroundColor, props.theme.colors.background, StyledTileIcon, props.theme.colors.background, selectedActiveBorderColor, selectedActiveBackgroundColor, props.theme.colors.background, StyledTileIcon, props.theme.colors.background, disabledBorderColor, disabledBackgroundColor, disabledColor, StyledTileIcon, disabledColor, selectedDisabledBackgroundColor, disabledColor, StyledTileIcon, disabledColor);
 };
-const StyledTile = Ye.label.attrs(props => ({
-  'data-garden-id': COMPONENT_ID$2$3,
+const StyledTile = styled.label.attrs(props => ({
+  'data-garden-id': COMPONENT_ID$2$5,
   'data-garden-version': '8.69.1',
   'data-garden-selected': props.isSelected
 })).withConfig({
   displayName: "StyledTile",
   componentId: "sc-1jjvmxs-0"
-})(["display:block;position:relative;transition:border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;border-radius:", ";cursor:", ";padding:", "px;direction:", ";min-width:132px;word-break:break-word;", ";", ";"], props => props.theme.borderRadii.md, props => !props.isDisabled && 'pointer', props => props.theme.space.base * 5, props => props.theme.rtl && 'rtl', props => colorStyles$d(props), props => retrieveComponentStyles(COMPONENT_ID$2$3, props));
+})(["display:block;position:relative;transition:border-color .25s ease-in-out,box-shadow .1s ease-in-out,background-color .25s ease-in-out,color .25s ease-in-out;border-radius:", ";cursor:", ";padding:", "px;direction:", ";min-width:132px;word-break:break-word;", ";", ";"], props => props.theme.borderRadii.md, props => !props.isDisabled && 'pointer', props => props.theme.space.base * 5, props => props.theme.rtl && 'rtl', props => colorStyles$d(props), props => retrieveComponentStyles(COMPONENT_ID$2$5, props));
 StyledTile.defaultProps = {
   theme: DEFAULT_THEME
 };
 
-const COMPONENT_ID$1$3 = 'forms.tile_description';
-const sizeStyles$1$1 = props => {
+const COMPONENT_ID$1$5 = 'forms.tile_description';
+const sizeStyles$1$3 = props => {
   let marginDirection = 'left';
   let marginValue;
   if (props.theme.rtl) {
@@ -6794,18 +6794,18 @@ const sizeStyles$1$1 = props => {
   }
   return Ne(["margin-top:", "px;margin-", ":", ";"], props.theme.space.base, marginDirection, marginValue);
 };
-const StyledTileDescription = Ye.span.attrs({
-  'data-garden-id': COMPONENT_ID$1$3,
+const StyledTileDescription = styled.span.attrs({
+  'data-garden-id': COMPONENT_ID$1$5,
   'data-garden-version': '8.69.1'
 }).withConfig({
   displayName: "StyledTileDescription",
   componentId: "sc-xfuu7u-0"
-})(["display:block;text-align:", ";line-height:", ";font-size:", ";", ";", ";"], props => props.isCentered && 'center', props => getLineHeight(props.theme.space.base * 4, props.theme.fontSizes.sm), props => props.theme.fontSizes.sm, props => sizeStyles$1$1(props), props => retrieveComponentStyles(COMPONENT_ID$1$3, props));
+})(["display:block;text-align:", ";line-height:", ";font-size:", ";", ";", ";"], props => props.isCentered && 'center', props => getLineHeight(props.theme.space.base * 4, props.theme.fontSizes.sm), props => props.theme.fontSizes.sm, props => sizeStyles$1$3(props), props => retrieveComponentStyles(COMPONENT_ID$1$5, props));
 StyledTileDescription.defaultProps = {
   theme: DEFAULT_THEME
 };
 
-const StyledTileInput = Ye.input.withConfig({
+const StyledTileInput = styled.input.withConfig({
   displayName: "StyledTileInput",
   componentId: "sc-1nq2m6q-0"
 })(["position:absolute;border:0;clip:rect(1px,1px,1px,1px);padding:0;width:1px;height:1px;overflow:hidden;white-space:nowrap;"]);
@@ -6827,7 +6827,7 @@ const sizeStyles$g = props => {
   }
   return Ne(["margin-top:", ";margin-", ":", ";"], marginTop, marginDirection, marginValue);
 };
-const StyledTileLabel = Ye.span.attrs({
+const StyledTileLabel = styled.span.attrs({
   'data-garden-id': COMPONENT_ID$L,
   'data-garden-version': '8.69.1'
 }).withConfig({
@@ -6970,19 +6970,19 @@ const Label$1 = React__default.forwardRef((props, ref) => {
       } = fieldContext;
       combinedProps = {
         ...combinedProps,
-        onMouseUp: composeEventHandlers$1(props.onMouseUp, () => {
+        onMouseUp: composeEventHandlers$2(props.onMouseUp, () => {
           setIsLabelActive(false);
         }),
-        onMouseDown: composeEventHandlers$1(props.onMouseDown, () => {
+        onMouseDown: composeEventHandlers$2(props.onMouseDown, () => {
           setIsLabelActive(true);
         }),
-        onMouseEnter: composeEventHandlers$1(props.onMouseEnter, () => {
+        onMouseEnter: composeEventHandlers$2(props.onMouseEnter, () => {
           setIsLabelHovered(true);
         }),
-        onMouseLeave: composeEventHandlers$1(props.onMouseLeave, () => {
+        onMouseLeave: composeEventHandlers$2(props.onMouseLeave, () => {
           setIsLabelHovered(false);
         }),
-        onClick: composeEventHandlers$1(props.onClick, () => {
+        onClick: composeEventHandlers$2(props.onClick, () => {
           multiThumbRangeRef.current && multiThumbRangeRef.current.focus();
         })
       };
@@ -7016,7 +7016,7 @@ const Label$1 = React__default.forwardRef((props, ref) => {
     };
     combinedProps = {
       ...combinedProps,
-      onClick: composeEventHandlers$1(combinedProps.onClick, onLabelSelect)
+      onClick: composeEventHandlers$2(combinedProps.onClick, onLabelSelect)
     };
     return React__default.createElement(StyledCheckLabel, _extends$t({
       ref: ref
@@ -7146,7 +7146,7 @@ const Input = React__default.forwardRef((_ref, ref) => {
   } = _ref;
   const fieldContext = useFieldContext$1();
   const inputGroupContext = useInputGroupContext();
-  const onSelectHandler = props.readOnly ? composeEventHandlers$1(onSelect, event => {
+  const onSelectHandler = props.readOnly ? composeEventHandlers$2(onSelect, event => {
     event.currentTarget.select();
   }) : onSelect;
   let combinedProps = {
@@ -7224,7 +7224,7 @@ const Range = React__default.forwardRef((_ref, ref) => {
   reactExports.useEffect(() => {
     updateBackgroundWidthFromInput(rangeRef.current);
   }, [rangeRef, updateBackgroundWidthFromInput, props.value]);
-  const onChange = hasLowerTrack ? composeEventHandlers$1(props.onChange, event => {
+  const onChange = hasLowerTrack ? composeEventHandlers$2(props.onChange, event => {
     updateBackgroundWidthFromInput(event.target);
   }) : props.onChange;
   let combinedProps = {
@@ -7341,7 +7341,7 @@ const Textarea = React__default.forwardRef((_ref, ref) => {
     computedStyle.height = state.height;
     computedStyle.overflow = state.overflow ? 'hidden' : undefined;
   }
-  const onSelectHandler = props.readOnly ? composeEventHandlers$1(onSelect, event => {
+  const onSelectHandler = props.readOnly ? composeEventHandlers$2(onSelect, event => {
     event.currentTarget.select();
   }) : onSelect;
   let combinedProps = {
@@ -7409,7 +7409,7 @@ Toggle.propTypes = {
 
 var _path$k;
 function _extends$l() { _extends$l = Object.assign ? Object.assign.bind() : function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends$l.apply(this, arguments); }
-var SvgChevronDownStroke$1 = function SvgChevronDownStroke(props) {
+var SvgChevronDownStroke$2 = function SvgChevronDownStroke(props) {
   return /*#__PURE__*/reactExports.createElement("svg", _extends$l({
     xmlns: "http://www.w3.org/2000/svg",
     width: 16,
@@ -7423,17 +7423,17 @@ var SvgChevronDownStroke$1 = function SvgChevronDownStroke(props) {
   })));
 };
 
-const StartIconComponent = props => React__default.createElement(StyledTextMediaFigure, _extends$t({
+const StartIconComponent$1 = props => React__default.createElement(StyledTextMediaFigure, _extends$t({
   position: "start"
 }, props));
-StartIconComponent.displayName = 'FauxInput.StartIcon';
-const StartIcon = StartIconComponent;
+StartIconComponent$1.displayName = 'FauxInput.StartIcon';
+const StartIcon$1 = StartIconComponent$1;
 
-const EndIconComponent = props => React__default.createElement(StyledTextMediaFigure, _extends$t({
+const EndIconComponent$1 = props => React__default.createElement(StyledTextMediaFigure, _extends$t({
   position: "end"
 }, props));
-EndIconComponent.displayName = 'FauxInput.EndIcon';
-const EndIcon = EndIconComponent;
+EndIconComponent$1.displayName = 'FauxInput.EndIcon';
+const EndIcon$1 = EndIconComponent$1;
 
 const FauxInputComponent = reactExports.forwardRef((_ref, ref) => {
   let {
@@ -7445,10 +7445,10 @@ const FauxInputComponent = reactExports.forwardRef((_ref, ref) => {
     ...props
   } = _ref;
   const [isFocused, setIsFocused] = reactExports.useState(false);
-  const onFocusHandler = composeEventHandlers$1(onFocus, () => {
+  const onFocusHandler = composeEventHandlers$2(onFocus, () => {
     setIsFocused(true);
   });
-  const onBlurHandler = composeEventHandlers$1(onBlur, () => {
+  const onBlurHandler = composeEventHandlers$2(onBlur, () => {
     setIsFocused(false);
   });
   return React__default.createElement(StyledTextFauxInput, _extends$t({
@@ -7474,8 +7474,8 @@ FauxInputComponent.propTypes = {
   isHovered: PropTypes.bool
 };
 const FauxInput = FauxInputComponent;
-FauxInput.EndIcon = EndIcon;
-FauxInput.StartIcon = StartIcon;
+FauxInput.EndIcon = EndIcon$1;
+FauxInput.StartIcon = StartIcon$1;
 
 const Select = React__default.forwardRef((_ref, ref) => {
   let {
@@ -7508,7 +7508,7 @@ const Select = React__default.forwardRef((_ref, ref) => {
     focusInset: focusInset
   }, React__default.createElement(StyledSelect, combinedProps), !isBare && React__default.createElement(FauxInput.EndIcon, {
     isDisabled: disabled
-  }, React__default.createElement(SvgChevronDownStroke$1, null)));
+  }, React__default.createElement(SvgChevronDownStroke$2, null)));
 });
 Select.propTypes = {
   isCompact: PropTypes.bool,
@@ -7719,7 +7719,7 @@ const TilesComponent = reactExports.forwardRef((_ref, ref) => {
       onChange(...args);
     }
   }, [onChange]);
-  const selectedValue = getControlledValue(controlledValue, value);
+  const selectedValue = getControlledValue$1(controlledValue, value);
   const tileContext = reactExports.useMemo(() => ({
     onChange: handleOnChange,
     value: selectedValue,
@@ -7815,7 +7815,7 @@ FileList.Item = Item;
 
 var _path$j;
 function _extends$k() { _extends$k = Object.assign ? Object.assign.bind() : function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends$k.apply(this, arguments); }
-var SvgXStroke$1 = function SvgXStroke(props) {
+var SvgXStroke$1$1 = function SvgXStroke(props) {
   return /*#__PURE__*/reactExports.createElement("svg", _extends$k({
     xmlns: "http://www.w3.org/2000/svg",
     width: 12,
@@ -7832,7 +7832,7 @@ var SvgXStroke$1 = function SvgXStroke(props) {
 
 var _path$i;
 function _extends$j() { _extends$j = Object.assign ? Object.assign.bind() : function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends$j.apply(this, arguments); }
-var SvgXStroke$2 = function SvgXStroke(props) {
+var SvgXStroke$3 = function SvgXStroke(props) {
   return /*#__PURE__*/reactExports.createElement("svg", _extends$j({
     xmlns: "http://www.w3.org/2000/svg",
     width: 16,
@@ -7854,7 +7854,7 @@ const useFileContext = () => {
 
 const CloseComponent$1 = React__default.forwardRef((props, ref) => {
   const fileContext = useFileContext();
-  const onMouseDown = composeEventHandlers$1(props.onMouseDown, event => event.preventDefault()
+  const onMouseDown = composeEventHandlers$2(props.onMouseDown, event => event.preventDefault()
   );
   const ariaLabel = useText(CloseComponent$1, props, 'aria-label', 'Close');
   return React__default.createElement(StyledFileClose, _extends$t({
@@ -7864,10 +7864,10 @@ const CloseComponent$1 = React__default.forwardRef((props, ref) => {
     type: "button",
     tabIndex: -1,
     onMouseDown: onMouseDown
-  }), fileContext && fileContext.isCompact ? React__default.createElement(SvgXStroke$1, null) : React__default.createElement(SvgXStroke$2, null));
+  }), fileContext && fileContext.isCompact ? React__default.createElement(SvgXStroke$1$1, null) : React__default.createElement(SvgXStroke$3, null));
 });
 CloseComponent$1.displayName = 'File.Close';
-const Close$1 = CloseComponent$1;
+const Close$2 = CloseComponent$1;
 
 var _path$h;
 function _extends$i() { _extends$i = Object.assign ? Object.assign.bind() : function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends$i.apply(this, arguments); }
@@ -7907,7 +7907,7 @@ var SvgTrashStroke = function SvgTrashStroke(props) {
 
 const DeleteComponent = React__default.forwardRef((props, ref) => {
   const fileContext = useFileContext();
-  const onMouseDown = composeEventHandlers$1(props.onMouseDown, event => event.preventDefault()
+  const onMouseDown = composeEventHandlers$2(props.onMouseDown, event => event.preventDefault()
   );
   const ariaLabel = useText(DeleteComponent, props, 'aria-label', 'Delete');
   return React__default.createElement(StyledFileDelete, _extends$t({
@@ -7966,7 +7966,7 @@ var SvgFileZipStroke$1 = function SvgFileZipStroke(props) {
   })));
 };
 
-var _path$d, _circle$1;
+var _path$d, _circle$1$1;
 function _extends$e() { _extends$e = Object.assign ? Object.assign.bind() : function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends$e.apply(this, arguments); }
 var SvgFileImageStroke$1 = function SvgFileImageStroke(props) {
   return /*#__PURE__*/reactExports.createElement("svg", _extends$e({
@@ -7982,7 +7982,7 @@ var SvgFileImageStroke$1 = function SvgFileImageStroke(props) {
     strokeLinecap: "round",
     strokeLinejoin: "round",
     d: "M10.5 3.21V11c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h5.79c.13 0 .26.05.35.15l2.21 2.21c.1.09.15.21.15.35zM7.5.5V3c0 .28.22.5.5.5h2.5m-7 6L5 8l1.5 1.5 1-1 1 1"
-  })), _circle$1 || (_circle$1 = /*#__PURE__*/reactExports.createElement("circle", {
+  })), _circle$1$1 || (_circle$1$1 = /*#__PURE__*/reactExports.createElement("circle", {
     cx: 8,
     cy: 6,
     r: 1,
@@ -8027,9 +8027,9 @@ var SvgFileSpreadsheetStroke$1 = function SvgFileSpreadsheetStroke(props) {
 };
 
 var _path$a;
-function _extends$b() { _extends$b = Object.assign ? Object.assign.bind() : function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends$b.apply(this, arguments); }
+function _extends$b$1() { _extends$b$1 = Object.assign ? Object.assign.bind() : function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends$b$1.apply(this, arguments); }
 var SvgFilePresentationStroke$1 = function SvgFilePresentationStroke(props) {
-  return /*#__PURE__*/reactExports.createElement("svg", _extends$b({
+  return /*#__PURE__*/reactExports.createElement("svg", _extends$b$1({
     xmlns: "http://www.w3.org/2000/svg",
     width: 12,
     height: 12,
@@ -8044,9 +8044,9 @@ var SvgFilePresentationStroke$1 = function SvgFilePresentationStroke(props) {
 };
 
 var _path$9;
-function _extends$a() { _extends$a = Object.assign ? Object.assign.bind() : function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends$a.apply(this, arguments); }
+function _extends$a$1() { _extends$a$1 = Object.assign ? Object.assign.bind() : function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends$a$1.apply(this, arguments); }
 var SvgFileGenericStroke$1 = function SvgFileGenericStroke(props) {
-  return /*#__PURE__*/reactExports.createElement("svg", _extends$a({
+  return /*#__PURE__*/reactExports.createElement("svg", _extends$a$1({
     xmlns: "http://www.w3.org/2000/svg",
     width: 12,
     height: 12,
@@ -8060,17 +8060,17 @@ var SvgFileGenericStroke$1 = function SvgFileGenericStroke(props) {
   })));
 };
 
-var _g;
-function _extends$9() { _extends$9 = Object.assign ? Object.assign.bind() : function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends$9.apply(this, arguments); }
-var SvgCheckCircleStroke = function SvgCheckCircleStroke(props) {
-  return /*#__PURE__*/reactExports.createElement("svg", _extends$9({
+var _g$3;
+function _extends$9$1() { _extends$9$1 = Object.assign ? Object.assign.bind() : function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends$9$1.apply(this, arguments); }
+var SvgCheckCircleStroke$2 = function SvgCheckCircleStroke(props) {
+  return /*#__PURE__*/reactExports.createElement("svg", _extends$9$1({
     xmlns: "http://www.w3.org/2000/svg",
     width: 12,
     height: 12,
     focusable: "false",
     viewBox: "0 0 12 12",
     "aria-hidden": "true"
-  }, props), _g || (_g = /*#__PURE__*/reactExports.createElement("g", {
+  }, props), _g$3 || (_g$3 = /*#__PURE__*/reactExports.createElement("g", {
     fill: "none",
     stroke: "currentColor"
   }, /*#__PURE__*/reactExports.createElement("path", {
@@ -8128,7 +8128,7 @@ var SvgFilePdfStroke = function SvgFilePdfStroke(props) {
   })));
 };
 
-var _path$6;
+var _path$6$1;
 function _extends$6$1() { _extends$6$1 = Object.assign ? Object.assign.bind() : function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends$6$1.apply(this, arguments); }
 var SvgFileZipStroke = function SvgFileZipStroke(props) {
   return /*#__PURE__*/reactExports.createElement("svg", _extends$6$1({
@@ -8138,7 +8138,7 @@ var SvgFileZipStroke = function SvgFileZipStroke(props) {
     focusable: "false",
     viewBox: "0 0 16 16",
     "aria-hidden": "true"
-  }, props), _path$6 || (_path$6 = /*#__PURE__*/reactExports.createElement("path", {
+  }, props), _path$6$1 || (_path$6$1 = /*#__PURE__*/reactExports.createElement("path", {
     fill: "none",
     stroke: "currentColor",
     strokeLinecap: "round",
@@ -8146,10 +8146,10 @@ var SvgFileZipStroke = function SvgFileZipStroke(props) {
   })));
 };
 
-var _path$5$1, _circle;
-function _extends$5$1() { _extends$5$1 = Object.assign ? Object.assign.bind() : function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends$5$1.apply(this, arguments); }
+var _path$5$1, _circle$6;
+function _extends$5$2() { _extends$5$2 = Object.assign ? Object.assign.bind() : function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends$5$2.apply(this, arguments); }
 var SvgFileImageStroke = function SvgFileImageStroke(props) {
-  return /*#__PURE__*/reactExports.createElement("svg", _extends$5$1({
+  return /*#__PURE__*/reactExports.createElement("svg", _extends$5$2({
     xmlns: "http://www.w3.org/2000/svg",
     width: 16,
     height: 16,
@@ -8161,7 +8161,7 @@ var SvgFileImageStroke = function SvgFileImageStroke(props) {
     stroke: "currentColor",
     strokeLinecap: "round",
     d: "M14.5 4.2V15c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h8.85c.13 0 .26.05.36.15l3.15 3.2c.09.1.14.22.14.35zm-4-3.7V4c0 .28.22.5.5.5h3.5m-11 9l2.65-2.65c.2-.2.51-.2.71 0l1.79 1.79c.2.2.51.2.71 0l.79-.79c.2-.2.51-.2.71 0l1.65 1.65"
-  })), _circle || (_circle = /*#__PURE__*/reactExports.createElement("circle", {
+  })), _circle$6 || (_circle$6 = /*#__PURE__*/reactExports.createElement("circle", {
     cx: 10.5,
     cy: 8.5,
     r: 1.5,
@@ -8170,9 +8170,9 @@ var SvgFileImageStroke = function SvgFileImageStroke(props) {
 };
 
 var _path$4$1;
-function _extends$4$1() { _extends$4$1 = Object.assign ? Object.assign.bind() : function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends$4$1.apply(this, arguments); }
+function _extends$4$2() { _extends$4$2 = Object.assign ? Object.assign.bind() : function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends$4$2.apply(this, arguments); }
 var SvgFileDocumentStroke = function SvgFileDocumentStroke(props) {
-  return /*#__PURE__*/reactExports.createElement("svg", _extends$4$1({
+  return /*#__PURE__*/reactExports.createElement("svg", _extends$4$2({
     xmlns: "http://www.w3.org/2000/svg",
     width: 16,
     height: 16,
@@ -8187,17 +8187,17 @@ var SvgFileDocumentStroke = function SvgFileDocumentStroke(props) {
   })));
 };
 
-var _path$3$1;
-function _extends$3$1() { _extends$3$1 = Object.assign ? Object.assign.bind() : function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends$3$1.apply(this, arguments); }
+var _path$3$2;
+function _extends$3$2() { _extends$3$2 = Object.assign ? Object.assign.bind() : function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends$3$2.apply(this, arguments); }
 var SvgFileSpreadsheetStroke = function SvgFileSpreadsheetStroke(props) {
-  return /*#__PURE__*/reactExports.createElement("svg", _extends$3$1({
+  return /*#__PURE__*/reactExports.createElement("svg", _extends$3$2({
     xmlns: "http://www.w3.org/2000/svg",
     width: 16,
     height: 16,
     focusable: "false",
     viewBox: "0 0 16 16",
     "aria-hidden": "true"
-  }, props), _path$3$1 || (_path$3$1 = /*#__PURE__*/reactExports.createElement("path", {
+  }, props), _path$3$2 || (_path$3$2 = /*#__PURE__*/reactExports.createElement("path", {
     fill: "none",
     stroke: "currentColor",
     strokeLinecap: "round",
@@ -8205,34 +8205,34 @@ var SvgFileSpreadsheetStroke = function SvgFileSpreadsheetStroke(props) {
   })));
 };
 
-var _path$2$1;
-function _extends$2$1() { _extends$2$1 = Object.assign ? Object.assign.bind() : function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends$2$1.apply(this, arguments); }
+var _path$2$2;
+function _extends$2$3() { _extends$2$3 = Object.assign ? Object.assign.bind() : function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends$2$3.apply(this, arguments); }
 var SvgFilePresentationStroke = function SvgFilePresentationStroke(props) {
-  return /*#__PURE__*/reactExports.createElement("svg", _extends$2$1({
+  return /*#__PURE__*/reactExports.createElement("svg", _extends$2$3({
     xmlns: "http://www.w3.org/2000/svg",
     width: 16,
     height: 16,
     focusable: "false",
     viewBox: "0 0 16 16",
     "aria-hidden": "true"
-  }, props), _path$2$1 || (_path$2$1 = /*#__PURE__*/reactExports.createElement("path", {
+  }, props), _path$2$2 || (_path$2$2 = /*#__PURE__*/reactExports.createElement("path", {
     fill: "none",
     stroke: "currentColor",
     d: "M14.5 4.2V15c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h8.85c.13 0 .26.05.36.15l3.15 3.2c.09.1.14.22.14.35zm-4-3.7V4c0 .28.22.5.5.5h3.5M7 9.5h4c.28 0 .5.22.5.5v3c0 .28-.22.5-.5.5H7c-.28 0-.5-.22-.5-.5v-3c0-.28.22-.5.5-.5zm-.5 2H5c-.28 0-.5-.22-.5-.5V8c0-.28.22-.5.5-.5h4c.28 0 .5.22.5.5v1.5"
   })));
 };
 
-var _path$1$1;
-function _extends$1$2() { _extends$1$2 = Object.assign ? Object.assign.bind() : function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends$1$2.apply(this, arguments); }
+var _path$1$3;
+function _extends$1$4() { _extends$1$4 = Object.assign ? Object.assign.bind() : function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends$1$4.apply(this, arguments); }
 var SvgFileGenericStroke = function SvgFileGenericStroke(props) {
-  return /*#__PURE__*/reactExports.createElement("svg", _extends$1$2({
+  return /*#__PURE__*/reactExports.createElement("svg", _extends$1$4({
     xmlns: "http://www.w3.org/2000/svg",
     width: 16,
     height: 16,
     focusable: "false",
     viewBox: "0 0 16 16",
     "aria-hidden": "true"
-  }, props), _path$1$1 || (_path$1$1 = /*#__PURE__*/reactExports.createElement("path", {
+  }, props), _path$1$3 || (_path$1$3 = /*#__PURE__*/reactExports.createElement("path", {
     fill: "none",
     stroke: "currentColor",
     d: "M14.5 4.2V15c0 .28-.22.5-.5.5H2c-.28 0-.5-.22-.5-.5V1c0-.28.22-.5.5-.5h8.85c.13 0 .26.05.36.15l3.15 3.2c.09.1.14.22.14.35zm-4-3.7V4c0 .28.22.5.5.5h3.5"
@@ -8276,7 +8276,7 @@ const fileIconsCompact = {
   spreadsheet: React__default.createElement(SvgFileSpreadsheetStroke$1, null),
   presentation: React__default.createElement(SvgFilePresentationStroke$1, null),
   generic: React__default.createElement(SvgFileGenericStroke$1, null),
-  success: React__default.createElement(SvgCheckCircleStroke, null),
+  success: React__default.createElement(SvgCheckCircleStroke$2, null),
   error: React__default.createElement(SvgFileErrorStroke$1, null)
 };
 
@@ -8312,7 +8312,7 @@ FileComponent.propTypes = {
   validation: PropTypes.oneOf(FILE_VALIDATION)
 };
 const File = FileComponent;
-File.Close = Close$1;
+File.Close = Close$2;
 File.Delete = Delete;
 
 const MediaInput = React__default.forwardRef((_ref, ref) => {
@@ -8342,22 +8342,22 @@ const MediaInput = React__default.forwardRef((_ref, ref) => {
     onMouseOut,
     ...otherWrapperProps
   } = wrapperProps;
-  const onFauxInputClickHandler = composeEventHandlers$1(onClick, () => {
+  const onFauxInputClickHandler = composeEventHandlers$2(onClick, () => {
     inputRef.current && inputRef.current.focus();
   });
-  const onFauxInputFocusHandler = composeEventHandlers$1(onFocus, () => {
+  const onFauxInputFocusHandler = composeEventHandlers$2(onFocus, () => {
     setIsFocused(true);
   });
-  const onFauxInputBlurHandler = composeEventHandlers$1(onBlur, () => {
+  const onFauxInputBlurHandler = composeEventHandlers$2(onBlur, () => {
     setIsFocused(false);
   });
-  const onFauxInputMouseOverHandler = composeEventHandlers$1(onMouseOver, () => {
+  const onFauxInputMouseOverHandler = composeEventHandlers$2(onMouseOver, () => {
     setIsHovered(true);
   });
-  const onFauxInputMouseOutHandler = composeEventHandlers$1(onMouseOut, () => {
+  const onFauxInputMouseOutHandler = composeEventHandlers$2(onMouseOut, () => {
     setIsHovered(false);
   });
-  const onSelectHandler = readOnly ? composeEventHandlers$1(onSelect, event => {
+  const onSelectHandler = readOnly ? composeEventHandlers$2(onSelect, event => {
     event.currentTarget.select();
   }) : onSelect;
   let combinedProps = {
@@ -8909,7 +8909,7 @@ function invokeOnChangeHandler(key, action, state, newState) {
  * @param {Object} a action with changes.
  * @returns {Object} changes.
  */
-function stateReducer(s, a) {
+function stateReducer$1(s, a) {
   return a.changes;
 }
 
@@ -9026,7 +9026,7 @@ function useEnhancedReducer(reducer, initialState, props) {
 }
 var defaultProps$3 = {
   itemToString: itemToString,
-  stateReducer: stateReducer,
+  stateReducer: stateReducer$1,
   getA11ySelectionMessage: getA11ySelectionMessage,
   scrollIntoView: scrollIntoView,
   environment: /* istanbul ignore next (ssr) */
@@ -10092,14 +10092,14 @@ const typeMap = {
   [useCombobox$1.stateChangeTypes.InputBlur]: 'input:blur',
   [useCombobox$1.stateChangeTypes.InputChange]: 'input:change',
   [useCombobox$1.stateChangeTypes.InputFocus]: 'input:focus',
-  [useCombobox$1.stateChangeTypes.InputKeyDownArrowDown]: `input:keyDown:${KEYS$1.DOWN}`,
-  [useCombobox$1.stateChangeTypes.InputKeyDownArrowUp]: `input:keyDown:${KEYS$1.UP}`,
-  [useCombobox$1.stateChangeTypes.InputKeyDownEnd]: `input:keyDown:${KEYS$1.END}`,
-  [useCombobox$1.stateChangeTypes.InputKeyDownEnter]: `input:keyDown:${KEYS$1.ENTER}`,
-  [useCombobox$1.stateChangeTypes.InputKeyDownEscape]: `input:keyDown:${KEYS$1.ESCAPE}`,
-  [useCombobox$1.stateChangeTypes.InputKeyDownHome]: `input:keyDown:${KEYS$1.HOME}`,
-  [useCombobox$1.stateChangeTypes.InputKeyDownPageDown]: `input:keyDown:${KEYS$1.PAGE_DOWN}`,
-  [useCombobox$1.stateChangeTypes.InputKeyDownPageUp]: `input:keyDown:${KEYS$1.PAGE_UP}`,
+  [useCombobox$1.stateChangeTypes.InputKeyDownArrowDown]: `input:keyDown:${KEYS$2.DOWN}`,
+  [useCombobox$1.stateChangeTypes.InputKeyDownArrowUp]: `input:keyDown:${KEYS$2.UP}`,
+  [useCombobox$1.stateChangeTypes.InputKeyDownEnd]: `input:keyDown:${KEYS$2.END}`,
+  [useCombobox$1.stateChangeTypes.InputKeyDownEnter]: `input:keyDown:${KEYS$2.ENTER}`,
+  [useCombobox$1.stateChangeTypes.InputKeyDownEscape]: `input:keyDown:${KEYS$2.ESCAPE}`,
+  [useCombobox$1.stateChangeTypes.InputKeyDownHome]: `input:keyDown:${KEYS$2.HOME}`,
+  [useCombobox$1.stateChangeTypes.InputKeyDownPageDown]: `input:keyDown:${KEYS$2.PAGE_DOWN}`,
+  [useCombobox$1.stateChangeTypes.InputKeyDownPageUp]: `input:keyDown:${KEYS$2.PAGE_UP}`,
   [useCombobox$1.stateChangeTypes.ItemClick]: 'option:click',
   [useCombobox$1.stateChangeTypes.ItemMouseMove]: 'option:mouseMove',
   [useCombobox$1.stateChangeTypes.MenuMouseLeave]: 'listbox:mouseLeave',
@@ -10438,8 +10438,8 @@ const useCombobox = _ref => {
       };
       return {
         ...triggerProps,
-        onBlur: composeEventHandlers$1(onBlur, handleBlur),
-        onClick: composeEventHandlers$1(onClick, handleClick),
+        onBlur: composeEventHandlers$2(onBlur, handleBlur),
+        onClick: composeEventHandlers$2(onClick, handleClick),
         'aria-controls': isAutocomplete ? triggerProps['aria-controls'] : undefined,
         'aria-expanded': undefined,
         'aria-disabled': disabled || undefined,
@@ -10457,7 +10457,7 @@ const useCombobox = _ref => {
       } = getFieldInputProps();
       const handleKeyDown = event => {
         event.stopPropagation();
-        if (!_isExpanded && (event.key === KEYS$1.SPACE || event.key === KEYS$1.ENTER)) {
+        if (!_isExpanded && (event.key === KEYS$2.SPACE || event.key === KEYS$2.ENTER)) {
           openListbox();
         } else if (/^(?:\S| ){1}$/u.test(event.key)) {
           const _matchValue = `${matchValue}${event.key}`;
@@ -10493,8 +10493,8 @@ const useCombobox = _ref => {
         'aria-disabled': disabled || undefined,
         disabled: undefined,
         role: 'combobox',
-        onBlur: composeEventHandlers$1(onBlur, handleBlur),
-        onKeyDown: composeEventHandlers$1(onKeyDown, onDownshiftKeyDown, handleKeyDown),
+        onBlur: composeEventHandlers$2(onBlur, handleBlur),
+        onKeyDown: composeEventHandlers$2(onKeyDown, onDownshiftKeyDown, handleKeyDown),
         tabIndex: disabled ? -1 : 0
       };
     }
@@ -10512,7 +10512,7 @@ const useCombobox = _ref => {
     const handleClick = () => !isEditable && triggerRef.current?.focus();
     return {
       ...labelProps,
-      onClick: composeEventHandlers$1(onClick, handleClick),
+      onClick: composeEventHandlers$2(onClick, handleClick),
       htmlFor: isEditable ? htmlFor : undefined
     };
   }, [getFieldLabelProps, isEditable, triggerRef]);
@@ -10540,7 +10540,7 @@ const useCombobox = _ref => {
         role,
         'aria-labelledby': ariaLabeledBy,
         'aria-autocomplete': isAutocomplete ? 'list' : undefined,
-        onClick: composeEventHandlers$1(onClick, handleClick),
+        onClick: composeEventHandlers$2(onClick, handleClick),
         ...getFieldInputProps(),
         ...other
       });
@@ -10565,7 +10565,7 @@ const useCombobox = _ref => {
       disabled,
       readOnly: true,
       tabIndex: -1,
-      onFocus: composeEventHandlers$1(onFocus, handleFocus),
+      onFocus: composeEventHandlers$2(onFocus, handleFocus),
       ...other
     };
   }, [getDownshiftInputProps, getFieldInputProps, inputRef, triggerRef, disabled, isAutocomplete, isEditable]);
@@ -10584,11 +10584,11 @@ const useCombobox = _ref => {
       }
     };
     const handleKeyDown = event => {
-      if (event.key === KEYS$1.BACKSPACE || event.key === KEYS$1.DELETE) {
+      if (event.key === KEYS$2.BACKSPACE || event.key === KEYS$2.DELETE) {
         setDownshiftSelection(option.value);
       } else {
         const triggerContainsTag = event.target instanceof Element && triggerRef.current?.contains(event.target);
-        if (triggerContainsTag && (event.key === KEYS$1.DOWN || event.key === KEYS$1.UP || event.key === KEYS$1.ESCAPE)) {
+        if (triggerContainsTag && (event.key === KEYS$2.DOWN || event.key === KEYS$2.UP || event.key === KEYS$2.ESCAPE)) {
           const inputProps = getDownshiftInputProps();
           if (isEditable) {
             inputRef.current?.focus();
@@ -10604,9 +10604,9 @@ const useCombobox = _ref => {
     return {
       'data-garden-container-id': 'containers.combobox.tag',
       'data-garden-container-version': '1.0.0',
-      onClick: composeEventHandlers$1(onClick, handleClick),
-      onFocus: composeEventHandlers$1(onFocus, handleFocus),
-      onKeyDown: composeEventHandlers$1(onKeyDown, handleKeyDown),
+      onClick: composeEventHandlers$2(onClick, handleClick),
+      onFocus: composeEventHandlers$2(onFocus, handleFocus),
+      onKeyDown: composeEventHandlers$2(onKeyDown, handleKeyDown),
       ...other
     };
   }, [triggerRef, setDownshiftSelection, getDownshiftInputProps, isEditable, _isExpanded, values, setActiveIndex, inputRef]);
@@ -10663,7 +10663,7 @@ const useCombobox = _ref => {
         'aria-selected': ariaSelected,
         id: option ? getOptionId(disabledValues.indexOf(option.value), option.disabled) : undefined,
         ...optionProps,
-        onMouseDown: composeEventHandlers$1(onMouseDown, handleMouseDown)
+        onMouseDown: composeEventHandlers$2(onMouseDown, handleMouseDown)
       };
     }
     return getDownshiftOptionProps({
@@ -10751,8 +10751,8 @@ const useCombobox = _ref => {
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-function _extends$1$1() {
-  _extends$1$1 = Object.assign ? Object.assign.bind() : function (target) {
+function _extends$1$3() {
+  _extends$1$3 = Object.assign ? Object.assign.bind() : function (target) {
     for (var i = 1; i < arguments.length; i++) {
       var source = arguments[i];
       for (var key in source) {
@@ -10763,43 +10763,43 @@ function _extends$1$1() {
     }
     return target;
   };
-  return _extends$1$1.apply(this, arguments);
+  return _extends$1$3.apply(this, arguments);
 }
 
-const SIZE$1 = ['small', 'medium', 'large'];
+const SIZE$2 = ['small', 'medium', 'large'];
 
-const COMPONENT_ID$2$2 = 'tags.avatar';
-const StyledAvatar = Ye(_ref => {
+const COMPONENT_ID$2$4 = 'tags.avatar';
+const StyledAvatar = styled(_ref => {
   let {
     children,
     ...props
   } = _ref;
   return React__default.cloneElement(reactExports.Children.only(children), props);
 }).attrs({
-  'data-garden-id': COMPONENT_ID$2$2,
+  'data-garden-id': COMPONENT_ID$2$4,
   'data-garden-version': '8.69.1'
 }).withConfig({
   displayName: "StyledAvatar",
   componentId: "sc-3kdmgt-0"
-})(["flex-shrink:0;font-size:0;", ";"], props => retrieveComponentStyles(COMPONENT_ID$2$2, props));
+})(["flex-shrink:0;font-size:0;", ";"], props => retrieveComponentStyles(COMPONENT_ID$2$4, props));
 StyledAvatar.defaultProps = {
   theme: DEFAULT_THEME
 };
 
-const COMPONENT_ID$1$2 = 'tags.close';
-const StyledClose = Ye.button.attrs({
-  'data-garden-id': COMPONENT_ID$1$2,
+const COMPONENT_ID$1$4 = 'tags.close';
+const StyledClose$1 = styled.button.attrs({
+  'data-garden-id': COMPONENT_ID$1$4,
   'data-garden-version': '8.69.1'
 }).withConfig({
   displayName: "StyledClose",
   componentId: "sc-d6lrpn-0"
-})(["display:flex;flex-shrink:0;align-items:center;justify-content:center;transition:opacity 0.25s ease-in-out;opacity:0.8;border:0;background:transparent;cursor:pointer;padding:0;color:inherit;font-size:0;appearance:none;&:hover{opacity:0.9;}&:focus{outline:none;}", ";"], props => retrieveComponentStyles(COMPONENT_ID$1$2, props));
-StyledClose.defaultProps = {
+})(["display:flex;flex-shrink:0;align-items:center;justify-content:center;transition:opacity 0.25s ease-in-out;opacity:0.8;border:0;background:transparent;cursor:pointer;padding:0;color:inherit;font-size:0;appearance:none;&:hover{opacity:0.9;}&:focus{outline:none;}", ";"], props => retrieveComponentStyles(COMPONENT_ID$1$4, props));
+StyledClose$1.defaultProps = {
   theme: DEFAULT_THEME
 };
 
-const COMPONENT_ID$n = 'tags.tag_view';
-const colorStyles$a = props => {
+const COMPONENT_ID$o = 'tags.tag_view';
+const colorStyles$b = props => {
   let backgroundColor;
   let foregroundColor;
   let closeColor;
@@ -10820,9 +10820,9 @@ const colorStyles$a = props => {
     theme: props.theme,
     shadowWidth: 'sm',
     selector: '&:focus'
-  }), StyledClose, closeColor);
+  }), StyledClose$1, closeColor);
 };
-const sizeStyles$c = props => {
+const sizeStyles$d = props => {
   let borderRadius;
   let padding;
   let height;
@@ -10868,31 +10868,31 @@ const sizeStyles$c = props => {
       minWidth = props.theme.space.base * 7.5;
     }
   }
-  return Ne(["border-radius:", ";padding:0 ", "px;min-width:", ";height:", "px;line-height:", ";font-size:", ";& > *{width:100%;min-width:", ";}& ", "{margin-", ":-", "px;margin-", ":", "px;border-radius:", ";width:", "px;min-width:", "px;height:", "px;}& ", "{margin-", ":-", "px;border-radius:", ";width:", "px;height:", "px;}"], borderRadius, padding, minWidth ? `${minWidth}px` : `calc(${padding * 2}px + 1ch)`, height, getLineHeight(height, fontSize), fontSize, minWidth ? `${minWidth - padding * 2}px` : '1ch', StyledAvatar, props.theme.rtl ? 'right' : 'left', padding - avatarMargin, props.theme.rtl ? 'left' : 'right', avatarTextMargin, avatarBorderRadius, avatarSize, avatarSize, avatarSize, StyledClose, props.theme.rtl ? 'left' : 'right', padding, borderRadius, height, height);
+  return Ne(["border-radius:", ";padding:0 ", "px;min-width:", ";height:", "px;line-height:", ";font-size:", ";& > *{width:100%;min-width:", ";}& ", "{margin-", ":-", "px;margin-", ":", "px;border-radius:", ";width:", "px;min-width:", "px;height:", "px;}& ", "{margin-", ":-", "px;border-radius:", ";width:", "px;height:", "px;}"], borderRadius, padding, minWidth ? `${minWidth}px` : `calc(${padding * 2}px + 1ch)`, height, getLineHeight(height, fontSize), fontSize, minWidth ? `${minWidth - padding * 2}px` : '1ch', StyledAvatar, props.theme.rtl ? 'right' : 'left', padding - avatarMargin, props.theme.rtl ? 'left' : 'right', avatarTextMargin, avatarBorderRadius, avatarSize, avatarSize, avatarSize, StyledClose$1, props.theme.rtl ? 'left' : 'right', padding, borderRadius, height, height);
 };
-const StyledTag$1 = Ye.div.attrs({
-  'data-garden-id': COMPONENT_ID$n,
+const StyledTag$1 = styled.div.attrs({
+  'data-garden-id': COMPONENT_ID$o,
   'data-garden-version': '8.69.1'
 }).withConfig({
   displayName: "StyledTag",
   componentId: "sc-1jvbe03-0"
-})(["display:inline-flex;flex-wrap:nowrap;align-items:center;justify-content:", ";transition:box-shadow 0.1s ease-in-out;box-sizing:border-box;border:0;max-width:100%;overflow:hidden;vertical-align:middle;text-decoration:none;white-space:nowrap;font-weight:", ";direction:", ";", ";&:hover{cursor:default;text-decoration:none;}&:link:hover,&:visited:hover{cursor:pointer;}&:any-link:hover{cursor:pointer;}", "{text-decoration:none;}", ";& > *{overflow:hidden;text-align:center;text-overflow:ellipsis;white-space:nowrap;}& b{font-weight:", ";}& ", "{display:", ";}& ", "{display:", ";}", ";"], props => props.isRound && 'center', props => !props.isRegular && props.theme.fontWeights.semibold, props => props.theme.rtl ? 'rtl' : 'ltr', props => sizeStyles$c(props), SELECTOR_FOCUS_VISIBLE, props => colorStyles$a(props), props => props.theme.fontWeights.semibold, StyledAvatar, props => (props.isRound || props.size === 'small') && 'none', StyledClose, props => props.isRound && 'none', props => retrieveComponentStyles(COMPONENT_ID$n, props));
+})(["display:inline-flex;flex-wrap:nowrap;align-items:center;justify-content:", ";transition:box-shadow 0.1s ease-in-out;box-sizing:border-box;border:0;max-width:100%;overflow:hidden;vertical-align:middle;text-decoration:none;white-space:nowrap;font-weight:", ";direction:", ";", ";&:hover{cursor:default;text-decoration:none;}&:link:hover,&:visited:hover{cursor:pointer;}&:any-link:hover{cursor:pointer;}", "{text-decoration:none;}", ";& > *{overflow:hidden;text-align:center;text-overflow:ellipsis;white-space:nowrap;}& b{font-weight:", ";}& ", "{display:", ";}& ", "{display:", ";}", ";"], props => props.isRound && 'center', props => !props.isRegular && props.theme.fontWeights.semibold, props => props.theme.rtl ? 'rtl' : 'ltr', props => sizeStyles$d(props), SELECTOR_FOCUS_VISIBLE, props => colorStyles$b(props), props => props.theme.fontWeights.semibold, StyledAvatar, props => (props.isRound || props.size === 'small') && 'none', StyledClose$1, props => props.isRound && 'none', props => retrieveComponentStyles(COMPONENT_ID$o, props));
 StyledTag$1.defaultProps = {
   size: 'medium',
   theme: DEFAULT_THEME
 };
 
-var _path$5;
-function _extends$8() { _extends$8 = Object.assign ? Object.assign.bind() : function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends$8.apply(this, arguments); }
-var SvgXStroke = function SvgXStroke(props) {
-  return /*#__PURE__*/reactExports.createElement("svg", _extends$8({
+var _path$6;
+function _extends$b() { _extends$b = Object.assign ? Object.assign.bind() : function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends$b.apply(this, arguments); }
+var SvgXStroke$2 = function SvgXStroke(props) {
+  return /*#__PURE__*/reactExports.createElement("svg", _extends$b({
     xmlns: "http://www.w3.org/2000/svg",
     width: 12,
     height: 12,
     focusable: "false",
     viewBox: "0 0 12 12",
     "aria-hidden": "true"
-  }, props), _path$5 || (_path$5 = /*#__PURE__*/reactExports.createElement("path", {
+  }, props), _path$6 || (_path$6 = /*#__PURE__*/reactExports.createElement("path", {
     stroke: "currentColor",
     strokeLinecap: "round",
     d: "M3 9l6-6m0 6L3 3"
@@ -10901,16 +10901,16 @@ var SvgXStroke = function SvgXStroke(props) {
 
 const CloseComponent = reactExports.forwardRef((props, ref) => {
   const ariaLabel = useText(CloseComponent, props, 'aria-label', 'Remove');
-  return React__default.createElement(StyledClose, _extends$1$1({
+  return React__default.createElement(StyledClose$1, _extends$1$3({
     ref: ref,
     "aria-label": ariaLabel
   }, props, {
     type: "button",
     tabIndex: -1
-  }), React__default.createElement(SvgXStroke, null));
+  }), React__default.createElement(SvgXStroke$2, null));
 });
 CloseComponent.displayName = 'Tag.Close';
-const Close = CloseComponent;
+const Close$1 = CloseComponent;
 
 const AvatarComponent = props => React__default.createElement(StyledAvatar, props);
 AvatarComponent.displayName = 'Tag.Avatar';
@@ -10922,7 +10922,7 @@ const TagComponent$1 = reactExports.forwardRef((_ref, ref) => {
     hue,
     ...otherProps
   } = _ref;
-  return React__default.createElement(StyledTag$1, _extends$1$1({
+  return React__default.createElement(StyledTag$1, _extends$1$3({
     ref: ref,
     size: size,
     hue: hue
@@ -10930,7 +10930,7 @@ const TagComponent$1 = reactExports.forwardRef((_ref, ref) => {
 });
 TagComponent$1.displayName = 'Tag';
 TagComponent$1.propTypes = {
-  size: PropTypes.oneOf(SIZE$1),
+  size: PropTypes.oneOf(SIZE$2),
   hue: PropTypes.string,
   isPill: PropTypes.bool,
   isRound: PropTypes.bool,
@@ -10941,7 +10941,7 @@ TagComponent$1.defaultProps = {
 };
 const Tag$1 = TagComponent$1;
 Tag$1.Avatar = Avatar;
-Tag$1.Close = Close;
+Tag$1.Close = Close$1;
 
 function getAlignment(placement) {
   return placement.split('-')[1];
@@ -12547,11 +12547,11 @@ const useTooltip = function (_temp) {
     } = _temp2 === void 0 ? {} : _temp2;
     return {
       tabIndex,
-      onMouseEnter: composeEventHandlers$1(onMouseEnter, () => openTooltip()),
-      onMouseLeave: composeEventHandlers$1(onMouseLeave, () => closeTooltip()),
-      onFocus: composeEventHandlers$1(onFocus, () => openTooltip()),
-      onBlur: composeEventHandlers$1(onBlur, () => closeTooltip(0)),
-      onKeyDown: composeEventHandlers$1(onKeyDown, event => {
+      onMouseEnter: composeEventHandlers$2(onMouseEnter, () => openTooltip()),
+      onMouseLeave: composeEventHandlers$2(onMouseLeave, () => closeTooltip()),
+      onFocus: composeEventHandlers$2(onFocus, () => openTooltip()),
+      onBlur: composeEventHandlers$2(onBlur, () => closeTooltip(0)),
+      onKeyDown: composeEventHandlers$2(onKeyDown, event => {
         if (event.keyCode === KEY_CODES.ESCAPE && visibility) {
           closeTooltip(0);
         }
@@ -12571,8 +12571,8 @@ const useTooltip = function (_temp) {
     } = _temp3 === void 0 ? {} : _temp3;
     return {
       role,
-      onMouseEnter: composeEventHandlers$1(onMouseEnter, () => openTooltip()),
-      onMouseLeave: composeEventHandlers$1(onMouseLeave, () => closeTooltip()),
+      onMouseEnter: composeEventHandlers$2(onMouseEnter, () => openTooltip()),
+      onMouseLeave: composeEventHandlers$2(onMouseLeave, () => closeTooltip()),
       'aria-hidden': !visibility,
       id: _id,
       ...other
@@ -14286,7 +14286,7 @@ var defineProperty = function (obj, key, value) {
   return obj;
 };
 
-var _extends$7 = Object.assign || function (target) {
+var _extends$a = Object.assign || function (target) {
   for (var i = 1; i < arguments.length; i++) {
     var source = arguments[i];
 
@@ -14308,7 +14308,7 @@ var _extends$7 = Object.assign || function (target) {
  * @returns {Object} ClientRect like output
  */
 function getClientRect(offsets) {
-  return _extends$7({}, offsets, {
+  return _extends$a({}, offsets, {
     right: offsets.left + offsets.width,
     bottom: offsets.top + offsets.height
   });
@@ -14596,7 +14596,7 @@ function computeAutoPlacement(placement, refRect, popper, reference, boundariesE
   };
 
   var sortedAreas = Object.keys(rects).map(function (key) {
-    return _extends$7({
+    return _extends$a({
       key: key
     }, rects[key], {
       area: getArea(rects[key])
@@ -15238,9 +15238,9 @@ function computeStyle(data, options) {
   };
 
   // Update `data` attributes, styles and arrowStyles
-  data.attributes = _extends$7({}, attributes, data.attributes);
-  data.styles = _extends$7({}, styles, data.styles);
-  data.arrowStyles = _extends$7({}, data.offsets.arrow, data.arrowStyles);
+  data.attributes = _extends$a({}, attributes, data.attributes);
+  data.styles = _extends$a({}, styles, data.styles);
+  data.arrowStyles = _extends$a({}, data.offsets.arrow, data.arrowStyles);
 
   return data;
 }
@@ -15520,7 +15520,7 @@ function flip(data, options) {
 
       // this object contains `position`, we want to preserve it along with
       // any additional property we may add in the future
-      data.offsets.popper = _extends$7({}, data.offsets.popper, getPopperOffsets(data.instance.popper, data.offsets.reference, data.placement));
+      data.offsets.popper = _extends$a({}, data.offsets.popper, getPopperOffsets(data.instance.popper, data.offsets.reference, data.placement));
 
       data = runModifiers(data.instance.modifiers, data, 'flip');
     }
@@ -15794,7 +15794,7 @@ function preventOverflow(data, options) {
 
   order.forEach(function (placement) {
     var side = ['left', 'top'].indexOf(placement) !== -1 ? 'primary' : 'secondary';
-    popper = _extends$7({}, popper, check[side](placement));
+    popper = _extends$a({}, popper, check[side](placement));
   });
 
   data.offsets.popper = popper;
@@ -15829,7 +15829,7 @@ function shift(data) {
       end: defineProperty({}, side, reference[side] + reference[measurement] - popper[measurement])
     };
 
-    data.offsets.popper = _extends$7({}, popper, shiftOffsets[shiftvariation]);
+    data.offsets.popper = _extends$a({}, popper, shiftOffsets[shiftvariation]);
   }
 
   return data;
@@ -16361,7 +16361,7 @@ var Popper$1 = function () {
     this.update = debounce(this.update.bind(this));
 
     // with {} we create a new object with the options inside it
-    this.options = _extends$7({}, Popper.Defaults, options);
+    this.options = _extends$a({}, Popper.Defaults, options);
 
     // init state
     this.state = {
@@ -16376,13 +16376,13 @@ var Popper$1 = function () {
 
     // Deep merge modifiers options
     this.options.modifiers = {};
-    Object.keys(_extends$7({}, Popper.Defaults.modifiers, options.modifiers)).forEach(function (name) {
-      _this.options.modifiers[name] = _extends$7({}, Popper.Defaults.modifiers[name] || {}, options.modifiers ? options.modifiers[name] : {});
+    Object.keys(_extends$a({}, Popper.Defaults.modifiers, options.modifiers)).forEach(function (name) {
+      _this.options.modifiers[name] = _extends$a({}, Popper.Defaults.modifiers[name] || {}, options.modifiers ? options.modifiers[name] : {});
     });
 
     // Refactoring modifiers' list (Object => Array)
     this.modifiers = Object.keys(this.options.modifiers).map(function (name) {
-      return _extends$7({
+      return _extends$a({
         name: name
       }, _this.options.modifiers[name]);
     })
@@ -17112,32 +17112,32 @@ function getArrowPosition(popperPlacement) {
   return arrowPositionMappings[popperPlacement] || 'top';
 }
 
-const COMPONENT_ID$2$1 = 'tooltip.paragraph';
-const StyledParagraph = Ye.p.attrs({
-  'data-garden-id': COMPONENT_ID$2$1,
+const COMPONENT_ID$2$3 = 'tooltip.paragraph';
+const StyledParagraph$1 = styled.p.attrs({
+  'data-garden-id': COMPONENT_ID$2$3,
   'data-garden-version': '8.69.1'
 }).withConfig({
   displayName: "StyledParagraph",
   componentId: "sc-wuqkfc-0"
-})(["margin:0;", ";"], props => retrieveComponentStyles(COMPONENT_ID$2$1, props));
-StyledParagraph.defaultProps = {
+})(["margin:0;", ";"], props => retrieveComponentStyles(COMPONENT_ID$2$3, props));
+StyledParagraph$1.defaultProps = {
   theme: DEFAULT_THEME
 };
 
-const COMPONENT_ID$1$1 = 'tooltip.title';
-const StyledTitle = Ye.strong.attrs({
-  'data-garden-id': COMPONENT_ID$1$1,
+const COMPONENT_ID$1$3 = 'tooltip.title';
+const StyledTitle$1 = styled.strong.attrs({
+  'data-garden-id': COMPONENT_ID$1$3,
   'data-garden-version': '8.69.1'
 }).withConfig({
   displayName: "StyledTitle",
   componentId: "sc-vnjcvz-0"
-})(["display:none;margin:0;font-weight:", ";", ";"], props => props.theme.fontWeights.semibold, props => retrieveComponentStyles(COMPONENT_ID$1$1, props));
-StyledTitle.defaultProps = {
+})(["display:none;margin:0;font-weight:", ";", ";"], props => props.theme.fontWeights.semibold, props => retrieveComponentStyles(COMPONENT_ID$1$3, props));
+StyledTitle$1.defaultProps = {
   theme: DEFAULT_THEME
 };
 
-const COMPONENT_ID$m = 'tooltip.tooltip';
-const sizeStyles$b = _ref => {
+const COMPONENT_ID$n = 'tooltip.tooltip';
+const sizeStyles$c = _ref => {
   let {
     theme,
     size,
@@ -17201,9 +17201,9 @@ const sizeStyles$b = _ref => {
   return Ne(["margin:", ";border-radius:", ";padding:", ";max-width:", ";line-height:", ";word-wrap:", ";white-space:", ";font-size:", ";overflow-wrap:", ";", ";", "{margin-top:", ";}", "{display:", ";}"], margin, borderRadius, padding, maxWidth, lineHeight, wordWrap, whiteSpace, fontSize, overflowWrap, hasArrow && arrowStyles(getArrowPosition(placement), {
     size: arrowSize,
     inset: arrowInset
-  }), StyledParagraph, paragraphMarginTop, StyledTitle, titleDisplay);
+  }), StyledParagraph$1, paragraphMarginTop, StyledTitle$1, titleDisplay);
 };
-const colorStyles$9 = _ref2 => {
+const colorStyles$a = _ref2 => {
   let {
     theme,
     type
@@ -17220,20 +17220,20 @@ const colorStyles$9 = _ref2 => {
     color = getColor('neutralHue', 700, theme);
     titleColor = theme.colors.foreground;
   }
-  return Ne(["border:", ";box-shadow:", ";background-color:", ";color:", ";", "{color:", ";}"], border, boxShadow, backgroundColor, color, StyledTitle, titleColor);
+  return Ne(["border:", ";box-shadow:", ";background-color:", ";color:", ";", "{color:", ";}"], border, boxShadow, backgroundColor, color, StyledTitle$1, titleColor);
 };
-const StyledTooltip = Ye.div.attrs({
-  'data-garden-id': COMPONENT_ID$m,
+const StyledTooltip = styled.div.attrs({
+  'data-garden-id': COMPONENT_ID$n,
   'data-garden-version': '8.69.1'
 }).withConfig({
   displayName: "StyledTooltip",
   componentId: "sc-gzzjq4-0"
-})(["display:inline-block;box-sizing:border-box;direction:", ";text-align:", ";font-weight:", ";", ";&[aria-hidden='true']{display:none;}", ";", ";"], props => props.theme.rtl && 'rtl', props => props.theme.rtl ? 'right' : 'left', props => props.theme.fontWeights.regular, props => sizeStyles$b(props), colorStyles$9, props => retrieveComponentStyles(COMPONENT_ID$m, props));
+})(["display:inline-block;box-sizing:border-box;direction:", ";text-align:", ";font-weight:", ";", ";&[aria-hidden='true']{display:none;}", ";", ";"], props => props.theme.rtl && 'rtl', props => props.theme.rtl ? 'right' : 'left', props => props.theme.fontWeights.regular, props => sizeStyles$c(props), colorStyles$a, props => retrieveComponentStyles(COMPONENT_ID$n, props));
 StyledTooltip.defaultProps = {
   theme: DEFAULT_THEME
 };
 
-const StyledTooltipWrapper = Ye.div.withConfig({
+const StyledTooltipWrapper = styled.div.withConfig({
   displayName: "StyledTooltipWrapper",
   componentId: "sc-1b7q9q6-0"
 })(["transition:opacity 10ms;opacity:1;z-index:", ";&[aria-hidden='true']{visibility:hidden;opacity:0;}"], props => props.zIndex);
@@ -17243,8 +17243,8 @@ StyledTooltipWrapper.defaultProps = {
 
 const SHARED_PLACEMENT = ['auto', 'top', 'top-start', 'top-end', 'bottom', 'bottom-start', 'bottom-end'];
 const PLACEMENT = [...SHARED_PLACEMENT, 'end', 'end-top', 'end-bottom', 'start', 'start-top', 'start-bottom'];
-const SIZE = ['small', 'medium', 'large', 'extra-large'];
-const TYPE = ['light', 'dark'];
+const SIZE$1 = ['small', 'medium', 'large', 'extra-large'];
+const TYPE$1 = ['light', 'dark'];
 
 const Tooltip = _ref => {
   let {
@@ -17280,7 +17280,7 @@ const Tooltip = _ref => {
     delayMilliseconds: delayMS,
     isVisible: isInitialVisible
   });
-  const controlledIsVisible = getControlledValue(externalIsVisible, isVisible);
+  const controlledIsVisible = getControlledValue$1(externalIsVisible, isVisible);
   reactExports.useEffect(() => {
     if (controlledIsVisible && scheduleUpdateRef.current) {
       scheduleUpdateRef.current();
@@ -17331,10 +17331,10 @@ const Tooltip = _ref => {
       hasArrow,
       placement: currentPlacement,
       size: computedSize,
-      onFocus: composeEventHandlers$1(onFocus, () => {
+      onFocus: composeEventHandlers$2(onFocus, () => {
         openTooltip();
       }),
-      onBlur: composeEventHandlers$1(onBlur, () => {
+      onBlur: composeEventHandlers$2(onBlur, () => {
         closeTooltip(0);
       }),
       'aria-hidden': !controlledIsVisible,
@@ -17363,8 +17363,8 @@ Tooltip.propTypes = {
   content: PropTypes.node.isRequired,
   placement: PropTypes.oneOf(PLACEMENT),
   popperModifiers: PropTypes.any,
-  size: PropTypes.oneOf(SIZE),
-  type: PropTypes.oneOf(TYPE),
+  size: PropTypes.oneOf(SIZE$1),
+  type: PropTypes.oneOf(TYPE$1),
   zIndex: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   isInitialVisible: PropTypes.bool,
   refKey: PropTypes.string
@@ -17378,8 +17378,8 @@ Tooltip.defaultProps = {
   refKey: 'ref'
 };
 
-function _extends$6() {
-  _extends$6 = Object.assign ? Object.assign.bind() : function (target) {
+function _extends$9() {
+  _extends$9 = Object.assign ? Object.assign.bind() : function (target) {
     for (var i = 1; i < arguments.length; i++) {
       var source = arguments[i];
       for (var key in source) {
@@ -17390,18 +17390,18 @@ function _extends$6() {
     }
     return target;
   };
-  return _extends$6.apply(this, arguments);
+  return _extends$9.apply(this, arguments);
 }
 
-const Paragraph = reactExports.forwardRef((props, ref) => React__default.createElement(StyledParagraph, _extends$6({
+const Paragraph$1 = reactExports.forwardRef((props, ref) => React__default.createElement(StyledParagraph$1, _extends$9({
   ref: ref
 }, props)));
-Paragraph.displayName = 'Paragraph';
+Paragraph$1.displayName = 'Paragraph';
 
-const Title = reactExports.forwardRef((props, ref) => React__default.createElement(StyledTitle, _extends$6({
+const Title$1 = reactExports.forwardRef((props, ref) => React__default.createElement(StyledTitle$1, _extends$9({
   ref: ref
 }, props)));
-Title.displayName = 'Title';
+Title$1.displayName = 'Title';
 
 /**
  * Copyright Zendesk, Inc.
@@ -17410,8 +17410,8 @@ Title.displayName = 'Title';
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-function _extends$5() {
-  _extends$5 = Object.assign ? Object.assign.bind() : function (target) {
+function _extends$5$1() {
+  _extends$5$1 = Object.assign ? Object.assign.bind() : function (target) {
     for (var i = 1; i < arguments.length; i++) {
       var source = arguments[i];
       for (var key in source) {
@@ -17422,13 +17422,13 @@ function _extends$5() {
     }
     return target;
   };
-  return _extends$5.apply(this, arguments);
+  return _extends$5$1.apply(this, arguments);
 }
 
 var _path$4;
-function _extends$4() { _extends$4 = Object.assign ? Object.assign.bind() : function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends$4.apply(this, arguments); }
-var SvgChevronDownStroke = function SvgChevronDownStroke(props) {
-  return /*#__PURE__*/reactExports.createElement("svg", _extends$4({
+function _extends$4$1() { _extends$4$1 = Object.assign ? Object.assign.bind() : function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends$4$1.apply(this, arguments); }
+var SvgChevronDownStroke$1 = function SvgChevronDownStroke(props) {
+  return /*#__PURE__*/reactExports.createElement("svg", _extends$4$1({
     xmlns: "http://www.w3.org/2000/svg",
     width: 16,
     height: 16,
@@ -17460,7 +17460,7 @@ const useFieldContext = () => {
 };
 
 const COMPONENT_ID$l = 'dropdowns.combobox.label';
-const StyledLabel = Ye(Label$1).attrs({
+const StyledLabel = styled(Label$1).attrs({
   'data-garden-id': COMPONENT_ID$l,
   'data-garden-version': '8.69.1'
 }).withConfig({
@@ -17472,7 +17472,7 @@ StyledLabel.defaultProps = {
 };
 
 const COMPONENT_ID$k = 'dropdowns.combobox.hint';
-const StyledHint = Ye(Hint$1).attrs({
+const StyledHint = styled(Hint$1).attrs({
   'data-garden-id': COMPONENT_ID$k,
   'data-garden-version': '8.69.1'
 }).withConfig({
@@ -17484,7 +17484,7 @@ StyledHint.defaultProps = {
 };
 
 const COMPONENT_ID$j = 'dropdowns.combobox.message';
-const StyledMessage = Ye(Message$1).attrs({
+const StyledMessage = styled(Message$1).attrs({
   'data-garden-id': COMPONENT_ID$j,
   'data-garden-version': '8.69.1'
 }).withConfig({
@@ -17501,7 +17501,7 @@ const sizeStyles$a = props => {
   const marginTop = `${props.theme.space.base * (props.isCompact ? 1 : 2)}px`;
   return Ne(["min-width:", ";", ":not([hidden]) + &&,", " + &&,", " + &&,&& + ", ",&& + ", "{margin-top:", ";}"], minWidth, StyledLabel, StyledHint, StyledMessage, StyledHint, StyledMessage, marginTop);
 };
-const StyledCombobox = Ye.div.attrs({
+const StyledCombobox = styled.div.attrs({
   'data-garden-id': COMPONENT_ID$i,
   'data-garden-version': '8.69.1'
 }).withConfig({
@@ -17513,7 +17513,7 @@ StyledCombobox.defaultProps = {
 };
 
 const COMPONENT_ID$h = 'dropdowns.combobox.container';
-const StyledContainer = Ye.div.attrs({
+const StyledContainer = styled.div.attrs({
   'data-garden-id': COMPONENT_ID$h,
   'data-garden-version': '8.69.1'
 }).withConfig({
@@ -17525,7 +17525,7 @@ StyledContainer.defaultProps = {
 };
 
 const COMPONENT_ID$g = 'dropdowns.combobox.field';
-const StyledField = Ye.div.attrs({
+const StyledField = styled.div.attrs({
   'data-garden-id': COMPONENT_ID$g,
   'data-garden-version': '8.69.1'
 }).withConfig({
@@ -17557,7 +17557,7 @@ const sizeStyles$9 = props => {
   const paddingVertical = props.$type === 'group' ? 0 : math(`(${minHeight} - ${lineHeight}) / 2`);
   return Ne(["box-sizing:border-box;padding:", " ", ";min-height:", "px;line-height:", ";"], paddingVertical, paddingHorizontal, minHeight, lineHeight);
 };
-const StyledOption = Ye.li.attrs({
+const StyledOption = styled.li.attrs({
   'data-garden-id': COMPONENT_ID$f,
   'data-garden-version': '8.69.1'
 }).withConfig({
@@ -17574,7 +17574,7 @@ const sizeStyles$8 = props => {
   const minHeight = props.minHeight === undefined ? `${getMinHeight(props) + padding * 2}px` : props.minHeight;
   return Ne(["min-height:", ";max-height:", ";&&&{padding-top:", "px;padding-bottom:", "px;}"], minHeight, props.maxHeight, padding, padding);
 };
-const StyledListbox = Ye.ul.attrs({
+const StyledListbox = styled.ul.attrs({
   'data-garden-id': COMPONENT_ID$e,
   'data-garden-version': '8.69.1'
 }).withConfig({
@@ -17586,7 +17586,7 @@ StyledListbox.defaultProps = {
 };
 
 const COMPONENT_ID$d = 'dropdowns.combobox.floating';
-const StyledFloating = Ye.div.attrs({
+const StyledFloating = styled.div.attrs({
   'data-garden-id': COMPONENT_ID$d,
   'data-garden-version': '8.69.1'
 }).withConfig({
@@ -17603,12 +17603,12 @@ StyledFloating.defaultProps = {
   theme: DEFAULT_THEME
 };
 
-const COMPONENT_ID$c = 'dropdowns.combobox.input';
-const colorStyles$7 = props => {
+const COMPONENT_ID$c$1 = 'dropdowns.combobox.input';
+const colorStyles$7$1 = props => {
   const placeholderColor = getColor('neutralHue', 400, props.theme);
   return Ne(["background-color:inherit;color:inherit;&::placeholder{opacity:1;color:", ";}"], placeholderColor);
 };
-const getHeight = props => {
+const getHeight$1 = props => {
   if (props.isBare && !props.isMultiselectable) {
     return props.theme.space.base * 5;
   }
@@ -17618,39 +17618,39 @@ const sizeStyles$7 = props => {
   const height = props.theme.space.base * 5;
   const fontSize = props.theme.fontSizes.md;
   const lineHeight = getLineHeight(height, fontSize);
-  const margin = math(`${props.theme.shadowWidths.sm} + ${(getHeight(props) - height) / 2}`);
+  const margin = math(`${props.theme.shadowWidths.sm} + ${(getHeight$1(props) - height) / 2}`);
   const minWidth = `${props.theme.space.base * 8}px`;
   return Ne(["min-width:", ";height:", "px;line-height:", ";font-size:", ";&&{margin-top:", ";margin-bottom:", ";}"], minWidth, height, lineHeight, fontSize, margin, margin);
 };
-const StyledInput = Ye.input.attrs({
-  'data-garden-id': COMPONENT_ID$c,
+const StyledInput = styled.input.attrs({
+  'data-garden-id': COMPONENT_ID$c$1,
   'data-garden-version': '8.69.1'
 }).withConfig({
   displayName: "StyledInput",
   componentId: "sc-m2m56e-0"
-})(["flex-basis:0;flex-grow:1;border:none;padding:0;font-family:inherit;:focus{outline:none;}", ";", ";&[hidden]{display:revert;", "}", ";"], sizeStyles$7, colorStyles$7, hideVisually(), props => retrieveComponentStyles(COMPONENT_ID$c, props));
+})(["flex-basis:0;flex-grow:1;border:none;padding:0;font-family:inherit;:focus{outline:none;}", ";", ";&[hidden]{display:revert;", "}", ";"], sizeStyles$7, colorStyles$7$1, hideVisually(), props => retrieveComponentStyles(COMPONENT_ID$c$1, props));
 StyledInput.defaultProps = {
   theme: DEFAULT_THEME
 };
 
-const COMPONENT_ID$b = 'dropdowns.combobox.input_group';
+const COMPONENT_ID$b$1 = 'dropdowns.combobox.input_group';
 const sizeStyles$6 = props => {
   const margin = props.theme.shadowWidths.sm;
   return Ne(["margin:-", ";min-width:0;& > *{margin:", ";}"], margin, margin);
 };
-const StyledInputGroup = Ye.div.attrs({
-  'data-garden-id': COMPONENT_ID$b,
+const StyledInputGroup = styled.div.attrs({
+  'data-garden-id': COMPONENT_ID$b$1,
   'data-garden-version': '8.69.1'
 }).withConfig({
   displayName: "StyledInputGroup",
   componentId: "sc-2agt8f-0"
-})(["display:flex;flex-grow:1;flex-wrap:wrap;", ";", ";"], sizeStyles$6, props => retrieveComponentStyles(COMPONENT_ID$b, props));
+})(["display:flex;flex-grow:1;flex-wrap:wrap;", ";", ";"], sizeStyles$6, props => retrieveComponentStyles(COMPONENT_ID$b$1, props));
 StyledInputGroup.defaultProps = {
   theme: DEFAULT_THEME
 };
 
-const COMPONENT_ID$a = 'dropdowns.combobox.trigger';
-const colorStyles$6 = props => {
+const COMPONENT_ID$a$1 = 'dropdowns.combobox.trigger';
+const colorStyles$6$1 = props => {
   const SHADE = 600;
   let hue = 'neutralHue';
   if (props.validation === 'success') {
@@ -17699,7 +17699,7 @@ const colorStyles$6 = props => {
   }), disabledBorderColor, disabledBackgroundColor, disabledForegroundColor);
 };
 const sizeStyles$5 = props => {
-  const inputHeight = getHeight(props);
+  const inputHeight = getHeight$1(props);
   let minHeight;
   let horizontalPadding;
   if (props.isBare) {
@@ -17718,27 +17718,27 @@ const sizeStyles$5 = props => {
   const verticalPadding = math(`(${minHeight} - ${inputHeight} - (${props.isBare ? 0 : props.theme.borderWidths.sm} * 2)) / 2`);
   return Ne(["padding:", " ", ";min-height:", ";max-height:", ";font-size:", ";"], verticalPadding, horizontalPadding, minHeight, maxHeight, props.theme.fontSizes.md);
 };
-const StyledTrigger = Ye.div.attrs({
-  'data-garden-id': COMPONENT_ID$a,
+const StyledTrigger = styled.div.attrs({
+  'data-garden-id': COMPONENT_ID$a$1,
   'data-garden-version': '8.69.1'
 }).withConfig({
   displayName: "StyledTrigger",
   componentId: "sc-14t9k4c-0"
-})(["overflow-y:auto;transition:border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;border:", ";border-radius:", ";cursor:", ";box-sizing:border-box;", ";&:focus{outline:none;}", ";&[aria-disabled='true']{cursor:default;}", ";"], props => props.isBare ? 'none' : props.theme.borders.sm, props => props.isBare ? '0' : props.theme.borderRadii.md, props => !props.isAutocomplete && props.isEditable ? 'text' : 'pointer', sizeStyles$5, colorStyles$6, props => retrieveComponentStyles(COMPONENT_ID$a, props));
+})(["overflow-y:auto;transition:border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out;border:", ";border-radius:", ";cursor:", ";box-sizing:border-box;", ";&:focus{outline:none;}", ";&[aria-disabled='true']{cursor:default;}", ";"], props => props.isBare ? 'none' : props.theme.borders.sm, props => props.isBare ? '0' : props.theme.borderRadii.md, props => !props.isAutocomplete && props.isEditable ? 'text' : 'pointer', sizeStyles$5, colorStyles$6$1, props => retrieveComponentStyles(COMPONENT_ID$a$1, props));
 StyledTrigger.defaultProps = {
   theme: DEFAULT_THEME
 };
 
-const COMPONENT_ID$9 = 'dropdowns.combobox.input_icon';
-const colorStyles$5 = props => {
+const COMPONENT_ID$9$1 = 'dropdowns.combobox.input_icon';
+const colorStyles$5$1 = props => {
   const color = getColor('neutralHue', 600, props.theme);
   const focusColor = getColor('neutralHue', 700, props.theme);
   const disabledColor = getColor('neutralHue', 400, props.theme);
   return Ne(["color:", ";", ":hover &,", ":focus-within &,", ":focus &,", "[data-garden-focus-visible='true'] &{color:", ";}", "[aria-disabled='true'] &{color:", ";}"], props.isLabelHovered ? focusColor : color, StyledTrigger, StyledTrigger, StyledTrigger, StyledTrigger, focusColor, StyledTrigger, disabledColor);
 };
-const sizeStyles$4 = props => {
+const sizeStyles$4$1 = props => {
   const size = props.theme.iconSizes.md;
-  const position = math(`(${getHeight(props)} - ${size}) / 2`);
+  const position = math(`(${getHeight$1(props)} - ${size}) / 2`);
   const margin = `${props.theme.space.base * 2}px`;
   let side;
   if (props.isEnd) {
@@ -17748,7 +17748,7 @@ const sizeStyles$4 = props => {
   }
   return Ne(["top:", ";margin-", ":", ";width:", ";height:", ";"], position, side, margin, size, size);
 };
-const StyledInputIcon = Ye(_ref => {
+const StyledInputIcon = styled(_ref => {
   let {
     children,
     isCompact,
@@ -17761,48 +17761,48 @@ const StyledInputIcon = Ye(_ref => {
   } = _ref;
   return reactExports.cloneElement(reactExports.Children.only(children), props);
 }).attrs({
-  'data-garden-id': COMPONENT_ID$9,
+  'data-garden-id': COMPONENT_ID$9$1,
   'data-garden-version': '8.69.1'
 }).withConfig({
   displayName: "StyledInputIcon",
   componentId: "sc-15ewmjl-0"
-})(["position:sticky;flex-shrink:0;transform:", ";transition:transform 0.25s ease-in-out,color 0.25s ease-in-out;", ";", ";", ";"], props => props.isRotated && `rotate(${props.theme.rtl ? '-' : '+'}180deg)`, sizeStyles$4, colorStyles$5, props => retrieveComponentStyles(COMPONENT_ID$9, props));
+})(["position:sticky;flex-shrink:0;transform:", ";transition:transform 0.25s ease-in-out,color 0.25s ease-in-out;", ";", ";", ";"], props => props.isRotated && `rotate(${props.theme.rtl ? '-' : '+'}180deg)`, sizeStyles$4$1, colorStyles$5$1, props => retrieveComponentStyles(COMPONENT_ID$9$1, props));
 StyledInputIcon.defaultProps = {
   theme: DEFAULT_THEME
 };
 
-const COMPONENT_ID$8 = 'dropdowns.combobox.optgroup';
-const StyledOptGroup = Ye.ul.attrs({
-  'data-garden-id': COMPONENT_ID$8,
+const COMPONENT_ID$8$1 = 'dropdowns.combobox.optgroup';
+const StyledOptGroup = styled.ul.attrs({
+  'data-garden-id': COMPONENT_ID$8$1,
   'data-garden-version': '8.69.1'
 }).withConfig({
   displayName: "StyledOptGroup",
   componentId: "sc-12dbq5s-0"
-})(["margin:0;padding:0;list-style-type:none;", ";"], props => retrieveComponentStyles(COMPONENT_ID$8, props));
+})(["margin:0;padding:0;list-style-type:none;", ";"], props => retrieveComponentStyles(COMPONENT_ID$8$1, props));
 StyledOptGroup.defaultProps = {
   theme: DEFAULT_THEME
 };
 
-const COMPONENT_ID$7 = 'dropdowns.combobox.option.content';
-const StyledOptionContent = Ye.div.attrs({
-  'data-garden-id': COMPONENT_ID$7,
+const COMPONENT_ID$7$1 = 'dropdowns.combobox.option.content';
+const StyledOptionContent = styled.div.attrs({
+  'data-garden-id': COMPONENT_ID$7$1,
   'data-garden-version': '8.69.1'
 }).withConfig({
   displayName: "StyledOptionContent",
   componentId: "sc-536085-0"
-})(["display:flex;flex-direction:column;flex-grow:1;", ";"], props => retrieveComponentStyles(COMPONENT_ID$7, props));
+})(["display:flex;flex-direction:column;flex-grow:1;", ";"], props => retrieveComponentStyles(COMPONENT_ID$7$1, props));
 StyledOptionContent.defaultProps = {
   theme: DEFAULT_THEME
 };
 
-const COMPONENT_ID$6 = 'dropdowns.combobox.option.icon';
-const sizeStyles$3 = props => {
+const COMPONENT_ID$6$1 = 'dropdowns.combobox.option.icon';
+const sizeStyles$3$1 = props => {
   const size = props.theme.iconSizes.md;
   const marginTop = math(`(${props.theme.lineHeights.md} - ${size}) / 2`);
   const marginHorizontal = `${props.theme.space.base * 2}px`;
   return Ne(["margin-top:", ";margin-", ":", ";width:", ";height:", ";"], marginTop, props.theme.rtl ? 'left' : 'right', marginHorizontal, size, size);
 };
-const StyledOptionIcon = Ye(_ref => {
+const StyledOptionIcon = styled(_ref => {
   let {
     children,
     theme,
@@ -17810,39 +17810,39 @@ const StyledOptionIcon = Ye(_ref => {
   } = _ref;
   return reactExports.cloneElement(reactExports.Children.only(children), props);
 }).attrs({
-  'data-garden-id': COMPONENT_ID$6,
+  'data-garden-id': COMPONENT_ID$6$1,
   'data-garden-version': '8.69.1'
 }).withConfig({
   displayName: "StyledOptionIcon",
   componentId: "sc-3vecfi-0"
-})(["flex-shrink:0;", ";", ";"], sizeStyles$3, props => retrieveComponentStyles(COMPONENT_ID$6, props));
+})(["flex-shrink:0;", ";", ";"], sizeStyles$3$1, props => retrieveComponentStyles(COMPONENT_ID$6$1, props));
 StyledOptionIcon.defaultProps = {
   theme: DEFAULT_THEME
 };
 
-const COMPONENT_ID$5 = 'dropdowns.combobox.option.meta';
-const colorStyles$4 = props => {
+const COMPONENT_ID$5$2 = 'dropdowns.combobox.option.meta';
+const colorStyles$4$1 = props => {
   const color = getColor('neutralHue', props.isDisabled ? 400 : 600, props.theme);
   return Ne(["color:", ";"], color);
 };
-const sizeStyles$2 = props => {
+const sizeStyles$2$1 = props => {
   const lineHeight = props.theme.lineHeights.sm;
   const fontSize = props.theme.fontSizes.sm;
   return Ne(["line-height:", ";font-size:", ";"], lineHeight, fontSize);
 };
-const StyledOptionMeta = Ye.div.attrs({
-  'data-garden-id': COMPONENT_ID$5,
+const StyledOptionMeta = styled.div.attrs({
+  'data-garden-id': COMPONENT_ID$5$2,
   'data-garden-version': '8.69.1'
 }).withConfig({
   displayName: "StyledOptionMeta",
   componentId: "sc-1nizjb3-0"
-})(["transition:color 0.25s ease-in-out;font-weight:", ";", ";", ";", ";"], props => props.theme.fontWeights.regular, sizeStyles$2, colorStyles$4, props => retrieveComponentStyles(COMPONENT_ID$5, props));
+})(["transition:color 0.25s ease-in-out;font-weight:", ";", ";", ";", ";"], props => props.theme.fontWeights.regular, sizeStyles$2$1, colorStyles$4$1, props => retrieveComponentStyles(COMPONENT_ID$5$2, props));
 StyledOptionMeta.defaultProps = {
   theme: DEFAULT_THEME
 };
 
-const COMPONENT_ID$4 = 'dropdowns.combobox.option.type_icon';
-const colorStyles$3 = props => {
+const COMPONENT_ID$4$2 = 'dropdowns.combobox.option.type_icon';
+const colorStyles$3$1 = props => {
   const opacity = props.type && props.type !== 'danger' ? 1 : 0;
   let color;
   if (props.type === 'add' || props.type === 'danger') {
@@ -17854,7 +17854,7 @@ const colorStyles$3 = props => {
   }
   return Ne(["opacity:", ";color:", ";", "[aria-selected='true'] > &{opacity:1;}", "[aria-disabled='true'] > &{color:inherit;}"], opacity, color, StyledOption, StyledOption);
 };
-const sizeStyles$1 = props => {
+const sizeStyles$1$2 = props => {
   const size = props.theme.iconSizes.md;
   const position = `${props.theme.space.base * 3}px`;
   const top = math(`(${getMinHeight(props)} - ${size}) / 2`);
@@ -17866,7 +17866,7 @@ const sizeStyles$1 = props => {
   }
   return Ne(["top:", ";", ":", ";width:", ";height:", ";"], top, side, position, size, size);
 };
-const StyledOptionTypeIcon = Ye(_ref => {
+const StyledOptionTypeIcon = styled(_ref => {
   let {
     children,
     isCompact,
@@ -17876,56 +17876,56 @@ const StyledOptionTypeIcon = Ye(_ref => {
   } = _ref;
   return reactExports.cloneElement(reactExports.Children.only(children), props);
 }).attrs({
-  'data-garden-id': COMPONENT_ID$4,
+  'data-garden-id': COMPONENT_ID$4$2,
   'data-garden-version': '8.69.1'
 }).withConfig({
   displayName: "StyledOptionTypeIcon",
   componentId: "sc-vlhimu-0"
-})(["position:absolute;transform:", ";transition:opacity 0.1s ease-in-out;", ";", ";", ";"], props => props.theme.rtl && (props.type === 'next' || props.type === 'previous') && 'rotate(180deg)', sizeStyles$1, colorStyles$3, props => retrieveComponentStyles(COMPONENT_ID$4, props));
+})(["position:absolute;transform:", ";transition:opacity 0.1s ease-in-out;", ";", ";", ";"], props => props.theme.rtl && (props.type === 'next' || props.type === 'previous') && 'rotate(180deg)', sizeStyles$1$2, colorStyles$3$1, props => retrieveComponentStyles(COMPONENT_ID$4$2, props));
 StyledOptionTypeIcon.defaultProps = {
   theme: DEFAULT_THEME
 };
 
-const COMPONENT_ID$3 = 'dropdowns.combobox.separator';
-const colorStyles$2 = props => {
+const COMPONENT_ID$3$2 = 'dropdowns.combobox.separator';
+const colorStyles$2$1 = props => {
   const backgroundColor = getColor('neutralHue', 200, props.theme);
   return Ne(["background-color:", ";"], backgroundColor);
 };
-const sizeStyles = props => {
+const sizeStyles$b = props => {
   const margin = `${props.theme.space.base}px`;
   const height = props.theme.borderWidths.sm;
   return Ne(["margin:", " 0;height:", ";"], margin, height);
 };
-const StyledSeparator = Ye.li.attrs({
-  'data-garden-id': COMPONENT_ID$3,
+const StyledSeparator = styled.li.attrs({
+  'data-garden-id': COMPONENT_ID$3$2,
   'data-garden-version': '8.69.1'
 }).withConfig({
   displayName: "StyledSeparator",
   componentId: "sc-1uj1t6p-0"
-})(["cursor:default;", ";", ";", ";"], sizeStyles, colorStyles$2, props => retrieveComponentStyles(COMPONENT_ID$3, props));
+})(["cursor:default;", ";", ";", ";"], sizeStyles$b, colorStyles$2$1, props => retrieveComponentStyles(COMPONENT_ID$3$2, props));
 StyledSeparator.defaultProps = {
   theme: DEFAULT_THEME
 };
 
-const COMPONENT_ID$2 = 'dropdowns.combobox.tag';
-const StyledTag = Ye(Tag$1).attrs({
-  'data-garden-id': COMPONENT_ID$2,
+const COMPONENT_ID$2$2 = 'dropdowns.combobox.tag';
+const StyledTag = styled(Tag$1).attrs({
+  'data-garden-id': COMPONENT_ID$2$2,
   'data-garden-version': '8.69.1'
 }).withConfig({
   displayName: "StyledTag",
   componentId: "sc-1mrab0f-0"
-})(["&[aria-disabled='true']{color:", ";}&[hidden]{display:revert;", "}", ";"], props => props.hue ? undefined : getColor('neutralHue', 400, props.theme), hideVisually(), props => retrieveComponentStyles(COMPONENT_ID$2, props));
+})(["&[aria-disabled='true']{color:", ";}&[hidden]{display:revert;", "}", ";"], props => props.hue ? undefined : getColor('neutralHue', 400, props.theme), hideVisually(), props => retrieveComponentStyles(COMPONENT_ID$2$2, props));
 StyledTag.defaultProps = {
   theme: DEFAULT_THEME
 };
 
-const COMPONENT_ID$1 = 'dropdowns.combobox.value';
-const colorStyles$1 = props => {
+const COMPONENT_ID$1$2 = 'dropdowns.combobox.value';
+const colorStyles$1$1 = props => {
   const foregroundColor = props.isPlaceholder && getColor('neutralHue', 400, props.theme);
   return Ne(["color:", ";"], foregroundColor);
 };
-const StyledValue = Ye.div.attrs({
-  'data-garden-id': COMPONENT_ID$1,
+const StyledValue = styled.div.attrs({
+  'data-garden-id': COMPONENT_ID$1$2,
   'data-garden-version': '8.69.1'
 }).withConfig({
   displayName: "StyledValue",
@@ -17935,24 +17935,24 @@ const StyledValue = Ye.div.attrs({
     return 'default';
   }
   return props.isEditable ? 'text' : 'pointer';
-}, sizeStyles$7, colorStyles$1, props => retrieveComponentStyles(COMPONENT_ID$1, props));
+}, sizeStyles$7, colorStyles$1$1, props => retrieveComponentStyles(COMPONENT_ID$1$2, props));
 StyledValue.defaultProps = {
   theme: DEFAULT_THEME
 };
 
-const COMPONENT_ID = 'dropdowns.combobox.tags_button';
-const colorStyles = props => {
+const COMPONENT_ID$m = 'dropdowns.combobox.tags_button';
+const colorStyles$9 = props => {
   const color = getColor('primaryHue', 600, props.theme);
   return Ne(["color:", ";&:disabled{color:inherit;}"], color);
 };
-const StyledTagsButton = Ye(StyledValue).attrs({
+const StyledTagsButton = styled(StyledValue).attrs({
   as: 'button',
-  'data-garden-id': COMPONENT_ID,
+  'data-garden-id': COMPONENT_ID$m,
   'data-garden-version': '8.69.1'
 }).withConfig({
   displayName: "StyledTagsButton",
   componentId: "sc-ewyffo-0"
-})(["flex:0 1 auto;transition:color 0.25s ease-in-out 0;border:none;background-color:transparent;cursor:pointer;min-width:auto;font-family:inherit;&:hover{text-decoration:underline;}", ";&:disabled{cursor:default;text-decoration:none;}", ";"], colorStyles, props => retrieveComponentStyles(COMPONENT_ID, props));
+})(["flex:0 1 auto;transition:color 0.25s ease-in-out 0;border:none;background-color:transparent;cursor:pointer;min-width:auto;font-family:inherit;&:hover{text-decoration:underline;}", ";&:disabled{cursor:default;text-decoration:none;}", ";"], colorStyles$9, props => retrieveComponentStyles(COMPONENT_ID$m, props));
 StyledTagsButton.defaultProps = {
   theme: DEFAULT_THEME
 };
@@ -18040,7 +18040,7 @@ const Listbox = reactExports.forwardRef((_ref, ref) => {
     },
     zIndex: zIndex,
     ref: floatingRef
-  }, React__default.createElement(StyledListbox, _extends$5({
+  }, React__default.createElement(StyledListbox, _extends$5$1({
     isCompact: isCompact,
     maxHeight: maxHeight,
     minHeight: minHeight,
@@ -18116,7 +18116,7 @@ const TagComponent = reactExports.forwardRef((_ref, ref) => {
   const theme = reactExports.useContext(Be) || DEFAULT_THEME;
   const doc = useDocument(theme);
   const handleClick = () => removeSelection(option.value);
-  return React__default.createElement(StyledTag, _extends$5({
+  return React__default.createElement(StyledTag, _extends$5$1({
     "aria-disabled": option.disabled,
     tabIndex: option.disabled ? undefined : 0
   }, tagProps, props, {
@@ -18306,7 +18306,7 @@ const Combobox = reactExports.forwardRef((_ref, ref) => {
       const key = toString(option);
       const disabled = isDisabled || option.disabled;
       const hidden = !isFocused && index >= maxTags;
-      return React__default.createElement(Tag, _extends$5({
+      return React__default.createElement(Tag, _extends$5$1({
         key: key,
         hidden: hidden,
         onFocus: () => setIsFocused(true),
@@ -18327,7 +18327,7 @@ const Combobox = reactExports.forwardRef((_ref, ref) => {
   };
   return React__default.createElement(ComboboxContext.Provider, {
     value: contextValue
-  }, React__default.createElement(StyledCombobox, _extends$5({
+  }, React__default.createElement(StyledCombobox, _extends$5$1({
     isCompact: isCompact
   }, props, {
     ref: ref
@@ -18357,7 +18357,7 @@ const Combobox = reactExports.forwardRef((_ref, ref) => {
     isEnd: true,
     isLabelHovered: isLabelHovered,
     isRotated: hasChevron && isExpanded
-  }, hasChevron ? React__default.createElement(SvgChevronDownStroke, null) : endIcon))), React__default.createElement(Listbox, _extends$5({
+  }, hasChevron ? React__default.createElement(SvgChevronDownStroke$1, null) : endIcon))), React__default.createElement(Listbox, _extends$5$1({
     appendToNode: listboxAppendToNode,
     isCompact: isCompact,
     isExpanded: isExpanded,
@@ -18420,7 +18420,7 @@ const Field = reactExports.forwardRef((props, ref) => {
   }), [labelProps, setLabelProps, hasHint, setHasHint, hasMessage, setHasMessage]);
   return React__default.createElement(FieldContext.Provider, {
     value: contextValue
-  }, React__default.createElement(StyledField, _extends$5({}, props, {
+  }, React__default.createElement(StyledField, _extends$5$1({}, props, {
     ref: ref
   })));
 });
@@ -18434,7 +18434,7 @@ const Hint = reactExports.forwardRef((props, ref) => {
     setHasHint(true);
     return () => setHasHint(false);
   }, [setHasHint]);
-  return React__default.createElement(StyledHint, _extends$5({}, props, {
+  return React__default.createElement(StyledHint, _extends$5$1({}, props, {
     ref: ref
   }));
 });
@@ -18450,10 +18450,10 @@ const Label = reactExports.forwardRef((_ref, ref) => {
   const {
     labelProps
   } = useFieldContext();
-  return React__default.createElement(StyledLabel, _extends$5({}, labelProps, {
-    onClick: composeEventHandlers$1(onClick, labelProps?.onClick),
-    onMouseEnter: composeEventHandlers$1(onMouseEnter, labelProps?.onMouseEnter),
-    onMouseLeave: composeEventHandlers$1(onMouseLeave, labelProps?.onMouseLeave)
+  return React__default.createElement(StyledLabel, _extends$5$1({}, labelProps, {
+    onClick: composeEventHandlers$2(onClick, labelProps?.onClick),
+    onMouseEnter: composeEventHandlers$2(onMouseEnter, labelProps?.onMouseEnter),
+    onMouseLeave: composeEventHandlers$2(onMouseLeave, labelProps?.onMouseLeave)
   }, props, {
     ref: ref
   }));
@@ -18472,7 +18472,7 @@ const Message = reactExports.forwardRef((props, ref) => {
     setHasMessage(true);
     return () => setHasMessage(false);
   }, [setHasMessage]);
-  return React__default.createElement(StyledMessage, _extends$5({}, props, {
+  return React__default.createElement(StyledMessage, _extends$5$1({}, props, {
     ref: ref
   }));
 });
@@ -18482,66 +18482,66 @@ Message.propTypes = {
   validationLabel: PropTypes.string
 };
 
-var _path$3;
-function _extends$3() { _extends$3 = Object.assign ? Object.assign.bind() : function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends$3.apply(this, arguments); }
+var _path$3$1;
+function _extends$3$1() { _extends$3$1 = Object.assign ? Object.assign.bind() : function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends$3$1.apply(this, arguments); }
 var SvgPlusStroke = function SvgPlusStroke(props) {
-  return /*#__PURE__*/reactExports.createElement("svg", _extends$3({
+  return /*#__PURE__*/reactExports.createElement("svg", _extends$3$1({
     xmlns: "http://www.w3.org/2000/svg",
     width: 16,
     height: 16,
     focusable: "false",
     viewBox: "0 0 16 16",
     "aria-hidden": "true"
-  }, props), _path$3 || (_path$3 = /*#__PURE__*/reactExports.createElement("path", {
+  }, props), _path$3$1 || (_path$3$1 = /*#__PURE__*/reactExports.createElement("path", {
     stroke: "currentColor",
     strokeLinecap: "round",
     d: "M7.5 2.5v12m6-6h-12"
   })));
 };
 
-var _path$2;
-function _extends$2() { _extends$2 = Object.assign ? Object.assign.bind() : function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends$2.apply(this, arguments); }
+var _path$2$1;
+function _extends$2$2() { _extends$2$2 = Object.assign ? Object.assign.bind() : function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends$2$2.apply(this, arguments); }
 var SvgChevronRightStroke = function SvgChevronRightStroke(props) {
-  return /*#__PURE__*/reactExports.createElement("svg", _extends$2({
+  return /*#__PURE__*/reactExports.createElement("svg", _extends$2$2({
     xmlns: "http://www.w3.org/2000/svg",
     width: 16,
     height: 16,
     focusable: "false",
     viewBox: "0 0 16 16",
     "aria-hidden": "true"
-  }, props), _path$2 || (_path$2 = /*#__PURE__*/reactExports.createElement("path", {
+  }, props), _path$2$1 || (_path$2$1 = /*#__PURE__*/reactExports.createElement("path", {
     fill: "currentColor",
     d: "M5.61 3.312a.5.5 0 01.718-.69l.062.066 4 5a.5.5 0 01.054.542l-.054.082-4 5a.5.5 0 01-.83-.55l.05-.074L9.359 8l-3.75-4.688z"
   })));
 };
 
-var _path$1;
-function _extends$1() { _extends$1 = Object.assign ? Object.assign.bind() : function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends$1.apply(this, arguments); }
+var _path$1$2;
+function _extends$1$2() { _extends$1$2 = Object.assign ? Object.assign.bind() : function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends$1$2.apply(this, arguments); }
 var SvgChevronLeftStroke = function SvgChevronLeftStroke(props) {
-  return /*#__PURE__*/reactExports.createElement("svg", _extends$1({
+  return /*#__PURE__*/reactExports.createElement("svg", _extends$1$2({
     xmlns: "http://www.w3.org/2000/svg",
     width: 16,
     height: 16,
     focusable: "false",
     viewBox: "0 0 16 16",
     "aria-hidden": "true"
-  }, props), _path$1 || (_path$1 = /*#__PURE__*/reactExports.createElement("path", {
+  }, props), _path$1$2 || (_path$1$2 = /*#__PURE__*/reactExports.createElement("path", {
     fill: "currentColor",
     d: "M10.39 12.688a.5.5 0 01-.718.69l-.062-.066-4-5a.5.5 0 01-.054-.542l.054-.082 4-5a.5.5 0 01.83.55l-.05.074L6.641 8l3.75 4.688z"
   })));
 };
 
-var _path;
-function _extends() { _extends = Object.assign ? Object.assign.bind() : function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends.apply(this, arguments); }
+var _path$5;
+function _extends$8() { _extends$8 = Object.assign ? Object.assign.bind() : function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends$8.apply(this, arguments); }
 var SvgCheckLgStroke = function SvgCheckLgStroke(props) {
-  return /*#__PURE__*/reactExports.createElement("svg", _extends({
+  return /*#__PURE__*/reactExports.createElement("svg", _extends$8({
     xmlns: "http://www.w3.org/2000/svg",
     width: 16,
     height: 16,
     focusable: "false",
     viewBox: "0 0 16 16",
     "aria-hidden": "true"
-  }, props), _path || (_path = /*#__PURE__*/reactExports.createElement("path", {
+  }, props), _path$5 || (_path$5 = /*#__PURE__*/reactExports.createElement("path", {
     fill: "none",
     stroke: "currentColor",
     strokeLinecap: "round",
@@ -18565,7 +18565,7 @@ const OptionMetaComponent = reactExports.forwardRef((props, ref) => {
   const {
     isDisabled
   } = useOptionContext();
-  return React__default.createElement(StyledOptionMeta, _extends$5({
+  return React__default.createElement(StyledOptionMeta, _extends$5$1({
     isDisabled: isDisabled
   }, props, {
     ref: ref
@@ -18630,7 +18630,7 @@ const OptionComponent = reactExports.forwardRef((_ref, ref) => {
   });
   return React__default.createElement(OptionContext.Provider, {
     value: contextValue
-  }, React__default.createElement(StyledOption, _extends$5({
+  }, React__default.createElement(StyledOption, _extends$5$1({
     isActive: isActive,
     isCompact: isCompact,
     $type: type
@@ -18675,10 +18675,10 @@ const OptGroup = reactExports.forwardRef((_ref, ref) => {
   const optGroupProps = getOptGroupProps({
     'aria-label': groupAriaLabel || label
   });
-  return React__default.createElement(StyledOption, _extends$5({
+  return React__default.createElement(StyledOption, _extends$5$1({
     isCompact: isCompact,
     $type: "group",
-    onMouseDown: composeEventHandlers$1(onMouseDown, handleMouseDown),
+    onMouseDown: composeEventHandlers$2(onMouseDown, handleMouseDown),
     role: "none"
   }, props, {
     ref: ref
@@ -18689,7 +18689,7 @@ const OptGroup = reactExports.forwardRef((_ref, ref) => {
   }, icon && React__default.createElement(StyledOptionTypeIcon, {
     isCompact: isCompact,
     type: "header"
-  }, icon), content || label), React__default.createElement(StyledOptGroup, _extends$5({
+  }, icon), content || label), React__default.createElement(StyledOptGroup, _extends$5$1({
     isCompact: isCompact
   }, optGroupProps), React__default.createElement(StyledSeparator, {
     role: "none"
@@ -18702,4 +18702,1705 @@ OptGroup.propTypes = {
   label: PropTypes.string
 };
 
-export { Combobox as C, DEFAULT_THEME as D, Field$1 as F, Hint$1 as H, Input as I, Label$1 as L, Message$1 as M, Option as O, Textarea as T, Field as a, Label as b, Hint as c, Message as d, ThemeProvider as e, jsxRuntimeExports as j, reactDomExports as r };
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+function composeEventHandlers() {
+  for (var _len = arguments.length, fns = new Array(_len), _key = 0; _key < _len; _key++) {
+    fns[_key] = arguments[_key];
+  }
+  return function (event) {
+    for (var _len2 = arguments.length, args = new Array(_len2 > 1 ? _len2 - 1 : 0), _key2 = 1; _key2 < _len2; _key2++) {
+      args[_key2 - 1] = arguments[_key2];
+    }
+    return fns.some(fn => {
+      fn && fn(event, ...args);
+      return event && event.defaultPrevented;
+    });
+  };
+}
+
+function getControlledValue() {
+  for (var _len = arguments.length, values = new Array(_len), _key = 0; _key < _len; _key++) {
+    values[_key] = arguments[_key];
+  }
+  for (const value of values) {
+    if (value !== undefined) {
+      return value;
+    }
+  }
+  return undefined;
+}
+const KEYS = {
+  ALT: 'Alt',
+  ASTERISK: '*',
+  BACKSPACE: 'Backspace',
+  COMMA: ',',
+  DELETE: 'Delete',
+  DOWN: 'ArrowDown',
+  END: 'End',
+  ENTER: 'Enter',
+  ESCAPE: 'Escape',
+  HOME: 'Home',
+  LEFT: 'ArrowLeft',
+  NUMPAD_ADD: 'Add',
+  NUMPAD_DECIMAL: 'Decimal',
+  NUMPAD_DIVIDE: 'Divide',
+  NUMPAD_ENTER: 'Enter',
+  NUMPAD_MULTIPLY: 'Multiply',
+  NUMPAD_SUBTRACT: 'Subtract',
+  PAGE_DOWN: 'PageDown',
+  PAGE_UP: 'PageUp',
+  PERIOD: '.',
+  RIGHT: 'ArrowRight',
+  SHIFT: 'Shift',
+  SPACE: ' ',
+  TAB: 'Tab',
+  UNIDENTIFIED: 'Unidentified',
+  UP: 'ArrowUp'
+};
+
+var DocumentPosition;
+(function (DocumentPosition) {
+  DocumentPosition[DocumentPosition["DISCONNECTED"] = 1] = "DISCONNECTED";
+  DocumentPosition[DocumentPosition["PRECEDING"] = 2] = "PRECEDING";
+  DocumentPosition[DocumentPosition["FOLLOWING"] = 4] = "FOLLOWING";
+  DocumentPosition[DocumentPosition["CONTAINS"] = 8] = "CONTAINS";
+  DocumentPosition[DocumentPosition["CONTAINED_BY"] = 16] = "CONTAINED_BY";
+  DocumentPosition[DocumentPosition["IMPLEMENTATION_SPECIFIC"] = 32] = "IMPLEMENTATION_SPECIFIC";
+})(DocumentPosition || (DocumentPosition = {}));
+
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+const stateReducer = (state, action) => {
+  switch (action.type) {
+    case 'END':
+    case 'HOME':
+    case 'FOCUS':
+    case 'INCREMENT':
+    case 'DECREMENT':
+      {
+        return {
+          ...state,
+          focusedValue: action.payload
+        };
+      }
+    case 'MOUSE_SELECT':
+      {
+        return {
+          ...state,
+          selectedValue: action.payload,
+          focusedValue: undefined
+        };
+      }
+    case 'KEYBOARD_SELECT':
+      {
+        return {
+          ...state,
+          selectedValue: action.payload
+        };
+      }
+    case 'EXIT_WIDGET':
+      {
+        return {
+          ...state,
+          focusedValue: undefined
+        };
+      }
+    default:
+      return state;
+  }
+};
+
+const useSelection = _ref => {
+  let {
+    values,
+    direction = 'horizontal',
+    defaultFocusedValue = values[0],
+    defaultSelectedValue,
+    rtl,
+    selectedValue,
+    focusedValue,
+    onSelect,
+    onFocus
+  } = _ref;
+  const isSelectedValueControlled = selectedValue !== undefined;
+  const isFocusedValueControlled = focusedValue !== undefined;
+  const refs = reactExports.useMemo(() => values.reduce((all, value) => {
+    all[value] = reactExports.createRef();
+    return all;
+  }, {}), [values]);
+  const [state, dispatch] = reactExports.useReducer(stateReducer, {
+    selectedValue,
+    focusedValue
+  });
+  const controlledFocusedValue = getControlledValue(focusedValue, state.focusedValue);
+  const controlledSelectedValue = getControlledValue(selectedValue, state.selectedValue);
+  reactExports.useEffect(() => {
+    if (controlledFocusedValue !== undefined) {
+      const targetRef = refs[controlledFocusedValue];
+      targetRef?.current && targetRef.current.focus();
+    }
+  }, [controlledFocusedValue]);
+  reactExports.useEffect(() => {
+    if (selectedValue === undefined && defaultSelectedValue !== undefined) {
+      onSelect && onSelect(defaultSelectedValue);
+      if (!isSelectedValueControlled) {
+        dispatch({
+          type: 'KEYBOARD_SELECT',
+          payload: defaultSelectedValue
+        });
+      }
+    }
+  }, []);
+  const getGroupProps = reactExports.useCallback(function (_temp) {
+    let {
+      role = 'group',
+      ...other
+    } = _temp === void 0 ? {} : _temp;
+    return {
+      role: role === null ? undefined : role,
+      'data-garden-container-id': 'containers.selection',
+      'data-garden-container-version': '3.0.2',
+      ...other
+    };
+  }, []);
+  const getElementProps = _ref2 => {
+    let {
+      selectedAriaKey = 'aria-selected',
+      onFocus: onFocusCallback,
+      onKeyDown,
+      onClick,
+      value,
+      ...other
+    } = _ref2;
+    const isSelected = controlledSelectedValue === value;
+    const isFocused = controlledFocusedValue === undefined ? isSelected : controlledFocusedValue === value;
+    const tabIndex = isFocused || controlledSelectedValue === undefined && controlledFocusedValue === undefined && value === defaultFocusedValue ? 0 : -1;
+    const verticalDirection = direction === 'vertical' || direction === 'both';
+    const horizontalDirection = direction === 'horizontal' || direction === 'both';
+    const handleFocus = () => {
+      onFocus && onFocus(value);
+      !isFocusedValueControlled && dispatch({
+        type: 'FOCUS',
+        payload: value
+      });
+    };
+    const handleClick = () => {
+      onSelect && onSelect(value);
+      onFocus && onFocus(value);
+      !isSelectedValueControlled && dispatch({
+        type: 'MOUSE_SELECT',
+        payload: value
+      });
+    };
+    const handleKeyDown = event => {
+      let nextItem;
+      let currentItem;
+      if (isFocusedValueControlled) {
+        currentItem = values.find(id => focusedValue === id);
+      } else {
+        currentItem = values.find(id => state.focusedValue === id);
+      }
+      const onIncrement = () => {
+        const nextItemIndex = values.indexOf(currentItem) + 1;
+        nextItem = values[nextItemIndex];
+        if (!nextItem) {
+          nextItem = values[0];
+        }
+        !isFocusedValueControlled && dispatch({
+          type: 'INCREMENT',
+          payload: nextItem
+        });
+        onFocus && onFocus(nextItem);
+      };
+      const onDecrement = () => {
+        const nextItemIndex = values.indexOf(currentItem) - 1;
+        nextItem = values[nextItemIndex];
+        if (!nextItem) {
+          nextItem = values[values.length - 1];
+        }
+        !isFocusedValueControlled && dispatch({
+          type: 'DECREMENT',
+          payload: nextItem
+        });
+        onFocus && onFocus(nextItem);
+      };
+      const hasModifierKeyPressed = event.ctrlKey || event.metaKey || event.shiftKey || event.altKey;
+      if (!hasModifierKeyPressed) {
+        if (event.key === KEYS.UP && verticalDirection || event.key === KEYS.LEFT && horizontalDirection) {
+          if (rtl && horizontalDirection) {
+            onIncrement();
+          } else {
+            onDecrement();
+          }
+          event.preventDefault();
+        } else if (event.key === KEYS.DOWN && verticalDirection || event.key === KEYS.RIGHT && horizontalDirection) {
+          if (rtl && horizontalDirection) {
+            onDecrement();
+          } else {
+            onIncrement();
+          }
+          event.preventDefault();
+        } else if (event.key === KEYS.HOME) {
+          const firstItem = values[0];
+          !isFocusedValueControlled && dispatch({
+            type: 'HOME',
+            payload: firstItem
+          });
+          onFocus && onFocus(firstItem);
+          event.preventDefault();
+        } else if (event.key === KEYS.END) {
+          const lastItem = values[values.length - 1];
+          !isFocusedValueControlled && dispatch({
+            type: 'END',
+            payload: lastItem
+          });
+          onFocus && onFocus(lastItem);
+          event.preventDefault();
+        } else if (event.key === KEYS.SPACE || event.key === KEYS.ENTER) {
+          onSelect && onSelect(value);
+          !isSelectedValueControlled && dispatch({
+            type: 'KEYBOARD_SELECT',
+            payload: value
+          });
+          event.preventDefault();
+        }
+      }
+    };
+    const onBlur = event => {
+      if (event.target.tabIndex === 0) {
+        dispatch({
+          type: 'EXIT_WIDGET'
+        });
+        onFocus && onFocus();
+      }
+    };
+    return {
+      tabIndex,
+      [selectedAriaKey]: selectedAriaKey ? isSelected : undefined,
+      ref: refs[value],
+      onFocus: composeEventHandlers(onFocusCallback, handleFocus),
+      onClick: composeEventHandlers(onClick, handleClick),
+      onKeyDown: composeEventHandlers(onKeyDown, handleKeyDown),
+      onBlur,
+      ...other
+    };
+  };
+  return {
+    focusedValue: controlledFocusedValue,
+    selectedValue: controlledSelectedValue,
+    getElementProps,
+    getGroupProps
+  };
+};
+({
+  children: PropTypes.func,
+  render: PropTypes.func,
+  values: PropTypes.arrayOf(PropTypes.any).isRequired,
+  rtl: PropTypes.bool,
+  direction: PropTypes.oneOf(['horizontal', 'vertical', 'both']),
+  defaultFocusedValue: PropTypes.string,
+  defaultSelectedValue: PropTypes.string,
+  focusedValue: PropTypes.any,
+  selectedValue: PropTypes.any,
+  onSelect: PropTypes.func,
+  onFocus: PropTypes.func
+});
+
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+function _extends$2$1() {
+  _extends$2$1 = Object.assign ? Object.assign.bind() : function (target) {
+    for (var i = 1; i < arguments.length; i++) {
+      var source = arguments[i];
+      for (var key in source) {
+        if (Object.prototype.hasOwnProperty.call(source, key)) {
+          target[key] = source[key];
+        }
+      }
+    }
+    return target;
+  };
+  return _extends$2$1.apply(this, arguments);
+}
+
+const SIZE = ['small', 'medium', 'large'];
+
+const COMPONENT_ID$5$1 = 'buttons.button_group_view';
+const StyledButtonGroup = styled.div.attrs({
+  'data-garden-id': COMPONENT_ID$5$1,
+  'data-garden-version': '8.69.5'
+}).withConfig({
+  displayName: "StyledButtonGroup",
+  componentId: "sc-1fbpzef-0"
+})(["display:inline-flex;position:relative;z-index:0;direction:", ";white-space:nowrap;", ";"], props => props.theme.rtl && 'rtl', props => retrieveComponentStyles(COMPONENT_ID$5$1, props));
+StyledButtonGroup.defaultProps = {
+  theme: DEFAULT_THEME
+};
+
+const COMPONENT_ID$4$1 = 'buttons.icon';
+const sizeStyles$1$1 = props => {
+  let marginProperty;
+  if (props.position === 'start') {
+    marginProperty = `margin-${props.theme.rtl ? 'left' : 'right'}`;
+  } else if (props.position === 'end') {
+    marginProperty = `margin-${props.theme.rtl ? 'right' : 'left'}`;
+  }
+  return marginProperty && Ne(["", ":", "px;"], marginProperty, props.theme.space.base * 2);
+};
+const StyledIcon$1 = styled(_ref => {
+  let {
+    children,
+    isRotated,
+    theme,
+    ...props
+  } = _ref;
+  return React__default.cloneElement(reactExports.Children.only(children), props);
+}).attrs({
+  'data-garden-id': COMPONENT_ID$4$1,
+  'data-garden-version': '8.69.5'
+}).withConfig({
+  displayName: "StyledIcon",
+  componentId: "sc-19meqgg-0"
+})(["transform:", ";transition:transform 0.25s ease-in-out,color 0.25s ease-in-out;", ";", ";"], props => props.isRotated && `rotate(${props.theme.rtl ? '-' : '+'}180deg)`, props => sizeStyles$1$1(props), props => retrieveComponentStyles(COMPONENT_ID$4$1, props));
+StyledIcon$1.defaultProps = {
+  theme: DEFAULT_THEME
+};
+
+const COMPONENT_ID$3$1 = 'buttons.button';
+const getBorderRadius = props => {
+  if (props.isPill) {
+    return '100px';
+  }
+  return props.theme.borderRadii.md;
+};
+const getDisabledBackgroundColor = props => {
+  return getColor('neutralHue', 200, props.theme);
+};
+const getHeight = props => {
+  if (props.size === 'small') {
+    return `${props.theme.space.base * 8}px`;
+  } else if (props.size === 'large') {
+    return `${props.theme.space.base * 12}px`;
+  }
+  return `${props.theme.space.base * 10}px`;
+};
+const colorStyles$7 = props => {
+  let retVal;
+  let hue;
+  if (props.disabled || props.isNeutral && (props.isPrimary || props.isSelected) && !props.isDanger) {
+    hue = 'neutralHue';
+  } else if (props.isDanger) {
+    hue = 'dangerHue';
+  } else {
+    hue = 'primaryHue';
+  }
+  const shade = 600;
+  const baseColor = getColor(hue, shade, props.theme);
+  const hoverColor = getColor(hue, shade + 100, props.theme);
+  const activeColor = getColor(hue, shade + 200, props.theme);
+  const focusColor = getColor('primaryHue', shade, props.theme);
+  const disabledBackgroundColor = getDisabledBackgroundColor(props);
+  const disabledForegroundColor = getColor(hue, shade - 200, props.theme);
+  if (props.isLink) {
+    retVal = Ne(["outline-color:transparent;background-color:transparent;color:", ";", " &:hover{color:", ";}&:active,&[aria-pressed='true'],&[aria-pressed='mixed']{color:", ";}&:disabled{color:", ";}"], baseColor, focusStyles({
+      theme: props.theme,
+      condition: false,
+      styles: {
+        color: baseColor,
+        outlineColor: focusColor
+      }
+    }), hoverColor, activeColor, disabledForegroundColor);
+  } else if (props.isPrimary || props.isSelected) {
+    retVal = Ne(["outline-color:transparent;background-color:", ";color:", ";&:hover{background-color:", ";}", " &:active{background-color:", ";}&[aria-pressed='true'],&[aria-pressed='mixed']{background-color:", ";}&:disabled{background-color:", ";color:", ";}"], props.isPrimary && props.isSelected ? activeColor : baseColor, props.theme.palette.white, hoverColor, focusStyles({
+      theme: props.theme,
+      inset: props.focusInset,
+      shadowWidth: props.focusInset ? 'sm' : 'md',
+      spacerWidth: props.focusInset ? 'sm' : 'xs',
+      styles: props.isDanger && props.focusInset ? {
+        borderColor: focusColor
+      } : undefined
+    }), activeColor, props.isPrimary && activeColor, disabledBackgroundColor, disabledForegroundColor);
+  } else {
+    const borderColor = props.isNeutral && !props.isDanger ? getColor('neutralHue', 300, props.theme) : baseColor;
+    const foregroundColor = props.isNeutral ? props.theme.colors.foreground : baseColor;
+    const hoverBorderColor = props.isNeutral && !props.isDanger ? baseColor : hoverColor;
+    const hoverForegroundColor = props.isNeutral ? foregroundColor : hoverColor;
+    retVal = Ne(["outline-color:transparent;border-color:", ";background-color:transparent;color:", ";&:hover{border-color:", ";background-color:", ";color:", ";}", " &:active,&[aria-pressed='true'],&[aria-pressed='mixed']{border-color:", ";background-color:", ";color:", ";}&:disabled{border-color:transparent;background-color:", ";color:", ";}& ", "{color:", ";}&:hover ", ",&:focus-visible ", ",&[data-garden-focus-visible] ", "{color:", ";}&:active ", "{color:", ";}&:disabled ", "{color:", ";}"], !props.isBasic && borderColor, foregroundColor, !props.isBasic && hoverBorderColor, rgba(baseColor, 0.08), hoverForegroundColor, focusStyles({
+      theme: props.theme,
+      inset: props.focusInset,
+      styles: props.isNeutral ? {
+        borderColor: baseColor
+      } : undefined
+    }), !props.isBasic && activeColor, rgba(baseColor, 0.2), !props.isNeutral && activeColor, disabledBackgroundColor, disabledForegroundColor, StyledIcon$1, props.isNeutral && getColor('neutralHue', shade, props.theme), StyledIcon$1, StyledIcon$1, StyledIcon$1, props.isNeutral && getColor('neutralHue', shade + 100, props.theme), StyledIcon$1, props.isNeutral && foregroundColor, StyledIcon$1, disabledForegroundColor);
+  }
+  return retVal;
+};
+const groupStyles = props => {
+  const {
+    theme,
+    isPrimary,
+    isBasic,
+    isSelected,
+    isPill,
+    focusInset
+  } = props;
+  const {
+    rtl,
+    borderWidths,
+    borders
+  } = theme;
+  const startPosition = rtl ? 'right' : 'left';
+  const endPosition = rtl ? 'left' : 'right';
+  const marginOffset = borderWidths.sm;
+  const marginDisplacement = `${isPrimary || isBasic ? '' : '-'}${marginOffset}`;
+  const iconMarginDisplacement = isPill && '-2px';
+  const disabledBackgroundColor = !isPrimary && getDisabledBackgroundColor(props);
+  const borderColor = isBasic ? 'transparent' : 'revert';
+  const focusColor = getColor('primaryHue', 600, theme);
+  const focusBoxShadow = isBasic && !isSelected && !isPrimary && getFocusBoxShadow({
+    theme,
+    inset: focusInset,
+    spacerHue: focusColor,
+    hue: 'transparent'
+  });
+  return Ne(["position:relative;transition:border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,margin-", " 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;border:", " ", ";", "{border-color:", ";box-shadow:", ";}&:hover,&:active,", "{z-index:1;}&:disabled{z-index:-1;background-color:", ";}&:not(:first-of-type){margin-", ":", ";}&:not(:first-of-type):disabled{margin-", ":", ";}&:not(:first-of-type):not(:last-of-type){border-radius:0;}&:first-of-type:not(:last-of-type){border-top-", "-radius:0;border-bottom-", "-radius:0;}&:last-of-type:not(:first-of-type){border-top-", "-radius:0;border-bottom-", "-radius:0;}&:first-of-type:not(:last-of-type) ", "{margin-", ":", ";}&:last-of-type:not(:first-of-type) ", "{margin-", ":", ";}"], startPosition, borders.sm, borderColor, SELECTOR_FOCUS_VISIBLE, focusColor, focusBoxShadow, SELECTOR_FOCUS_VISIBLE, disabledBackgroundColor, startPosition, marginDisplacement, startPosition, marginOffset, endPosition, endPosition, startPosition, startPosition, StyledIcon$1, endPosition, iconMarginDisplacement, StyledIcon$1, startPosition, iconMarginDisplacement);
+};
+const iconStyles$1 = props => {
+  const size = props.size === 'small' ? props.theme.iconSizes.sm : props.theme.iconSizes.md;
+  return Ne(["width:", ";min-width:", ";height:", ";vertical-align:", ";"], size, size, size, props.isLink && 'middle');
+};
+const sizeStyles$4 = props => {
+  let retVal;
+  if (props.isLink) {
+    retVal = Ne(["padding:0;font-size:inherit;"]);
+  } else {
+    const height = getHeight(props);
+    const lineHeight = math(`${height} - (${props.theme.borderWidths.sm} * 2)`);
+    let padding;
+    let fontSize;
+    if (props.size === 'small') {
+      fontSize = props.theme.fontSizes.sm;
+      padding = `${props.theme.space.base * 3}px`;
+    } else {
+      fontSize = props.theme.fontSizes.md;
+      if (props.size === 'large') {
+        padding = `${props.theme.space.base * 5}px`;
+      } else {
+        padding = `${props.theme.space.base * 4}px`;
+      }
+    }
+    retVal = Ne(["padding:0 ", ";height:", ";line-height:", ";font-size:", ";"], em$1(math(`${padding} - ${props.theme.borderWidths.sm}`), fontSize), height, lineHeight, fontSize);
+  }
+  return retVal;
+};
+const StyledButton = styled.button.attrs(props => ({
+  'data-garden-id': COMPONENT_ID$3$1,
+  'data-garden-version': '8.69.5',
+  type: props.type || 'button'
+})).withConfig({
+  displayName: "StyledButton",
+  componentId: "sc-qe3ace-0"
+})(["display:", ";align-items:", ";justify-content:", ";transition:border-color 0.25s ease-in-out,box-shadow 0.1s ease-in-out,background-color 0.25s ease-in-out,color 0.25s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;margin:0;border:", ";border-radius:", ";cursor:pointer;width:", ";overflow:hidden;text-decoration:none;text-overflow:ellipsis;white-space:", ";font-family:inherit;font-weight:", ";-webkit-font-smoothing:subpixel-antialiased;box-sizing:border-box;user-select:", ";-webkit-touch-callout:none;", ";&::-moz-focus-inner{border:0;padding:0;}", "{text-decoration:none;}&:hover{text-decoration:", ";}&:active,&[aria-pressed='true'],&[aria-pressed='mixed']{transition:border-color 0.1s ease-in-out,background-color 0.1s ease-in-out,box-shadow 0.1s ease-in-out,color 0.1s ease-in-out,outline-color 0.1s ease-in-out,z-index 0.25s ease-in-out;text-decoration:", ";}", ";&:disabled{cursor:default;text-decoration:", ";}& ", "{", "}", " &&{", "}", ""], props => props.isLink ? 'inline' : 'inline-flex', props => !props.isLink && 'center', props => !props.isLink && 'center', props => `${props.isLink ? `0px solid` : props.theme.borders.sm} transparent`, props => getBorderRadius(props), props => props.isStretched ? '100%' : '', props => !props.isLink && 'nowrap', props => props.isLink ? 'inherit' : props.theme.fontWeights.regular, props => !props.isLink && 'none', props => sizeStyles$4(props), SELECTOR_FOCUS_VISIBLE, props => props.isLink ? 'underline' : 'none', props => props.isLink ? 'underline' : 'none', props => colorStyles$7(props), props => props.isLink && 'none', StyledIcon$1, props => iconStyles$1(props), StyledButtonGroup, props => groupStyles(props), props => retrieveComponentStyles(COMPONENT_ID$3$1, props));
+StyledButton.defaultProps = {
+  theme: DEFAULT_THEME
+};
+
+const COMPONENT_ID$2$1 = 'buttons.anchor';
+const StyledAnchor = styled(StyledButton).attrs(props => ({
+  'data-garden-id': COMPONENT_ID$2$1,
+  'data-garden-version': '8.69.5',
+  as: 'a',
+  dir: props.theme.rtl ? 'rtl' : undefined,
+  isLink: true,
+  type: undefined
+})).withConfig({
+  displayName: "StyledAnchor",
+  componentId: "sc-xshgmo-0"
+})(["direction:", ";", ";"], props => props.theme.rtl && 'rtl', props => retrieveComponentStyles(COMPONENT_ID$2$1, props));
+StyledAnchor.defaultProps = {
+  theme: DEFAULT_THEME
+};
+
+var _path$1$1;
+function _extends$1$1() { _extends$1$1 = Object.assign ? Object.assign.bind() : function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends$1$1.apply(this, arguments); }
+var SvgNewWindowStroke = function SvgNewWindowStroke(props) {
+  return /*#__PURE__*/reactExports.createElement("svg", _extends$1$1({
+    xmlns: "http://www.w3.org/2000/svg",
+    width: 12,
+    height: 12,
+    focusable: "false",
+    viewBox: "0 0 12 12",
+    "aria-hidden": "true"
+  }, props), _path$1$1 || (_path$1$1 = /*#__PURE__*/reactExports.createElement("path", {
+    fill: "none",
+    stroke: "currentColor",
+    strokeLinecap: "round",
+    d: "M10.5 8.5V10c0 .3-.2.5-.5.5H2c-.3 0-.5-.2-.5-.5V2c0-.3.2-.5.5-.5h1.5M6 6l4-4m-3.5-.5H10c.3 0 .5.2.5.5v3.5"
+  })));
+};
+
+const COMPONENT_ID$1$1 = 'buttons.external_icon';
+const StyledExternalIcon = styled(SvgNewWindowStroke).attrs({
+  'data-garden-id': COMPONENT_ID$1$1,
+  'data-garden-version': '8.69.5'
+}).withConfig({
+  displayName: "StyledExternalIcon",
+  componentId: "sc-16oz07e-0"
+})(["transform:", ";margin-bottom:-0.085em;padding-left:0.25em;box-sizing:content-box;width:0.85em;height:0.85em;", ";"], props => props.theme.rtl && 'scaleX(-1)', props => retrieveComponentStyles(COMPONENT_ID$1$1, props));
+StyledExternalIcon.defaultProps = {
+  theme: DEFAULT_THEME
+};
+
+const COMPONENT_ID$c = 'buttons.icon_button';
+const iconColorStyles = props => {
+  const shade = 600;
+  const baseColor = getColor('neutralHue', shade, props.theme);
+  const hoverColor = getColor('neutralHue', shade + 100, props.theme);
+  const activeColor = getColor('neutralHue', shade + 200, props.theme);
+  return Ne(["color:", ";&:hover{color:", ";}&:active,&[aria-pressed='true'],&[aria-pressed='mixed']{color:", ";}"], baseColor, hoverColor, activeColor);
+};
+const iconButtonStyles = props => {
+  const width = getHeight(props);
+  return Ne(["border:", ";padding:0;width:", ";min-width:", ";", ";&:disabled{background-color:", ";}"], props.isBasic && 'none', width, width, props.isBasic && !(props.isPrimary || props.isDanger || props.disabled) && iconColorStyles(props), !props.isPrimary && 'transparent');
+};
+const iconStyles = props => {
+  const size = props.theme.iconSizes.md;
+  return Ne(["width:", ";height:", ";& > svg{transition:opacity 0.15s ease-in-out;}"], size, size);
+};
+const StyledIconButton = styled(StyledButton).attrs({
+  'data-garden-id': COMPONENT_ID$c,
+  'data-garden-version': '8.69.5'
+}).withConfig({
+  displayName: "StyledIconButton",
+  componentId: "sc-1t0ughp-0"
+})(["", ";& ", "{", "}", ";"], props => iconButtonStyles(props), StyledIcon$1, props => iconStyles(props), props => retrieveComponentStyles(COMPONENT_ID$c, props));
+StyledIconButton.defaultProps = {
+  theme: DEFAULT_THEME
+};
+
+const ButtonGroupContext = reactExports.createContext(undefined);
+const useButtonGroupContext = () => {
+  return reactExports.useContext(ButtonGroupContext);
+};
+
+const SplitButtonContext = reactExports.createContext(undefined);
+const useSplitButtonContext = () => {
+  return reactExports.useContext(SplitButtonContext);
+};
+
+const StartIconComponent = props => React__default.createElement(StyledIcon$1, _extends$2$1({
+  position: "start"
+}, props));
+StartIconComponent.displayName = 'Button.StartIcon';
+const StartIcon = StartIconComponent;
+
+const EndIconComponent = props => React__default.createElement(StyledIcon$1, _extends$2$1({
+  position: "end"
+}, props));
+EndIconComponent.displayName = 'Button.EndIcon';
+const EndIcon = EndIconComponent;
+
+const ButtonComponent = reactExports.forwardRef((props, ref) => {
+  const buttonGroupContext = useButtonGroupContext();
+  const splitButtonContext = useSplitButtonContext();
+  let computedRef = ref;
+  let computedProps = {
+    ...props,
+    focusInset: props.focusInset || buttonGroupContext !== undefined || splitButtonContext
+  };
+  if (buttonGroupContext && !props.disabled) {
+    if (!props.value) {
+      throw new Error('"value" prop must be provided to Button when used within a ButtonGroup');
+    }
+    computedProps = buttonGroupContext.getButtonProps({
+      isSelected: props.value === buttonGroupContext.selectedItem,
+      ...computedProps
+    });
+    computedRef = mergeRefs([
+    computedProps.ref, ref]);
+  }
+  return React__default.createElement(StyledButton, _extends$2$1({}, computedProps, {
+    ref: computedRef
+  }));
+});
+ButtonComponent.displayName = 'Button';
+ButtonComponent.propTypes = {
+  isNeutral: PropTypes.bool,
+  isPrimary: PropTypes.bool,
+  isDanger: PropTypes.bool,
+  isPill: PropTypes.bool,
+  isBasic: PropTypes.bool,
+  focusInset: PropTypes.bool,
+  isLink: PropTypes.bool,
+  isStretched: PropTypes.bool,
+  isSelected: PropTypes.bool,
+  size: PropTypes.oneOf(SIZE)
+};
+ButtonComponent.defaultProps = {
+  size: 'medium'
+};
+const Button = ButtonComponent;
+Button.EndIcon = EndIcon;
+Button.StartIcon = StartIcon;
+
+const Anchor = reactExports.forwardRef((_ref, ref) => {
+  let {
+    children,
+    isExternal,
+    externalIconLabel,
+    ...otherProps
+  } = _ref;
+  let anchorProps = otherProps;
+  if (isExternal) {
+    anchorProps = {
+      target: '_blank',
+      rel: 'noopener noreferrer',
+      ...anchorProps
+    };
+  }
+  const checkProps = isExternal ? {
+    externalIconLabel
+  } : {
+    noIconLabel: 'true'
+  };
+  const iconAriaLabel = useText(Anchor, checkProps, isExternal ? 'externalIconLabel' : 'noIconLabel', '(opens in a new tab)');
+  return React__default.createElement(StyledAnchor, _extends$2$1({
+    ref: ref
+  }, anchorProps), children, isExternal &&
+  React__default.createElement(StyledExternalIcon, {
+    role: "img",
+    "aria-label": iconAriaLabel,
+    "aria-hidden": undefined
+  }));
+});
+Anchor.displayName = 'Anchor';
+Anchor.propTypes = {
+  isExternal: PropTypes.bool,
+  isDanger: PropTypes.bool,
+  externalIconLabel: PropTypes.string
+};
+
+const ButtonGroup = reactExports.forwardRef((_ref, ref) => {
+  let {
+    children,
+    onSelect,
+    selectedItem: controlledSelectedValue,
+    ...otherProps
+  } = _ref;
+  const {
+    rtl
+  } = reactExports.useContext(Be) || DEFAULT_THEME;
+  const [internalSelectedValue, setInternalSelectedValue] = reactExports.useState();
+  const selectedValue = getControlledValue$1(controlledSelectedValue, internalSelectedValue);
+  const values = reactExports.useMemo(() => reactExports.Children.toArray(children).reduce((buttons, child) => {
+    if ( reactExports.isValidElement(child) && child.type !== 'string' && !child.props.disabled) {
+      buttons.push(child.props.value);
+    }
+    return buttons;
+  }, []), [children]);
+  const {
+    selectedValue: selectedItem,
+    getElementProps,
+    getGroupProps
+  } = useSelection({
+    rtl,
+    values,
+    defaultSelectedValue: values[0],
+    selectedValue,
+    onSelect: reactExports.useCallback(value => {
+      onSelect && onSelect(value);
+      setInternalSelectedValue(value);
+    }, [onSelect])
+  });
+  const contextValue = reactExports.useMemo(() => ({
+    selectedItem,
+    getButtonProps: props => getElementProps({
+      role: 'button',
+      selectedAriaKey: 'aria-pressed',
+      ...props
+    })
+  }), [selectedItem, getElementProps]);
+  return React__default.createElement(ButtonGroupContext.Provider, {
+    value: contextValue
+  }, React__default.createElement(StyledButtonGroup, _extends$2$1({
+    ref: ref
+  }, getGroupProps(otherProps)), children));
+});
+ButtonGroup.displayName = 'ButtonGroup';
+ButtonGroup.propTypes = {
+  selectedItem: PropTypes.any,
+  onSelect: PropTypes.func
+};
+
+const IconButton = reactExports.forwardRef((_ref, ref) => {
+  let {
+    children,
+    isRotated,
+    ...otherProps
+  } = _ref;
+  const focusInset = useSplitButtonContext();
+  return React__default.createElement(StyledIconButton, _extends$2$1({
+    ref: ref
+  }, otherProps, {
+    focusInset: otherProps.focusInset || focusInset
+  }), React__default.createElement(StyledIcon$1, {
+    isRotated: isRotated
+  }, children));
+});
+IconButton.displayName = 'IconButton';
+IconButton.propTypes = {
+  isDanger: PropTypes.bool,
+  size: PropTypes.oneOf(SIZE),
+  isNeutral: PropTypes.bool,
+  isPrimary: PropTypes.bool,
+  isBasic: PropTypes.bool,
+  isPill: PropTypes.bool,
+  focusInset: PropTypes.bool,
+  isRotated: PropTypes.bool
+};
+IconButton.defaultProps = {
+  isPill: true,
+  isBasic: true,
+  size: 'medium'
+};
+
+var _path$3;
+function _extends$7() { _extends$7 = Object.assign ? Object.assign.bind() : function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends$7.apply(this, arguments); }
+var SvgChevronDownStroke = function SvgChevronDownStroke(props) {
+  return /*#__PURE__*/reactExports.createElement("svg", _extends$7({
+    xmlns: "http://www.w3.org/2000/svg",
+    width: 16,
+    height: 16,
+    focusable: "false",
+    viewBox: "0 0 16 16",
+    "aria-hidden": "true"
+  }, props), _path$3 || (_path$3 = /*#__PURE__*/reactExports.createElement("path", {
+    fill: "currentColor",
+    d: "M12.688 5.61a.5.5 0 01.69.718l-.066.062-5 4a.5.5 0 01-.542.054l-.082-.054-5-4a.5.5 0 01.55-.83l.074.05L8 9.359l4.688-3.75z"
+  })));
+};
+
+const ChevronButton = reactExports.forwardRef((_ref, ref) => {
+  let {
+    ...buttonProps
+  } = _ref;
+  return React__default.createElement(IconButton, _extends$2$1({
+    ref: ref
+  }, buttonProps), React__default.createElement(SvgChevronDownStroke, null));
+});
+ChevronButton.displayName = 'ChevronButton';
+ChevronButton.propTypes = IconButton.propTypes;
+ChevronButton.defaultProps = {
+  isBasic: false,
+  isPill: false,
+  size: 'medium'
+};
+
+const SplitButton = reactExports.forwardRef((_ref, ref) => {
+  let {
+    children,
+    ...other
+  } = _ref;
+  return React__default.createElement(SplitButtonContext.Provider, {
+    value: true
+  }, React__default.createElement(StyledButtonGroup, _extends$2$1({
+    ref: ref
+  }, other), children));
+});
+SplitButton.displayName = 'SplitButton';
+
+const ToggleButton = reactExports.forwardRef((_ref, ref) => {
+  let {
+    isPressed,
+    ...otherProps
+  } = _ref;
+  return React__default.createElement(Button, _extends$2$1({
+    "aria-pressed": isPressed,
+    ref: ref
+  }, otherProps));
+});
+ToggleButton.displayName = 'ToggleButton';
+ToggleButton.propTypes = {
+  ...Button.propTypes,
+  isPressed: PropTypes.oneOf([true, false, 'mixed'])
+};
+ToggleButton.defaultProps = {
+  size: 'medium'
+};
+
+const ToggleIconButton = reactExports.forwardRef((_ref, ref) => {
+  let {
+    isPressed,
+    ...otherProps
+  } = _ref;
+  return React__default.createElement(IconButton, _extends$2$1({
+    "aria-pressed": isPressed,
+    ref: ref
+  }, otherProps));
+});
+ToggleIconButton.displayName = 'ToggleIconButton';
+ToggleIconButton.propTypes = {
+  ...IconButton.propTypes,
+  isPressed: PropTypes.oneOf([true, false, 'mixed'])
+};
+ToggleIconButton.defaultProps = {
+  isPill: true,
+  isBasic: true,
+  size: 'medium'
+};
+
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+function _extends$6() {
+  _extends$6 = Object.assign ? Object.assign.bind() : function (target) {
+    for (var i = 1; i < arguments.length; i++) {
+      var source = arguments[i];
+      for (var key in source) {
+        if (Object.prototype.hasOwnProperty.call(source, key)) {
+          target[key] = source[key];
+        }
+      }
+    }
+    return target;
+  };
+  return _extends$6.apply(this, arguments);
+}
+
+const TYPE = ['success', 'warning', 'error', 'info'];
+
+const COMPONENT_ID$b = 'notifications.close';
+const StyledClose = styled.button.attrs({
+  'data-garden-id': COMPONENT_ID$b,
+  'data-garden-version': '8.69.5'
+}).withConfig({
+  displayName: "StyledClose",
+  componentId: "sc-1mr9nx1-0"
+})(["display:block;position:absolute;top:", "px;", ":", ";transition:background-color 0.1s ease-in-out,color 0.25s ease-in-out,box-shadow 0.1s ease-in-out;border:none;border-radius:50%;background-color:transparent;cursor:pointer;padding:0;width:", "px;height:", "px;overflow:hidden;color:", ";font-size:0;user-select:none;&::-moz-focus-inner{border:0;}&:hover{color:", ";}", " ", ";"], props => props.theme.space.base, props => props.theme.rtl ? 'left' : 'right', props => `${props.theme.space.base}px`, props => props.theme.space.base * 7, props => props.theme.space.base * 7, props => props.hue ? getColor(props.hue, props.hue === 'warningHue' ? 700 : 600, props.theme) : getColor('neutralHue', 600, props.theme), props => props.hue ? getColor(props.hue, 800, props.theme) : getColor('neutralHue', 800, props.theme), props => focusStyles({
+  theme: props.theme,
+  inset: true
+}), props => retrieveComponentStyles(COMPONENT_ID$b, props));
+StyledClose.defaultProps = {
+  theme: DEFAULT_THEME
+};
+
+const COMPONENT_ID$a = 'notifications.paragraph';
+const StyledParagraph = styled.p.attrs({
+  'data-garden-id': COMPONENT_ID$a,
+  'data-garden-version': '8.69.5'
+}).withConfig({
+  displayName: "StyledParagraph",
+  componentId: "sc-12tmd6p-0"
+})(["margin:", "px 0 0;", ";"], props => props.theme.space.base * 2, props => retrieveComponentStyles(COMPONENT_ID$a, props));
+StyledParagraph.defaultProps = {
+  theme: DEFAULT_THEME
+};
+
+const COMPONENT_ID$9 = 'notifications.title';
+const StyledTitle = styled.div.attrs({
+  'data-garden-id': COMPONENT_ID$9,
+  'data-garden-version': '8.69.5'
+}).withConfig({
+  displayName: "StyledTitle",
+  componentId: "sc-xx4jsv-0"
+})(["margin:0;color:", ";font-weight:", ";", ";"], props => props.theme.colors.foreground, props => props.isRegular ? props.theme.fontWeights.regular : props.theme.fontWeights.semibold, props => retrieveComponentStyles(COMPONENT_ID$9, props));
+StyledTitle.defaultProps = {
+  theme: DEFAULT_THEME
+};
+
+const boxShadow = props => {
+  const {
+    theme
+  } = props;
+  const {
+    space,
+    shadows
+  } = theme;
+  const offsetY = `${space.base * 5}px`;
+  const blurRadius = `${space.base * 7}px`;
+  const color = getColor('chromeHue', 600, theme, 0.15);
+  return shadows.lg(offsetY, blurRadius, color);
+};
+const colorStyles$6 = props => {
+  let backgroundColor;
+  let borderColor;
+  let foregroundColor;
+  if (props.hue) {
+    backgroundColor = getColor(props.hue, 100, props.theme);
+    borderColor = getColor(props.hue, 300, props.theme);
+    foregroundColor = getColor(props.hue, props.type === 'info' ? 600 : 700, props.theme);
+  } else {
+    backgroundColor = props.theme.colors.background;
+    borderColor = getColor('neutralHue', 300, props.theme);
+    foregroundColor = getColor('neutralHue', 800, props.theme);
+  }
+  return Ne(["border-color:", ";background-color:", ";color:", ";"], borderColor, backgroundColor, foregroundColor);
+};
+const padding = props => {
+  const {
+    space
+  } = props.theme;
+  const paddingVertical = `${space.base * 5}px`;
+  const paddingHorizontal = `${space.base * 10}px`;
+  return `${paddingVertical} ${paddingHorizontal}`;
+};
+const StyledBase = styled.div.withConfig({
+  displayName: "StyledBase",
+  componentId: "sc-14syaqw-0"
+})(["position:relative;border:", ";border-radius:", ";box-shadow:", ";padding:", ";line-height:", ";font-size:", ";direction:", ";", ";"], props => props.theme.borders.sm, props => props.theme.borderRadii.md, props => props.isFloating && boxShadow, padding, props => getLineHeight(props.theme.space.base * 5, props.theme.fontSizes.md), props => props.theme.fontSizes.md, props => props.theme.rtl && 'rtl', colorStyles$6);
+StyledBase.defaultProps = {
+  theme: DEFAULT_THEME
+};
+
+const COMPONENT_ID$8 = 'notifications.alert';
+const colorStyles$5 = props => Ne(["", "{color:", ";}"], StyledTitle, props.hue && getColor(props.hue, 800, props.theme));
+const StyledAlert = styled(StyledBase).attrs(props => ({
+  'data-garden-id': COMPONENT_ID$8,
+  'data-garden-version': '8.69.5',
+  role: props.role === undefined ? 'alert' : props.role
+})).withConfig({
+  displayName: "StyledAlert",
+  componentId: "sc-fyn8jp-0"
+})(["", " ", ";"], colorStyles$5, props => retrieveComponentStyles(COMPONENT_ID$8, props));
+StyledAlert.defaultProps = {
+  theme: DEFAULT_THEME
+};
+
+const COMPONENT_ID$7 = 'notifications.notification';
+const colorStyles$4 = props => {
+  const {
+    type,
+    theme
+  } = props;
+  const {
+    colors
+  } = theme;
+  const {
+    successHue,
+    dangerHue,
+    warningHue,
+    foreground
+  } = colors;
+  let color;
+  switch (type) {
+    case 'success':
+      color = getColor(successHue, 600, theme);
+      break;
+    case 'error':
+      color = getColor(dangerHue, 600, theme);
+      break;
+    case 'warning':
+      color = getColor(warningHue, 700, theme);
+      break;
+    case 'info':
+      color = foreground;
+      break;
+    default:
+      color = 'inherit';
+      break;
+  }
+  return Ne(["", "{color:", ";}"], StyledTitle, color);
+};
+const StyledNotification = styled(StyledBase).attrs({
+  'data-garden-id': COMPONENT_ID$7,
+  'data-garden-version': '8.69.5'
+}).withConfig({
+  displayName: "StyledNotification",
+  componentId: "sc-uf6jh-0"
+})(["", " ", ";"], colorStyles$4, props => retrieveComponentStyles(COMPONENT_ID$7, props));
+StyledNotification.propTypes = {
+  type: PropTypes.oneOf(TYPE)
+};
+StyledNotification.defaultProps = {
+  theme: DEFAULT_THEME
+};
+
+const COMPONENT_ID$6 = 'notifications.well';
+const StyledWell = styled(StyledBase).attrs({
+  'data-garden-id': COMPONENT_ID$6,
+  'data-garden-version': '8.69.5'
+}).withConfig({
+  displayName: "StyledWell",
+  componentId: "sc-a5831c-0"
+})(["background-color:", ";color:", " ", ";"], props => props.isRecessed && getColor('neutralHue', 100, props.theme), props => getColor('neutralHue', 600, props.theme), props => retrieveComponentStyles(COMPONENT_ID$6, props));
+StyledWell.defaultProps = {
+  theme: DEFAULT_THEME
+};
+
+const StyledIcon = styled(_ref => {
+  let {
+    children,
+    ...props
+  } = _ref;
+  return React__default.cloneElement(reactExports.Children.only(children), props);
+}).withConfig({
+  displayName: "StyledIcon",
+  componentId: "sc-msklws-0"
+})(["position:absolute;right:", ";left:", ";margin-top:", "px;color:", ";"], props => props.theme.rtl && `${props.theme.space.base * 4}px`, props => !props.theme.rtl && `${props.theme.space.base * 4}px`, props => props.theme.space.base / 2, props => props.hue && getColor(props.hue, props.hue === 'warningHue' ? 700 : 600, props.theme));
+StyledIcon.defaultProps = {
+  theme: DEFAULT_THEME
+};
+
+const COMPONENT_ID$5 = 'notifications.global-alert';
+const colorStyles$3 = props => {
+  let borderColor;
+  let backgroundColor;
+  let foregroundColor;
+  let anchorHoverColor;
+  let anchorActiveColor;
+  let focusColor;
+  switch (props.alertType) {
+    case 'success':
+      borderColor = getColor('successHue', 700, props.theme);
+      backgroundColor = getColor('successHue', 600, props.theme);
+      foregroundColor = getColor('successHue', 100, props.theme);
+      anchorHoverColor = props.theme.palette.white;
+      anchorActiveColor = props.theme.palette.white;
+      focusColor = 'successHue';
+      break;
+    case 'error':
+      borderColor = getColor('dangerHue', 700, props.theme);
+      backgroundColor = getColor('dangerHue', 600, props.theme);
+      foregroundColor = getColor('dangerHue', 100, props.theme);
+      anchorHoverColor = props.theme.palette.white;
+      anchorActiveColor = props.theme.palette.white;
+      focusColor = 'dangerHue';
+      break;
+    case 'warning':
+      borderColor = getColor('warningHue', 400, props.theme);
+      backgroundColor = getColor('warningHue', 300, props.theme);
+      foregroundColor = getColor('warningHue', 800, props.theme);
+      anchorHoverColor = getColor('warningHue', 900, props.theme);
+      anchorActiveColor = getColor('warningHue', 1000, props.theme);
+      focusColor = 'warningHue';
+      break;
+    case 'info':
+      borderColor = getColor('primaryHue', 300, props.theme);
+      backgroundColor = getColor('primaryHue', 200, props.theme);
+      foregroundColor = getColor('primaryHue', 700, props.theme);
+      anchorHoverColor = getColor('primaryHue', 800, props.theme);
+      anchorActiveColor = getColor('primaryHue', 900, props.theme);
+      focusColor = 'primaryHue';
+      break;
+  }
+  const boxShadow = `0 ${props.theme.borderWidths.sm} ${props.theme.borderWidths.sm} ${borderColor}`;
+  return Ne(["box-shadow:", ";background-color:", ";color:", ";& a{color:inherit;", " &:hover{color:", ";}&:active{color:", ";}}"], boxShadow, backgroundColor, foregroundColor, focusStyles({
+    theme: props.theme,
+    hue: focusColor,
+    shade: props.alertType === 'info' ? 600 : 800,
+    styles: {
+      color: 'inherit'
+    }
+  }), anchorHoverColor, anchorActiveColor);
+};
+const sizeStyles$3 = props => {
+  const {
+    fontSizes,
+    space
+  } = props.theme;
+  const minHeight = space.base * 13;
+  const padding = space.base * 4;
+  const lineHeight = getLineHeight(space.base * 5, fontSizes.md);
+  return Ne(["padding:", "px;min-height:", "px;line-height:", ";font-size:", ";"], padding, minHeight, lineHeight, fontSizes.md);
+};
+const StyledGlobalAlert = styled.div.attrs({
+  'data-garden-id': COMPONENT_ID$5,
+  'data-garden-version': '8.69.5'
+}).withConfig({
+  displayName: "StyledGlobalAlert",
+  componentId: "sc-k6rimt-0"
+})(["display:flex;flex-wrap:nowrap;overflow:auto;overflow-x:hidden;box-sizing:border-box;direction:", ";", " ", " && a{border-radius:", ";text-decoration:underline;}", ";"], props => props.theme.rtl ? 'rtl' : 'ltr', sizeStyles$3, colorStyles$3, props => props.theme.borderRadii.sm, props => retrieveComponentStyles(COMPONENT_ID$5, props));
+StyledGlobalAlert.defaultProps = {
+  theme: DEFAULT_THEME
+};
+
+const COMPONENT_ID$4 = 'notifications.global-alert.close';
+const colorStyles$2 = props => {
+  let hoverBackgroundColor;
+  let hoverForegroundColor;
+  let activeBackgroundColor;
+  let activeForegroundColor;
+  let focusColor;
+  switch (props.alertType) {
+    case 'success':
+      hoverBackgroundColor = getColor('successHue', 100, props.theme, 0.08);
+      hoverForegroundColor = props.theme.palette.white;
+      activeBackgroundColor = getColor('successHue', 100, props.theme, 0.2);
+      activeForegroundColor = props.theme.palette.white;
+      focusColor = 'successHue';
+      break;
+    case 'error':
+      hoverBackgroundColor = getColor('dangerHue', 100, props.theme, 0.08);
+      hoverForegroundColor = props.theme.palette.white;
+      activeBackgroundColor = getColor('dangerHue', 100, props.theme, 0.2);
+      activeForegroundColor = props.theme.palette.white;
+      focusColor = 'dangerHue';
+      break;
+    case 'warning':
+      hoverBackgroundColor = getColor('warningHue', 800, props.theme, 0.08);
+      hoverForegroundColor = getColor('warningHue', 900, props.theme);
+      activeBackgroundColor = getColor('warningHue', 800, props.theme, 0.2);
+      activeForegroundColor = getColor('warningHue', 1000, props.theme);
+      focusColor = 'warningHue';
+      break;
+    case 'info':
+      hoverBackgroundColor = getColor('primaryHue', 700, props.theme, 0.08);
+      hoverForegroundColor = getColor('primaryHue', 800, props.theme);
+      activeBackgroundColor = getColor('primaryHue', 700, props.theme, 0.2);
+      activeForegroundColor = getColor('primaryHue', 900, props.theme);
+      focusColor = 'primaryHue';
+      break;
+  }
+  return Ne(["color:inherit;&:hover{background-color:", ";color:", ";}", " &:active{background-color:", ";color:", ";}"], hoverBackgroundColor, hoverForegroundColor, focusStyles({
+    theme: props.theme,
+    hue: focusColor,
+    shade: props.alertType === 'info' ? 600 : 800
+  }), activeBackgroundColor, activeForegroundColor);
+};
+const sizeStyles$2 = props => {
+  const marginVertical = `-${props.theme.space.base * 1.5}px`;
+  const marginStart = `${props.theme.space.base * 2}px`;
+  const marginEnd = `-${props.theme.space.base * 2}px`;
+  return Ne(["margin:", " ", " ", " ", ";"], marginVertical, props.theme.rtl ? marginStart : marginEnd, marginVertical, props.theme.rtl ? marginEnd : marginStart);
+};
+const StyledGlobalAlertClose = styled(IconButton).attrs({
+  'data-garden-id': COMPONENT_ID$4,
+  'data-garden-version': '8.69.5',
+  size: 'small'
+}).withConfig({
+  displayName: "StyledGlobalAlertClose",
+  componentId: "sc-1g5s93s-0"
+})(["", ";", ";", ";"], sizeStyles$2, colorStyles$2, props => retrieveComponentStyles(COMPONENT_ID$4, props));
+StyledGlobalAlertClose.defaultProps = {
+  theme: DEFAULT_THEME
+};
+
+const COMPONENT_ID$3 = 'notifications.global-alert.button';
+function colorStyles$1(props) {
+  if (props.isBasic) {
+    return colorStyles$2(props);
+  }
+  let backgroundColor;
+  let hoverBackgroundColor;
+  let activeBackgroundColor;
+  let focusColor;
+  switch (props.alertType) {
+    case 'success':
+      backgroundColor = getColor('successHue', 800, props.theme);
+      hoverBackgroundColor = getColor('successHue', 900, props.theme);
+      activeBackgroundColor = getColor('successHue', 1000, props.theme);
+      focusColor = 'successHue';
+      break;
+    case 'error':
+      backgroundColor = getColor('dangerHue', 800, props.theme);
+      hoverBackgroundColor = getColor('dangerHue', 900, props.theme);
+      activeBackgroundColor = getColor('dangerHue', 1000, props.theme);
+      focusColor = 'dangerHue';
+      break;
+    case 'warning':
+      backgroundColor = getColor('warningHue', 800, props.theme);
+      hoverBackgroundColor = getColor('warningHue', 900, props.theme);
+      activeBackgroundColor = getColor('warningHue', 1000, props.theme);
+      focusColor = 'warningHue';
+      break;
+    case 'info':
+      focusColor = 'primaryHue';
+      break;
+  }
+  return Ne(["background-color:", ";&:hover{background-color:", ";}", " &:active{background-color:", ";}"], backgroundColor, hoverBackgroundColor, focusStyles({
+    theme: props.theme,
+    hue: focusColor,
+    shade: props.alertType === 'info' ? 600 : 800
+  }), activeBackgroundColor);
+}
+function sizeStyles$1(props) {
+  const marginVertical = `-${props.theme.space.base * 1.5}px`;
+  const marginStart = `${props.theme.space.base * 2}px`;
+  return Ne(["margin:", " ", " ", " ", ";"], marginVertical, props.theme.rtl ? marginStart : 0, marginVertical, props.theme.rtl ? 0 : marginStart);
+}
+const StyledGlobalAlertButton = styled(Button).attrs({
+  'data-garden-id': COMPONENT_ID$3,
+  'data-garden-version': '8.69.5',
+  focusInset: false,
+  isDanger: false,
+  isLink: false,
+  isNeutral: false,
+  isPill: false,
+  isStretched: false,
+  size: 'small'
+}).withConfig({
+  displayName: "StyledGlobalAlertButton",
+  componentId: "sc-1txe91a-0"
+})(["flex-shrink:0;", ";", ";", ";"], sizeStyles$1, colorStyles$1, props => retrieveComponentStyles(COMPONENT_ID$3, props));
+StyledGlobalAlertButton.defaultProps = {
+  theme: DEFAULT_THEME
+};
+
+const COMPONENT_ID$2 = 'notifications.global-alert.content';
+const StyledGlobalAlertContent = styled.div.attrs({
+  'data-garden-id': COMPONENT_ID$2,
+  'data-garden-version': '8.69.5'
+}).withConfig({
+  displayName: "StyledGlobalAlertContent",
+  componentId: "sc-rept0u-0"
+})(["flex-grow:1;", ";"], props => retrieveComponentStyles(COMPONENT_ID$2, props));
+StyledGlobalAlertContent.defaultProps = {
+  theme: DEFAULT_THEME
+};
+
+const COMPONENT_ID$1 = 'notifications.global-alert.icon';
+const sizeStyles = props => {
+  const size = props.theme.iconSizes.md;
+  const marginTop = math(`(${props.theme.space.base * 5} - ${size}) / 2`);
+  const marginHorizontal = `${props.theme.space.base * 2}px`;
+  return Ne(["margin-top:", ";margin-", ":", ";width:", ";height:", ";"], marginTop, props.theme.rtl ? 'left' : 'right', marginHorizontal, size, size);
+};
+const StyledGlobalAlertIcon = styled(_ref => {
+  let {
+    children,
+    ...props
+  } = _ref;
+  return React__default.cloneElement(reactExports.Children.only(children), props);
+}).attrs({
+  'data-garden-id': COMPONENT_ID$1,
+  'data-garden-version': '8.69.5'
+}).withConfig({
+  displayName: "StyledGlobalAlertIcon",
+  componentId: "sc-84ne9k-0"
+})(["flex-shrink:0;", ";", ";"], sizeStyles, props => retrieveComponentStyles(COMPONENT_ID$1, props));
+StyledGlobalAlertIcon.defaultProps = {
+  theme: DEFAULT_THEME
+};
+
+const COMPONENT_ID = 'notifications.global-alert.title';
+const colorStyles = props => {
+  let color;
+  switch (props.alertType) {
+    case 'success':
+    case 'error':
+      color = props.theme.palette.white;
+      break;
+    case 'warning':
+      color = getColor('warningHue', 900, props.theme);
+      break;
+    case 'info':
+      color = getColor('primaryHue', 800, props.theme);
+      break;
+  }
+  return Ne(["color:", ";"], color);
+};
+const StyledGlobalAlertTitle = styled.div.attrs({
+  'data-garden-id': COMPONENT_ID,
+  'data-garden-version': '8.69.5'
+}).withConfig({
+  displayName: "StyledGlobalAlertTitle",
+  componentId: "sc-10clqbo-0"
+})(["display:inline;margin-", ":", "px;font-weight:", ";", ";", ";"], props => props.theme.rtl ? 'left' : 'right', props => props.theme.space.base * 2, props => props.isRegular ? props.theme.fontWeights.regular : props.theme.fontWeights.semibold, colorStyles, props => retrieveComponentStyles(COMPONENT_ID, props));
+StyledGlobalAlertTitle.defaultProps = {
+  theme: DEFAULT_THEME
+};
+
+var _g$2, _circle$2;
+function _extends$5() { _extends$5 = Object.assign ? Object.assign.bind() : function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends$5.apply(this, arguments); }
+var SvgAlertErrorStroke = function SvgAlertErrorStroke(props) {
+  return /*#__PURE__*/reactExports.createElement("svg", _extends$5({
+    xmlns: "http://www.w3.org/2000/svg",
+    width: 16,
+    height: 16,
+    focusable: "false",
+    viewBox: "0 0 16 16",
+    "aria-hidden": "true"
+  }, props), _g$2 || (_g$2 = /*#__PURE__*/reactExports.createElement("g", {
+    fill: "none",
+    stroke: "currentColor"
+  }, /*#__PURE__*/reactExports.createElement("circle", {
+    cx: 7.5,
+    cy: 8.5,
+    r: 7
+  }), /*#__PURE__*/reactExports.createElement("path", {
+    strokeLinecap: "round",
+    d: "M7.5 4.5V9"
+  }))), _circle$2 || (_circle$2 = /*#__PURE__*/reactExports.createElement("circle", {
+    cx: 7.5,
+    cy: 12,
+    r: 1,
+    fill: "currentColor"
+  })));
+};
+
+var _g$1;
+function _extends$4() { _extends$4 = Object.assign ? Object.assign.bind() : function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends$4.apply(this, arguments); }
+var SvgCheckCircleStroke = function SvgCheckCircleStroke(props) {
+  return /*#__PURE__*/reactExports.createElement("svg", _extends$4({
+    xmlns: "http://www.w3.org/2000/svg",
+    width: 16,
+    height: 16,
+    focusable: "false",
+    viewBox: "0 0 16 16",
+    "aria-hidden": "true"
+  }, props), _g$1 || (_g$1 = /*#__PURE__*/reactExports.createElement("g", {
+    fill: "none",
+    stroke: "currentColor"
+  }, /*#__PURE__*/reactExports.createElement("path", {
+    strokeLinecap: "round",
+    strokeLinejoin: "round",
+    d: "M4 9l2.5 2.5 5-5"
+  }), /*#__PURE__*/reactExports.createElement("circle", {
+    cx: 7.5,
+    cy: 8.5,
+    r: 7
+  }))));
+};
+
+var _path$2, _circle$1;
+function _extends$3() { _extends$3 = Object.assign ? Object.assign.bind() : function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends$3.apply(this, arguments); }
+var SvgAlertWarningStroke = function SvgAlertWarningStroke(props) {
+  return /*#__PURE__*/reactExports.createElement("svg", _extends$3({
+    xmlns: "http://www.w3.org/2000/svg",
+    width: 16,
+    height: 16,
+    focusable: "false",
+    viewBox: "0 0 16 16",
+    "aria-hidden": "true"
+  }, props), _path$2 || (_path$2 = /*#__PURE__*/reactExports.createElement("path", {
+    fill: "none",
+    stroke: "currentColor",
+    strokeLinecap: "round",
+    d: "M.88 13.77L7.06 1.86c.19-.36.7-.36.89 0l6.18 11.91c.17.33-.07.73-.44.73H1.32c-.37 0-.61-.4-.44-.73zM7.5 6v3.5"
+  })), _circle$1 || (_circle$1 = /*#__PURE__*/reactExports.createElement("circle", {
+    cx: 7.5,
+    cy: 12,
+    r: 1,
+    fill: "currentColor"
+  })));
+};
+
+var _g, _circle;
+function _extends$2() { _extends$2 = Object.assign ? Object.assign.bind() : function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends$2.apply(this, arguments); }
+var SvgInfoStroke = function SvgInfoStroke(props) {
+  return /*#__PURE__*/reactExports.createElement("svg", _extends$2({
+    xmlns: "http://www.w3.org/2000/svg",
+    width: 16,
+    height: 16,
+    focusable: "false",
+    viewBox: "0 0 16 16",
+    "aria-hidden": "true"
+  }, props), _g || (_g = /*#__PURE__*/reactExports.createElement("g", {
+    stroke: "currentColor"
+  }, /*#__PURE__*/reactExports.createElement("circle", {
+    cx: 7.5,
+    cy: 8.5,
+    r: 7,
+    fill: "none"
+  }), /*#__PURE__*/reactExports.createElement("path", {
+    strokeLinecap: "round",
+    d: "M7.5 12.5V8"
+  }))), _circle || (_circle = /*#__PURE__*/reactExports.createElement("circle", {
+    cx: 7.5,
+    cy: 5,
+    r: 1,
+    fill: "currentColor"
+  })));
+};
+
+const validationIcons = {
+  success: SvgCheckCircleStroke,
+  error: SvgAlertErrorStroke,
+  warning: SvgAlertWarningStroke,
+  info: SvgInfoStroke
+};
+const validationHues = {
+  success: 'successHue',
+  error: 'dangerHue',
+  warning: 'warningHue',
+  info: 'neutralHue'
+};
+
+const NotificationsContext = reactExports.createContext(undefined);
+const useNotificationsContext = () => {
+  return reactExports.useContext(NotificationsContext);
+};
+
+const Alert = React__default.forwardRef((props, ref) => {
+  const hue = validationHues[props.type];
+  const Icon = validationIcons[props.type];
+  return React__default.createElement(NotificationsContext.Provider, {
+    value: hue
+  }, React__default.createElement(StyledAlert, _extends$6({
+    ref: ref,
+    hue: hue
+  }, props), React__default.createElement(StyledIcon, {
+    hue: hue
+  }, React__default.createElement(Icon, null)), props.children));
+});
+Alert.displayName = 'Alert';
+Alert.propTypes = {
+  type: PropTypes.oneOf(TYPE).isRequired
+};
+
+const Notification = reactExports.forwardRef((_ref, ref) => {
+  let {
+    role,
+    ...props
+  } = _ref;
+  const Icon = props.type ? validationIcons[props.type] : SvgInfoStroke;
+  const hue = props.type && validationHues[props.type];
+  return React__default.createElement(StyledNotification, _extends$6({
+    ref: ref,
+    type: props.type,
+    isFloating: true
+  }, props, {
+    role: role === undefined ? 'status' : role
+  }), props.type && React__default.createElement(StyledIcon, {
+    hue: hue
+  }, React__default.createElement(Icon, null)), props.children);
+});
+Notification.displayName = 'Notification';
+Notification.propTypes = {
+  type: PropTypes.oneOf(TYPE)
+};
+
+const Well = React__default.forwardRef((props, ref) => React__default.createElement(StyledWell, _extends$6({
+  ref: ref
+}, props)));
+Well.displayName = 'Well';
+Well.propTypes = {
+  isRecessed: PropTypes.bool,
+  isFloating: PropTypes.bool
+};
+
+var _path$1;
+function _extends$1() { _extends$1 = Object.assign ? Object.assign.bind() : function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends$1.apply(this, arguments); }
+var SvgXStroke$1 = function SvgXStroke(props) {
+  return /*#__PURE__*/reactExports.createElement("svg", _extends$1({
+    xmlns: "http://www.w3.org/2000/svg",
+    width: 12,
+    height: 12,
+    focusable: "false",
+    viewBox: "0 0 12 12",
+    "aria-hidden": "true"
+  }, props), _path$1 || (_path$1 = /*#__PURE__*/reactExports.createElement("path", {
+    stroke: "currentColor",
+    strokeLinecap: "round",
+    d: "M3 9l6-6m0 6L3 3"
+  })));
+};
+
+const Close = React__default.forwardRef((props, ref) => {
+  const ariaLabel = useText(Close, props, 'aria-label', 'Close');
+  const hue = useNotificationsContext();
+  return React__default.createElement(StyledClose, _extends$6({
+    ref: ref,
+    hue: hue,
+    "aria-label": ariaLabel
+  }, props), React__default.createElement(SvgXStroke$1, null));
+});
+Close.displayName = 'Close';
+
+const Paragraph = React__default.forwardRef((props, ref) => React__default.createElement(StyledParagraph, _extends$6({
+  ref: ref
+}, props)));
+Paragraph.displayName = 'Paragraph';
+
+const Title = React__default.forwardRef((props, ref) => React__default.createElement(StyledTitle, _extends$6({
+  ref: ref
+}, props)));
+Title.displayName = 'Title';
+
+reactExports.createContext(undefined);
+
+const TRANSITION_CLASS = 'garden-toast-transition';
+const DEFAULT_DURATION = '400ms';
+const StyledFadeInTransition = styled.div.withConfig({
+  displayName: "styled__StyledFadeInTransition",
+  componentId: "sc-nq0usb-0"
+})(["transition:opacity ", " ease-in 300ms;opacity:", ";margin-bottom:", "px;", " &.", "-enter{transform:translateY( ", " );opacity:0;max-height:0;}&.", "-enter-active{transform:translateY(0);transition:opacity ", " ease-in,transform ", " cubic-bezier(0.15,0.85,0.35,1.2),max-height ", ";opacity:1;max-height:500px;}&.", "-exit{opacity:1;max-height:500px;}&.", "-exit-active{transition:opacity 550ms ease-out,max-height ", " linear 150ms;opacity:0;max-height:0;}"], DEFAULT_DURATION, p => p.isHidden ? '0 !important' : 1, p => p.theme.space.base * 2, p => p.isHidden && hideVisually(), TRANSITION_CLASS, props => {
+  if (props.placement === 'bottom-start' || props.placement === 'bottom' || props.placement === 'bottom-end') {
+    return '100px';
+  }
+  return '-100px';
+}, TRANSITION_CLASS, DEFAULT_DURATION, DEFAULT_DURATION, DEFAULT_DURATION, TRANSITION_CLASS, TRANSITION_CLASS, DEFAULT_DURATION);
+StyledFadeInTransition.defaultProps = {
+  theme: DEFAULT_THEME
+};
+const placementStyles = props => {
+  const verticalDistance = `${props.theme.space.base * 16}px`;
+  const horizontalDistance = `${props.theme.space.base * 3}px`;
+  const topLeftStyles = Ne(["top:", ";left:", ";"], verticalDistance, horizontalDistance);
+  const topStyles = Ne(["top:", ";left:50%;transform:translate(-50%,0);"], verticalDistance);
+  const topRightStyles = Ne(["top:", ";right:", ";"], verticalDistance, horizontalDistance);
+  const bottomLeftStyles = Ne(["bottom:", ";left:", ";"], verticalDistance, horizontalDistance);
+  const bottomStyles = Ne(["bottom:", ";left:50%;transform:translate(-50%,0);"], verticalDistance);
+  const bottomRightStyles = Ne(["right:", ";bottom:", ";"], horizontalDistance, verticalDistance);
+  switch (props.toastPlacement) {
+    case 'top-start':
+      if (props.theme.rtl) {
+        return topRightStyles;
+      }
+      return topLeftStyles;
+    case 'top':
+      return topStyles;
+    case 'top-end':
+      if (props.theme.rtl) {
+        return topLeftStyles;
+      }
+      return topRightStyles;
+    case 'bottom-start':
+      if (props.theme.rtl) {
+        return bottomRightStyles;
+      }
+      return bottomLeftStyles;
+    case 'bottom':
+      return bottomStyles;
+    case 'bottom-end':
+      if (props.theme.rtl) {
+        return bottomLeftStyles;
+      }
+      return bottomRightStyles;
+    default:
+      return '';
+  }
+};
+const StyledTransitionContainer = styled.div.withConfig({
+  displayName: "styled__StyledTransitionContainer",
+  componentId: "sc-nq0usb-1"
+})(["position:fixed;z-index:", ";", ";"], props => props.toastZIndex, placementStyles);
+StyledTransitionContainer.defaultProps = {
+  theme: DEFAULT_THEME
+};
+({
+  limit: PropTypes.number,
+  zIndex: PropTypes.number,
+  placementProps: PropTypes.object
+});
+
+const GlobalAlertContext = reactExports.createContext({
+  type: 'info'
+});
+const useGlobalAlertContext = () => reactExports.useContext(GlobalAlertContext);
+
+const GlobalAlertButton = reactExports.forwardRef((_ref, ref) => {
+  let {
+    isBasic,
+    ...props
+  } = _ref;
+  const {
+    type
+  } = useGlobalAlertContext();
+  return React__default.createElement(StyledGlobalAlertButton, _extends$6({
+    ref: ref,
+    alertType: type
+  }, props, {
+    isPrimary: !isBasic,
+    isBasic: isBasic
+  }));
+});
+GlobalAlertButton.displayName = 'GlobalAlert.Button';
+GlobalAlertButton.propTypes = {
+  isBasic: PropTypes.bool
+};
+
+var _path;
+function _extends() { _extends = Object.assign ? Object.assign.bind() : function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends.apply(this, arguments); }
+var SvgXStroke = function SvgXStroke(props) {
+  return /*#__PURE__*/reactExports.createElement("svg", _extends({
+    xmlns: "http://www.w3.org/2000/svg",
+    width: 16,
+    height: 16,
+    focusable: "false",
+    viewBox: "0 0 16 16",
+    "aria-hidden": "true"
+  }, props), _path || (_path = /*#__PURE__*/reactExports.createElement("path", {
+    stroke: "currentColor",
+    strokeLinecap: "round",
+    d: "M3 13L13 3m0 10L3 3"
+  })));
+};
+
+const GlobalAlertClose = reactExports.forwardRef((props, ref) => {
+  const {
+    type
+  } = useGlobalAlertContext();
+  const label = useText(GlobalAlertClose, props, 'aria-label', 'Close');
+  return React__default.createElement(StyledGlobalAlertClose, _extends$6({
+    ref: ref,
+    alertType: type
+  }, props), React__default.createElement(SvgXStroke, {
+    role: "img",
+    "aria-label": label
+  }));
+});
+GlobalAlertClose.displayName = 'GlobalAlert.Close';
+
+const GlobalAlertContent = reactExports.forwardRef((props, ref) => {
+  return React__default.createElement(StyledGlobalAlertContent, _extends$6({
+    ref: ref
+  }, props));
+});
+GlobalAlertContent.displayName = 'GlobalAlert.Content';
+
+const GlobalAlertTitle = reactExports.forwardRef((props, ref) => {
+  const {
+    type
+  } = useGlobalAlertContext();
+  return React__default.createElement(StyledGlobalAlertTitle, _extends$6({
+    alertType: type,
+    ref: ref
+  }, props));
+});
+GlobalAlertTitle.displayName = 'GlobalAlert.Title';
+GlobalAlertTitle.propTypes = {
+  isRegular: PropTypes.bool
+};
+
+const GlobalAlertComponent = reactExports.forwardRef((_ref, ref) => {
+  let {
+    type,
+    ...props
+  } = _ref;
+  return React__default.createElement(GlobalAlertContext.Provider, {
+    value: reactExports.useMemo(() => ({
+      type
+    }), [type])
+  }, React__default.createElement(StyledGlobalAlert, _extends$6({
+    ref: ref,
+    role: "status",
+    alertType: type
+  }, props), {
+    success: React__default.createElement(StyledGlobalAlertIcon, null, React__default.createElement(SvgCheckCircleStroke, null)),
+    error: React__default.createElement(StyledGlobalAlertIcon, null, React__default.createElement(SvgAlertErrorStroke, null)),
+    warning: React__default.createElement(StyledGlobalAlertIcon, null, React__default.createElement(SvgAlertWarningStroke, null)),
+    info: React__default.createElement(StyledGlobalAlertIcon, null, React__default.createElement(SvgInfoStroke, null))
+  }[type], props.children));
+});
+GlobalAlertComponent.displayName = 'GlobalAlert';
+const GlobalAlert = GlobalAlertComponent;
+GlobalAlert.Button = GlobalAlertButton;
+GlobalAlert.Close = GlobalAlertClose;
+GlobalAlert.Content = GlobalAlertContent;
+GlobalAlert.Title = GlobalAlertTitle;
+GlobalAlert.propTypes = {
+  type: PropTypes.oneOf(TYPE).isRequired
+};
+
+export { Alert as A, Button as B, Combobox as C, DEFAULT_THEME as D, Field$1 as F, Hint$1 as H, Input as I, Label$1 as L, Message$1 as M, Option as O, Textarea as T, Field as a, Label as b, Hint as c, Message as d, ThemeProvider as e, jsxRuntimeExports as j, reactDomExports as r, styled as s };

--- a/assets/vendor.js
+++ b/assets/vendor.js
@@ -20403,4 +20403,4 @@ GlobalAlert.propTypes = {
   type: PropTypes.oneOf(TYPE).isRequired
 };
 
-export { Alert as A, Button as B, Combobox as C, DEFAULT_THEME as D, Field$1 as F, Hint$1 as H, Input as I, Label$1 as L, Message$1 as M, Option as O, Textarea as T, Field as a, Label as b, Hint as c, Message as d, ThemeProvider as e, jsxRuntimeExports as j, reactDomExports as r, styled as s };
+export { Alert as A, Button as B, Combobox as C, DEFAULT_THEME as D, Field$1 as F, Hint$1 as H, Input as I, Label$1 as L, Message$1 as M, Option as O, Textarea as T, Field as a, Label as b, Hint as c, Message as d, reactDomExports as e, ThemeProvider as f, jsxRuntimeExports as j, reactExports as r, styled as s };

--- a/package.json
+++ b/package.json
@@ -13,8 +13,10 @@
   },
   "dependencies": {
     "@zendesk/zcli": "^1.0.0-beta.35",
+    "@zendeskgarden/react-buttons": "^8.69.1",
     "@zendeskgarden/react-dropdowns.next": "^8.69.1",
     "@zendeskgarden/react-forms": "^8.69.1",
+    "@zendeskgarden/react-notifications": "^8.69.1",
     "@zendeskgarden/react-theming": "^8.69.1",
     "node-fetch": "2.6.9",
     "react": "^17.0.2",
@@ -34,6 +36,7 @@
     "@semantic-release/git": "10.0.1",
     "@types/react": "^17.0.62",
     "@types/react-dom": "^17.0.20",
+    "@types/styled-components": "^5.1.26",
     "@typescript-eslint/eslint-plugin": "^6.1.0",
     "@typescript-eslint/parser": "^6.1.0",
     "concurrently": "8.0.1",
@@ -56,6 +59,9 @@
     "typescript": "^5.1.6",
     "url-pattern": "1.0.3",
     "wait-on": "7.0.1"
+  },
+  "resolutions": {
+    "@types/react": "^17.0.62"
   },
   "commitlint": {
     "extends": [

--- a/src/modules/new-request-form/NewRequestForm.tsx
+++ b/src/modules/new-request-form/NewRequestForm.tsx
@@ -3,10 +3,10 @@ import { TextInput } from "./fields/TextInput";
 import { TextArea } from "./fields/TextArea";
 import { DropDown } from "./fields/DropDown";
 import { TicketFormField } from "./ticket-form-field/TicketFormField";
-import type { FormEventHandler } from "react";
 import { Button } from "@zendeskgarden/react-buttons";
 import styled from "styled-components";
 import { Alert } from "@zendeskgarden/react-notifications";
+import { useSubmitHandler } from "./useSubmitHandler";
 
 export interface NewRequestFormProps {
   ticketForms: TicketForm[];
@@ -36,29 +36,7 @@ export function NewRequestForm({
     ticket_form_field,
     ticket_forms_instructions,
   } = requestForm;
-
-  // NOTE: This is a temporary handling of the CSRF token
-  const fetchCsrfToken = async () => {
-    const response = await fetch("/hc/api/internal/csrf_token.json");
-    const { current_session } = await response.json();
-    return current_session.csrf_token as string;
-  };
-
-  const handleSubmit: FormEventHandler<HTMLFormElement> = (e) => {
-    e.preventDefault();
-
-    const form = e.target as HTMLFormElement;
-
-    fetchCsrfToken().then((token) => {
-      const hiddenInput = document.createElement("input");
-      hiddenInput.type = "hidden";
-      hiddenInput.name = "authenticity_token";
-      hiddenInput.value = token;
-      form.appendChild(hiddenInput);
-      form.submit();
-      form.removeChild(hiddenInput);
-    });
-  };
+  const handleSubmit = useSubmitHandler();
 
   return (
     <Form

--- a/src/modules/new-request-form/NewRequestForm.tsx
+++ b/src/modules/new-request-form/NewRequestForm.tsx
@@ -13,7 +13,7 @@ export interface NewRequestFormProps {
   requestForm: RequestForm;
 }
 
-const StyledForm = styled.form`
+const Form = styled.form`
   display: flex;
   flex-direction: column;
   gap: ${(props) => props.theme.space.md};
@@ -61,7 +61,7 @@ export function NewRequestForm({
   };
 
   return (
-    <StyledForm
+    <Form
       action={action}
       method={http_method}
       acceptCharset={accept_charset}
@@ -95,6 +95,6 @@ export function NewRequestForm({
           </Button>
         )}
       </Footer>
-    </StyledForm>
+    </Form>
   );
 }

--- a/src/modules/new-request-form/NewRequestForm.tsx
+++ b/src/modules/new-request-form/NewRequestForm.tsx
@@ -3,11 +3,25 @@ import { TextInput } from "./fields/TextInput";
 import { TextArea } from "./fields/TextArea";
 import { DropDown } from "./fields/DropDown";
 import { TicketFormField } from "./ticket-form-field/TicketFormField";
+import type { FormEventHandler } from "react";
+import { Button } from "@zendeskgarden/react-buttons";
+import styled from "styled-components";
+import { Alert } from "@zendeskgarden/react-notifications";
 
 export interface NewRequestFormProps {
   ticketForms: TicketForm[];
   requestForm: RequestForm;
 }
+
+const StyledForm = styled.form`
+  display: flex;
+  flex-direction: column;
+  gap: ${(props) => props.theme.space.md};
+`;
+
+const Footer = styled.div`
+  margin-top: ${(props) => props.theme.space.md};
+`;
 
 export function NewRequestForm({
   ticketForms,
@@ -18,12 +32,43 @@ export function NewRequestForm({
     action,
     http_method,
     accept_charset,
+    errors,
     ticket_form_field,
     ticket_forms_instructions,
   } = requestForm;
 
+  // NOTE: This is a temporary handling of the CSRF token
+  const fetchCsrfToken = async () => {
+    const response = await fetch("/hc/api/internal/csrf_token.json");
+    const { current_session } = await response.json();
+    return current_session.csrf_token as string;
+  };
+
+  const handleSubmit: FormEventHandler<HTMLFormElement> = (e) => {
+    e.preventDefault();
+
+    const form = e.target as HTMLFormElement;
+
+    fetchCsrfToken().then((token) => {
+      const hiddenInput = document.createElement("input");
+      hiddenInput.type = "hidden";
+      hiddenInput.name = "authenticity_token";
+      hiddenInput.value = token;
+      form.appendChild(hiddenInput);
+      form.submit();
+      form.removeChild(hiddenInput);
+    });
+  };
+
   return (
-    <form action={action} method={http_method} acceptCharset={accept_charset}>
+    <StyledForm
+      action={action}
+      method={http_method}
+      acceptCharset={accept_charset}
+      noValidate
+      onSubmit={handleSubmit}
+    >
+      {errors && <Alert type="error">{errors}</Alert>}
       <TicketFormField
         label={ticket_forms_instructions}
         ticketFormField={ticket_form_field}
@@ -43,6 +88,13 @@ export function NewRequestForm({
             return <></>;
         }
       })}
-    </form>
+      <Footer>
+        {ticket_form_field.value && (
+          <Button isPrimary type="submit">
+            Submit
+          </Button>
+        )}
+      </Footer>
+    </StyledForm>
   );
 }

--- a/src/modules/new-request-form/fields/TextArea.tsx
+++ b/src/modules/new-request-form/fields/TextArea.tsx
@@ -19,7 +19,7 @@ export function TextArea({ field }: TextAreaProps): JSX.Element {
       {description && <Hint>{description}</Hint>}
       <Textarea
         name={name}
-        value={value}
+        defaultValue={value}
         validation={error ? "error" : undefined}
         required={required}
       />

--- a/src/modules/new-request-form/fields/TextInput.tsx
+++ b/src/modules/new-request-form/fields/TextInput.tsx
@@ -19,7 +19,7 @@ export function TextInput({ field }: TextInputProps): JSX.Element {
       {description && <Hint>{description}</Hint>}
       <Input
         name={name}
-        value={value}
+        defaultValue={value}
         validation={error ? "error" : undefined}
         required={required}
       />

--- a/src/modules/new-request-form/useSubmitHandler.tsx
+++ b/src/modules/new-request-form/useSubmitHandler.tsx
@@ -1,0 +1,40 @@
+import { useRef, type FormEventHandler } from "react";
+
+// NOTE: This is a temporary handling of the CSRF token
+const fetchCsrfToken = async () => {
+  const response = await fetch("/hc/api/internal/csrf_token.json");
+  const { current_session } = await response.json();
+  return current_session.csrf_token as string;
+};
+
+/**
+ * This hook creates an event handler for form submits, fetching the CSRF token
+ * from the backend and appending it to the form
+ * @returns a Submit Event Handler function
+ */
+export function useSubmitHandler(): FormEventHandler<HTMLFormElement> {
+  const isSubmitting = useRef(false);
+
+  return async (e) => {
+    e.preventDefault();
+
+    /* We are performing an async call to fetch the CSRF token and for this reason
+       the submit is not immediate, and the user can click the submit button multiple times.
+       We don't want to disable the submit button for A11Y, so we use the isSubmitting ref 
+       to stop subsequent submits after the first one. */
+    if (isSubmitting.current === false) {
+      isSubmitting.current = true;
+
+      const form = e.target as HTMLFormElement;
+
+      const token = await fetchCsrfToken();
+      const hiddenInput = document.createElement("input");
+      hiddenInput.type = "hidden";
+      hiddenInput.name = "authenticity_token";
+      hiddenInput.value = token;
+      form.appendChild(hiddenInput);
+
+      form.submit();
+    }
+  };
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -117,7 +117,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.22.5"
 
-"@babel/runtime@^7.1.2", "@babel/runtime@^7.14.8", "@babel/runtime@^7.17.8", "@babel/runtime@^7.8.4":
+"@babel/runtime@^7.1.2", "@babel/runtime@^7.14.8", "@babel/runtime@^7.17.8", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7":
   version "7.22.6"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.22.6.tgz#57d64b9ae3cff1d67eb067ae117dac087f5bd438"
   integrity sha512-wDb5pWm4WDdF6LFUde3Jl8WzPA+3ZbxYqkC6xAXuD3irdEHN1k0NfTRrJD8ZD378SJ61miMLCqIOXYhd8x+AJQ==
@@ -1270,6 +1270,14 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
   integrity sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
 
+"@types/hoist-non-react-statics@*":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
+  integrity sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==
+  dependencies:
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
+
 "@types/inquirer@^8.0.0":
   version "8.2.6"
   resolved "https://registry.yarnpkg.com/@types/inquirer/-/inquirer-8.2.6.tgz#abd41a5fb689c7f1acb12933d787d4262a02a0ab"
@@ -1320,7 +1328,7 @@
   dependencies:
     "@types/react" "^17"
 
-"@types/react@^17", "@types/react@^17.0.62":
+"@types/react@*", "@types/react@^17", "@types/react@^17.0.62":
   version "17.0.62"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.62.tgz#2efe8ddf8533500ec44b1334dd1a97caa2f860e3"
   integrity sha512-eANCyz9DG8p/Vdhr0ZKST8JV12PhH2ACCDYlFw6DIO+D+ca+uP4jtEDEpVqXZrh/uZdXQGwk7whJa3ah5DtyLw==
@@ -1343,6 +1351,15 @@
   version "7.5.0"
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.5.0.tgz#591c1ce3a702c45ee15f47a42ade72c2fd78978a"
   integrity sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==
+
+"@types/styled-components@^5.1.26":
+  version "5.1.26"
+  resolved "https://registry.yarnpkg.com/@types/styled-components/-/styled-components-5.1.26.tgz#5627e6812ee96d755028a98dae61d28e57c233af"
+  integrity sha512-KuKJ9Z6xb93uJiIyxo/+ksS7yLjS1KzG6iv5i78dhVg/X3u5t1H7juRWqVmodIdz6wGVaIApo1u01kmFRdJHVw==
+  dependencies:
+    "@types/hoist-non-react-statics" "*"
+    "@types/react" "*"
+    csstype "^3.0.2"
 
 "@types/through@*":
   version "0.0.30"
@@ -1548,6 +1565,14 @@
   dependencies:
     "@babel/runtime" "^7.8.4"
 
+"@zendeskgarden/container-selection@^3.0.0":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-selection/-/container-selection-3.0.2.tgz#82befe2acb10100c416b61d7b222cfb25bcfd07e"
+  integrity sha512-y65jm0zkyEfJBU90K71TNf10yF0Krfe/qJqkjnXZoGx6qnKfj7zZbCrV3n4ktldsueQZBBTn48rYUJJt58x02g==
+  dependencies:
+    "@babel/runtime" "^7.8.4"
+    "@zendeskgarden/container-utilities" "^1.0.8"
+
 "@zendeskgarden/container-slider@^0.1.1":
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/@zendeskgarden/container-slider/-/container-slider-0.1.6.tgz#3ffa975059ea5263f3f99b27b91e1f411fe7b515"
@@ -1572,6 +1597,25 @@
   dependencies:
     "@babel/runtime" "^7.8.4"
     "@reach/auto-id" "^0.18.0"
+
+"@zendeskgarden/container-utilities@^1.0.8":
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/container-utilities/-/container-utilities-1.0.8.tgz#c2e59d355080cfcb2b9a516c53ddda604e9b34fc"
+  integrity sha512-7ERJtrnaVUD+qOnp8XTlofuV67+j5XleVRXJy1QmVi/Yy/usqjcCFpMosZnYVMgDHmJgvHomUyqTNvKdgqwfrg==
+  dependencies:
+    "@babel/runtime" "^7.8.4"
+    "@reach/auto-id" "^0.18.0"
+
+"@zendeskgarden/react-buttons@^8.69.1", "@zendeskgarden/react-buttons@^8.69.5":
+  version "8.69.5"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-buttons/-/react-buttons-8.69.5.tgz#71e79ad5a77de7f964f11195756c97ad3604989b"
+  integrity sha512-KP/RacKOJZIDNnDznOhUBqbg51Op171HVR9LFNmfpfiz0jWyw7Zj6BWX4weIcquYXWTJy2SiCmrRWZN2jOeueA==
+  dependencies:
+    "@zendeskgarden/container-selection" "^3.0.0"
+    "@zendeskgarden/container-utilities" "^1.0.6"
+    polished "^4.0.0"
+    prop-types "^15.5.7"
+    react-merge-refs "^1.1.0"
 
 "@zendeskgarden/react-dropdowns.next@^8.69.1":
   version "8.69.1"
@@ -1600,6 +1644,17 @@
     polished "^4.0.0"
     prop-types "^15.5.7"
     react-merge-refs "^1.1.0"
+
+"@zendeskgarden/react-notifications@^8.69.1":
+  version "8.69.5"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-notifications/-/react-notifications-8.69.5.tgz#304c1e69781d4ae030f321639643565c9ef63a9e"
+  integrity sha512-e65xK1gw9YCTnVm/Sn8BBoXGrzIK9gLdkJojz0//db2HIpU5sELmJIsOCVIGD52x9eFYKkiM7m71bamqUWRxXA==
+  dependencies:
+    "@zendeskgarden/react-buttons" "^8.69.5"
+    polished "^4.1.1"
+    prop-types "^15.5.7"
+    react-transition-group "^4.4.2"
+    react-uid "^2.3.1"
 
 "@zendeskgarden/react-tags@^8.69.1":
   version "8.69.1"
@@ -2894,6 +2949,14 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
+dom-helpers@^5.0.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-5.2.1.tgz#d9400536b2bf8225ad98fe052e029451ac40e902"
+  integrity sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==
+  dependencies:
+    "@babel/runtime" "^7.8.7"
+    csstype "^3.0.2"
+
 dot-prop@^5.1.0, dot-prop@^5.2.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-5.3.0.tgz#90ccce708cd9cd82cc4dc8c3ddd9abdd55b20e88"
@@ -3949,7 +4012,7 @@ has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
-hoist-non-react-statics@^3.0.0:
+hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.3.0:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -6167,7 +6230,7 @@ pkg-conf@^2.1.0:
     find-up "^2.0.0"
     load-json-file "^4.0.0"
 
-polished@^4.0.0:
+polished@^4.0.0, polished@^4.1.1:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/polished/-/polished-4.2.2.tgz#2529bb7c3198945373c52e34618c8fe7b1aa84d1"
   integrity sha512-Sz2Lkdxz6F2Pgnpi9U5Ng/WdWAUZxmHrNPoVlm3aAemxoy2Qy7LGjQg4uf8qKelDAUW94F4np3iH2YPf2qefcQ==
@@ -6272,7 +6335,7 @@ promzard@^0.3.0:
   dependencies:
     read "1"
 
-prop-types@^15.5.7, prop-types@^15.6.1, prop-types@^15.7.2, prop-types@^15.8.1:
+prop-types@^15.5.7, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -6450,7 +6513,17 @@ react-popper@^1.3.4:
     typed-styles "^0.0.7"
     warning "^4.0.2"
 
-react-uid@^2.2.0:
+react-transition-group@^4.4.2:
+  version "4.4.5"
+  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.5.tgz#e53d4e3f3344da8521489fbef8f2581d42becdd1"
+  integrity sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    dom-helpers "^5.0.1"
+    loose-envify "^1.4.0"
+    prop-types "^15.6.2"
+
+react-uid@^2.2.0, react-uid@^2.3.1:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/react-uid/-/react-uid-2.3.3.tgz#6a485ccc868555997f3506c6db97a3e735d97adf"
   integrity sha512-iNpDovcb9qBpBTo8iUgqRSQOS8GV3bWoNaTaUptHkXtAooXSo0OWe7vN6TqqB8x3x0bNBbQx96kkmSltQ5h9kQ==


### PR DESCRIPTION
## Description

This PR adds the possibility to submit the New Request Form.
- Added a Submit button rendered with Garden
- Added logic to fetch the CSRF token before submitting the form.
   - The logic should be more or less the same on the current implementation: the token is fetched just before submitting the form and appended as a hidden input. I didn't find a more "React-ish" version to do it, but I think it is fine
   - We are temporarily using the internal endpoint
- Changed `TextInput` and `TextArea` components, using `defaultValue` instead of `value`. In this way, they are considered uncontrolled components by React. Without this change, it was impossible to change the value once a value was set by the template data
- Added an `Alert` component for displaying any eventual global error on top of the form
- Minor UI improvements

## Screenshots

https://github.com/zendesk/copenhagen_theme/assets/13420283/c19aba69-7d0f-4ae1-9f0c-ee645a4211de


## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->