### PR TITLE
Rendering custom fields

### DIFF
--- a/assets/new-request-form.js
+++ b/assets/new-request-form.js
@@ -1,9 +1,14 @@
-import { j as jsxRuntimeExports, F as Field, L as Label$1, H as Hint, I as Input, M as Message, T as Textarea, a as Field$1, b as Label, c as Hint$1, C as Combobox, O as Option, d as Message$1, r as reactExports, s as styled, A as Alert, B as Button, e as reactDomExports } from 'vendor';
+import { j as jsxRuntimeExports, F as Field, L as Label$1, H as Hint, I as Input$1, M as Message, T as Textarea, a as Field$1, b as Label, c as Hint$1, C as Combobox, O as Option, d as Message$1, r as reactExports, s as styled, A as Alert, B as Button, e as reactDomExports } from 'vendor';
 import { ComponentProviders } from 'shared';
 
-function TextInput({ field }) {
-    const { label, error, value, name, required, description } = field;
-    return (jsxRuntimeExports.jsxs(Field, { children: [jsxRuntimeExports.jsx(Label$1, { children: label }), description && jsxRuntimeExports.jsx(Hint, { children: description }), jsxRuntimeExports.jsx(Input, { name: name, defaultValue: value, validation: error ? "error" : undefined, required: required }), error && jsxRuntimeExports.jsx(Message, { validation: "error", children: error })] }));
+function Input({ field }) {
+    const { label, error, value, name, required, description, type } = field;
+    const stepProp = {};
+    if (type === "integer")
+        stepProp.step = "1";
+    if (type === "decimal")
+        stepProp.step = "any";
+    return (jsxRuntimeExports.jsxs(Field, { children: [jsxRuntimeExports.jsx(Label$1, { children: label }), description && jsxRuntimeExports.jsx(Hint, { children: description }), jsxRuntimeExports.jsx(Input$1, { name: name, type: type === "text" ? "text" : "number", defaultValue: value, validation: error ? "error" : undefined, required: required, ...stepProp }), error && jsxRuntimeExports.jsx(Message, { validation: "error", children: error })] }));
 }
 
 function TextArea({ field }) {
@@ -86,7 +91,7 @@ function NewRequestForm({ ticketForms, requestForm, }) {
                     case "decimal":
                     case "regexp":
                     case "partialcreditcard":
-                        return jsxRuntimeExports.jsx(TextInput, { field: field });
+                        return jsxRuntimeExports.jsx(Input, { field: field });
                     case "description":
                     case "textarea":
                         return jsxRuntimeExports.jsx(TextArea, { field: field });

--- a/assets/new-request-form.js
+++ b/assets/new-request-form.js
@@ -81,7 +81,11 @@ function NewRequestForm({ ticketForms, requestForm, }) {
                 switch (field.type) {
                     case "anonymous_requester_email":
                     case "subject":
+                    case "text":
+                    case "integer":
+                    case "decimal":
                     case "regexp":
+                    case "partialcreditcard":
                         return jsxRuntimeExports.jsx(TextInput, { field: field });
                     case "description":
                     case "textarea":
@@ -90,6 +94,14 @@ function NewRequestForm({ ticketForms, requestForm, }) {
                     case "organization_id":
                     case "tickettype":
                         return jsxRuntimeExports.jsx(DropDown, { field: field });
+                    case "checkbox":
+                        return jsxRuntimeExports.jsx("div", { children: "checkbox" });
+                    case "date":
+                        return jsxRuntimeExports.jsx("div", { children: "date" });
+                    case "multiselect":
+                        return jsxRuntimeExports.jsx("div", { children: "multiselect" });
+                    case "tagger":
+                        return jsxRuntimeExports.jsx("div", { children: "tagger" });
                     default:
                         return jsxRuntimeExports.jsx(jsxRuntimeExports.Fragment, {});
                 }

--- a/src/modules/new-request-form/NewRequestForm.tsx
+++ b/src/modules/new-request-form/NewRequestForm.tsx
@@ -1,5 +1,5 @@
 import type { RequestForm, TicketForm } from "./data-types";
-import { TextInput } from "./fields/TextInput";
+import { Input } from "./fields/Input";
 import { TextArea } from "./fields/TextArea";
 import { DropDown } from "./fields/DropDown";
 import { TicketFormField } from "./ticket-form-field/TicketFormField";
@@ -63,7 +63,7 @@ export function NewRequestForm({
           case "decimal":
           case "regexp":
           case "partialcreditcard":
-            return <TextInput field={field} />;
+            return <Input field={field} />;
           case "description":
           case "textarea":
             return <TextArea field={field} />;

--- a/src/modules/new-request-form/NewRequestForm.tsx
+++ b/src/modules/new-request-form/NewRequestForm.tsx
@@ -58,7 +58,11 @@ export function NewRequestForm({
         switch (field.type) {
           case "anonymous_requester_email":
           case "subject":
+          case "text":
+          case "integer":
+          case "decimal":
           case "regexp":
+          case "partialcreditcard":
             return <TextInput field={field} />;
           case "description":
           case "textarea":
@@ -67,6 +71,14 @@ export function NewRequestForm({
           case "organization_id":
           case "tickettype":
             return <DropDown field={field} />;
+          case "checkbox":
+            return <div>checkbox</div>;
+          case "date":
+            return <div>date</div>;
+          case "multiselect":
+            return <div>multiselect</div>;
+          case "tagger":
+            return <div>tagger</div>;
           default:
             return <></>;
         }

--- a/src/modules/new-request-form/fields/Input.tsx
+++ b/src/modules/new-request-form/fields/Input.tsx
@@ -1,27 +1,34 @@
 import {
   Field as GardenField,
   Hint,
-  Input,
+  Input as GardenInput,
   Label,
   Message,
 } from "@zendeskgarden/react-forms";
 import type { Field } from "../data-types";
 
-interface TextInputProps {
+interface InputProps {
   field: Field;
 }
 
-export function TextInput({ field }: TextInputProps): JSX.Element {
-  const { label, error, value, name, required, description } = field;
+export function Input({ field }: InputProps): JSX.Element {
+  const { label, error, value, name, required, description, type } = field;
+  const stepProp: { step?: string } = {};
+
+  if (type === "integer") stepProp.step = "1";
+  if (type === "decimal") stepProp.step = "any";
+
   return (
     <GardenField>
       <Label>{label}</Label>
       {description && <Hint>{description}</Hint>}
-      <Input
+      <GardenInput
         name={name}
+        type={type === "text" ? "text" : "number"}
         defaultValue={value}
         validation={error ? "error" : undefined}
         required={required}
+        {...stepProp}
       />
       {error && <Message validation="error">{error}</Message>}
     </GardenField>


### PR DESCRIPTION
## Description

Adding missing custom field types.
`checkbox`, `date`, `multiselect` and `tagger` to be handled in following PRs.

## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->