### PR TITLE
[A11y] Make "Was this article helpful?" a `h2`

### DIFF
--- a/style.css
+++ b/style.css
@@ -1856,6 +1856,11 @@ ul {
   padding: 30px 0;
   text-align: center;
 }
+.article-votes-question {
+  font-size: 15px;
+  font-weight: normal;
+  margin-bottom: 0;
+}
 .article-vote {
   margin: 10px 5px;
   min-width: 90px;

--- a/styles/_article.scss
+++ b/styles/_article.scss
@@ -159,6 +159,12 @@
     border-top: 1px solid $low-contrast-border-color;
     padding: 30px 0;
     text-align: center;
+
+    &-question { // Explicit values for rendering h2 like a span for accessibility.
+      font-size: $font-size-base;
+      font-weight: normal;
+      margin-bottom: 0;
+    }
   }
 
   &-vote {

--- a/templates/article_page.hbs
+++ b/templates/article_page.hbs
@@ -148,7 +148,7 @@
         </div>
         {{#with article}}
           <div class="article-votes">
-            <span class="article-votes-question" id="article-votes-label">{{t 'was_this_article_helpful'}}</span>
+            <h2 class="article-votes-question" id="article-votes-label">{{t 'was_this_article_helpful'}}</h2>
             <div class="article-votes-controls" role="group" aria-labelledby="article-votes-label">
               {{vote 'up' class='button article-vote article-vote-up' selected_class="button-primary"}}
               {{vote 'down' class='button article-vote article-vote-down' selected_class="button-primary"}}


### PR DESCRIPTION
## Description

> When a page uses heading markup that does not match the information communicated visually by the heading screen reader users may not understand the content of the page.

This PR changes the `span` tag for the "Was this article helpful?" string to an `h2` tag, as well as the styling required to make this change seamless.

## Checklist

- [x] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [x] :arrow_left: changes are compatible with RTL direction
- [x] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [x] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [x] :iphone: changes are responsive and tested in mobile
- [x] :+1: PR is approved by @zendesk/vikings