### PR TITLE
feat: add parent id hidden input field

### DIFF
--- a/assets/new-request-form.js
+++ b/assets/new-request-form.js
@@ -33,6 +33,11 @@ function TicketFormField({ label, ticketFormField, ticketForms, }) {
     return (jsxRuntimeExports.jsxs(jsxRuntimeExports.Fragment, { children: [jsxRuntimeExports.jsx("input", { type: "hidden", name: ticketFormField.name, value: ticketFormField.value }), ticketForms.length > 1 && (jsxRuntimeExports.jsxs(Field$1, { children: [jsxRuntimeExports.jsx(Label, { children: label }), jsxRuntimeExports.jsx(Combobox, { isEditable: false, onChange: handleChange, children: ticketForms.map(({ id, url, display_name }) => (jsxRuntimeExports.jsx(Option, { value: url, label: display_name, isSelected: ticketFormField.value === id, children: display_name }, id))) })] }))] }));
 }
 
+function ParentTicketField({ field }) {
+    const { value, name } = field;
+    return (jsxRuntimeExports.jsx(jsxRuntimeExports.Fragment, { children: jsxRuntimeExports.jsx("input", { type: "hidden", name: name, value: value }) }));
+}
+
 // NOTE: This is a temporary handling of the CSRF token
 const fetchCsrfToken = async () => {
     const response = await fetch("/hc/api/internal/csrf_token.json");
@@ -74,10 +79,10 @@ const Form = styled.form `
 const Footer = styled.div `
   margin-top: ${(props) => props.theme.space.md};
 `;
-function NewRequestForm({ ticketForms, requestForm, }) {
-    const { fields, action, http_method, accept_charset, errors, ticket_form_field, ticket_forms_instructions, } = requestForm;
+function NewRequestForm({ ticketForms, requestForm, parentId }) {
+    const { fields, action, http_method, accept_charset, errors, ticket_form_field, ticket_forms_instructions, parent_id_field, } = requestForm;
     const handleSubmit = useSubmitHandler();
-    return (jsxRuntimeExports.jsxs(Form, { action: action, method: http_method, acceptCharset: accept_charset, noValidate: true, onSubmit: handleSubmit, children: [errors && jsxRuntimeExports.jsx(Alert, { type: "error", children: errors }), ticketForms.length > 0 && (jsxRuntimeExports.jsx(TicketFormField, { label: ticket_forms_instructions, ticketFormField: ticket_form_field, ticketForms: ticketForms })), fields.map((field) => {
+    return (jsxRuntimeExports.jsxs(Form, { action: action, method: http_method, acceptCharset: accept_charset, noValidate: true, onSubmit: handleSubmit, children: [errors && jsxRuntimeExports.jsx(Alert, { type: "error", children: errors }), parentId && (jsxRuntimeExports.jsx(ParentTicketField, { field: parent_id_field })), ticketForms.length > 0 && (jsxRuntimeExports.jsx(TicketFormField, { label: ticket_forms_instructions, ticketFormField: ticket_form_field, ticketForms: ticketForms })), fields.map((field) => {
                 switch (field.type) {
                     case "anonymous_requester_email":
                     case "subject":

--- a/src/modules/new-request-form/NewRequestForm.tsx
+++ b/src/modules/new-request-form/NewRequestForm.tsx
@@ -3,6 +3,7 @@ import { TextInput } from "./fields/TextInput";
 import { TextArea } from "./fields/TextArea";
 import { DropDown } from "./fields/DropDown";
 import { TicketFormField } from "./ticket-form-field/TicketFormField";
+import { ParentTicketField } from "./parent-ticket-field/ParentTicketField";
 import { Button } from "@zendeskgarden/react-buttons";
 import styled from "styled-components";
 import { Alert } from "@zendeskgarden/react-notifications";
@@ -11,6 +12,7 @@ import { useSubmitHandler } from "./useSubmitHandler";
 export interface NewRequestFormProps {
   ticketForms: TicketForm[];
   requestForm: RequestForm;
+  parentId: string;
 }
 
 const Form = styled.form`
@@ -26,6 +28,7 @@ const Footer = styled.div`
 export function NewRequestForm({
   ticketForms,
   requestForm,
+  parentId
 }: NewRequestFormProps) {
   const {
     fields,
@@ -35,6 +38,7 @@ export function NewRequestForm({
     errors,
     ticket_form_field,
     ticket_forms_instructions,
+    parent_id_field,
   } = requestForm;
   const handleSubmit = useSubmitHandler();
 
@@ -47,6 +51,9 @@ export function NewRequestForm({
       onSubmit={handleSubmit}
     >
       {errors && <Alert type="error">{errors}</Alert>}
+      {parentId && (
+        <ParentTicketField field={parent_id_field} />
+      )}
       {ticketForms.length > 0 && (
         <TicketFormField
           label={ticket_forms_instructions}

--- a/src/modules/new-request-form/data-types/RequestForm.tsx
+++ b/src/modules/new-request-form/data-types/RequestForm.tsx
@@ -7,5 +7,6 @@ export interface RequestForm {
   errors: string | null;
   ticket_forms_instructions: string;
   ticket_form_field: Field;
+  parent_id_field: Field;
   fields: Field[];
 }

--- a/src/modules/new-request-form/parent-ticket-field/ParentTicketField.tsx
+++ b/src/modules/new-request-form/parent-ticket-field/ParentTicketField.tsx
@@ -7,12 +7,10 @@ interface ParentTicketFieldProps {
 export function ParentTicketField({ field }: ParentTicketFieldProps): JSX.Element {
   const { value, name } = field;
   return (
-    <>
-      <input
-          type="hidden"
-          name={name}
-          value={value}
-      />
-    </>
+    <input
+      type="hidden"
+      name={name}
+      value={value}
+    />
   );
 }

--- a/src/modules/new-request-form/parent-ticket-field/ParentTicketField.tsx
+++ b/src/modules/new-request-form/parent-ticket-field/ParentTicketField.tsx
@@ -1,0 +1,18 @@
+import type { Field } from "../data-types";
+
+interface ParentTicketFieldProps {
+  field: Field;
+}
+
+export function ParentTicketField({ field }: ParentTicketFieldProps): JSX.Element {
+  const { value, name } = field;
+  return (
+    <>
+      <input
+          type="hidden"
+          name={name}
+          value={value}
+      />
+    </>
+  );
+}

--- a/templates/new_request_page.hbs
+++ b/templates/new_request_page.hbs
@@ -30,7 +30,9 @@
     {{id}}, url: "{{url}}", display_name: "{{display_name}}" });
   {{/each}}
 
+  const parentId = "{{ parent_id }}";
+
   const container = document.getElementById("new-request-form");
-  const props = { ticketForms, requestForm };
+  const props = { ticketForms, requestForm, parentId };
   renderNewRequestForm(props, container);
 </script>


### PR DESCRIPTION
## Description

Adding a hidden input field that contains the value of parent id (added only if the request is a follow-up to a previous ticket).

This change relies on both:
* https://github.com/zendesk/help_center/pull/27885
* https://github.com/zendesk/help_center/pull/27895

## Screenshots

<img width="1111" alt="Screenshot 2023-08-14 at 14 27 41" src="https://github.com/zendesk/copenhagen_theme/assets/25595674/3553452c-d303-4cd2-a7a7-4aecfbf9fec5">

----

<img width="1425" alt="Screenshot 2023-08-14 at 14 28 26" src="https://github.com/zendesk/copenhagen_theme/assets/25595674/12ec1a8c-f5e5-46e1-9052-76f2106dda83">


## Checklist

- [x] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [x] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->