### PR TITLE
feat: add follow-up string to request form header

### DIFF
--- a/templates/new_request_page.hbs
+++ b/templates/new_request_page.hbs
@@ -12,6 +12,11 @@
 
   <h1>
     {{t 'submit_a_request'}}
+    {{#if parent_id}}
+      <span class="follow-up-hint">
+        Follow-up to <a href="{{page_path 'request' id=parent_id}}">request #{{parent_id}}</a>
+      </span>
+    {{/if}}
   </h1>
 
   <div id="main-content" class="form">


### PR DESCRIPTION
## Description

Adding a follow-up string to the header of the new request page.

## Screenshots

https://github.com/zendesk/copenhagen_theme/assets/25595674/001bbefc-1f37-4eb4-8d7f-237c03207e62


## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->