### PR TITLE
fix: fixed request page organization dropdown on mobile

### DIFF
--- a/script.js
+++ b/script.js
@@ -640,6 +640,11 @@
       requestOrganisationSelect.addEventListener("change", () => {
         requestOrganisationSelect.form.submit();
       });
+
+      requestOrganisationSelect.addEventListener("click", (e) => {
+        // Prevents Ticket details collapsible-sidebar to close on mobile
+        e.stopPropagation();
+      });
     }
 
     // If there are any error notifications below an input field, focus that field

--- a/src/forms.js
+++ b/src/forms.js
@@ -149,6 +149,11 @@ window.addEventListener("DOMContentLoaded", () => {
     requestOrganisationSelect.addEventListener("change", () => {
       requestOrganisationSelect.form.submit();
     });
+
+    requestOrganisationSelect.addEventListener("click", (e) => {
+      // Prevents Ticket details collapsible-sidebar to close on mobile
+      e.stopPropagation();
+    });
   }
 
   // If there are any error notifications below an input field, focus that field


### PR DESCRIPTION
## Description

This PR fixes a long-standing issue with the organization dropdown on the Request page, which was impossible to use on mobile. When the user tried to interact with the dropdown, the collapsible sidebar closed itself, preventing the user to select a value.

This fix simply stops the propagation of the click event from the dropdown, to prevent the sidebar to close

## Screenshots

Before:

https://github.com/zendesk/copenhagen_theme/assets/13420283/728f52b5-0531-40a8-a03d-3c166b4d6aca

After

https://github.com/zendesk/copenhagen_theme/assets/13420283/7426a8e5-5a0a-499c-a389-925a746d78e8


<!-- (optional) when applicable, please include some screenshots or gifs that illustrate the changes -->

## Checklist

- [x] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [x] :arrow_left: changes are compatible with RTL direction
- [x] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [x] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [x] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->