### PR TITLE
[GG-3284] Render a multiselect field with Garden in the CPH Theme

### DIFF
--- a/assets/CcField.js
+++ b/assets/CcField.js
@@ -1,4 +1,4 @@
-import { r as reactExports, u as useGrid, j as jsxRuntimeExports, F as Field, L as Label$1, H as Hint, i as Tag, M as Message, s as styled, k as focusStyles, l as hideVisually, m as FauxInput, N as Ne, n as getLineHeight, I as Input } from 'vendor';
+import { r as reactExports, u as useGrid, j as jsxRuntimeExports, F as Field, L as Label$1, H as Hint, k as Tag, M as Message, s as styled, l as focusStyles, m as hideVisually, n as FauxInput, N as Ne, o as getLineHeight, I as Input } from 'vendor';
 
 function useTagsInputContainer({ tags, onTagsChange, inputValue, onInputValueChange, inputRef, gridRowRef, i18n, }) {
     const [selectedIndex, setSelectedIndex] = reactExports.useState(0);

--- a/assets/DatePicker.js
+++ b/assets/DatePicker.js
@@ -1,4 +1,4 @@
-import { r as reactExports, j as jsxRuntimeExports, F as Field, L as Label$1, H as Hint, h as Datepicker, I as Input, M as Message } from 'vendor';
+import { r as reactExports, j as jsxRuntimeExports, F as Field, L as Label$1, H as Hint, i as Datepicker, I as Input, M as Message } from 'vendor';
 
 function DatePicker({ field, locale, valueFormat, }) {
     const { label, error, value, name, required, description } = field;

--- a/assets/shared.js
+++ b/assets/shared.js
@@ -1,4 +1,4 @@
-import { D as DEFAULT_THEME, j as jsxRuntimeExports, g as ThemeProvider } from 'vendor';
+import { D as DEFAULT_THEME, j as jsxRuntimeExports, h as ThemeProvider } from 'vendor';
 
 let theme = DEFAULT_THEME;
 function setupGardenTheme(callback) {

--- a/assets/vendor.js
+++ b/assets/vendor.js
@@ -26545,4 +26545,4 @@ function useGrid(_ref) {
   environment: PropTypes.any
 });
 
-export { Alert as A, Button as B, Combobox as C, DEFAULT_THEME as D, Field$1 as F, Hint$1 as H, Input as I, Label$1 as L, Message$1 as M, Ne as N, Option as O, Textarea as T, Field as a, Label as b, Hint as c, Message as d, Checkbox as e, reactDomExports as f, ThemeProvider as g, Datepicker as h, Tag$1 as i, jsxRuntimeExports as j, focusStyles as k, hideVisually as l, FauxInput as m, getLineHeight as n, reactExports as r, styled as s, useGrid as u };
+export { Alert as A, Button as B, Combobox as C, DEFAULT_THEME as D, Field$1 as F, Hint$1 as H, Input as I, Label$1 as L, Message$1 as M, Ne as N, Option as O, Textarea as T, Field as a, Label as b, Hint as c, Message as d, Checkbox as e, OptGroup as f, reactDomExports as g, ThemeProvider as h, Datepicker as i, jsxRuntimeExports as j, Tag$1 as k, focusStyles as l, hideVisually as m, FauxInput as n, getLineHeight as o, reactExports as r, styled as s, useGrid as u };

--- a/src/modules/new-request-form/NewRequestForm.tsx
+++ b/src/modules/new-request-form/NewRequestForm.tsx
@@ -3,6 +3,7 @@ import { Input } from "./fields/Input";
 import { TextArea } from "./fields/TextArea";
 import { DropDown } from "./fields/DropDown";
 import { Checkbox } from "./fields/Checkbox";
+import { MultiSelect } from "./fields/MultiSelect";
 import { TicketFormField } from "./ticket-form-field/TicketFormField";
 import { ParentTicketField } from "./parent-ticket-field/ParentTicketField";
 import { Button } from "@zendeskgarden/react-buttons";
@@ -110,7 +111,7 @@ export function NewRequestForm({
               </Suspense>
             );
           case "multiselect":
-            return <div>multiselect</div>;
+            return <MultiSelect field={field}/>;
           case "tagger":
             return <div>tagger</div>;
           case "due_at":

--- a/src/modules/new-request-form/buildNestedOptions.tsx
+++ b/src/modules/new-request-form/buildNestedOptions.tsx
@@ -1,0 +1,77 @@
+import type { OptionType } from "@zendeskgarden/react-dropdowns.next/dist/typings/types";
+import type { FieldOption } from "./data-types";
+
+export interface NestedOption {
+  name: string;
+  value: string;
+  type?: OptionType;
+  label: string;
+}
+export type NestedOptions = Record<string, NestedOption[]>;
+
+// Maps a flat option data structure into a nested option structure.
+// Original option data structure:
+// [
+//   {name: 'Color::Special::Radioactive Green', value: 'color__special__radioactive_green'}
+//   {name: 'Color::Red', value: 'color__red'}
+//   {name: 'Color::Green', value: 'color__green'}
+//   {name: 'Simple Value', value: 'simple_value'}
+// ]
+// Mapped nested option data strucutre:
+// {
+//   "root": [
+//     {value: 'Color', name: 'Color', type: 'next'},
+//     {value: 'simple_value', label: 'Simple Value', name: 'Simple Value'}
+//   ],
+//   "Color": [
+//       {value: 'Special', name: 'Special', type: 'next'},
+//       {value: 'color__red', label: 'Color::Red', name: 'Red'},
+//       {value: 'color__green', label: 'Color::Green', name: 'Green'},
+//   ],
+//   "Special": [
+//      {value: 'color__special__atomic_green', label: 'Color::Special::Atomic Green', name: 'Atomic Green'}
+//   ]
+export function buildNestedOptions(options: FieldOption[]): NestedOptions {
+  const result: NestedOptions = { root: [] };
+
+  options.forEach((option: FieldOption) => {
+    // for flat values
+    if (!option.name.includes("::")) {
+      result["root"]?.push({
+        value: option.value,
+        label: option.name,
+        name: option.name,
+      });
+    }
+    // for nested values ex: (Color::Special::Radioactive Green)
+    else {
+      const optionNameList: string[] = option.name.split("::");
+      for (let i = 0; i < optionNameList.length - 1; i++) {
+        const subGroupName = optionNameList[i];
+        if (subGroupName && result[subGroupName] == null) {
+          // creates an entry in `result` to store the options associated to `subGroupName`
+          result[subGroupName] = [];
+
+          // links the new option subgroup to the parent option group
+          const list = i == 0 ? result.root : result[optionNameList[i - 1]!];
+          list?.push({
+            value: subGroupName,
+            label: subGroupName,
+            name: subGroupName,
+            type: "next",
+          });
+        }
+      }
+      // adds a option to the last subgroup of the chain, ex:
+      // ex: adding `Radioactive Green` to `result[Special]`
+      const lastSubGroupName = optionNameList[optionNameList.length - 2]!;
+      result[lastSubGroupName]?.push({
+        value: option.value,
+        label: option.name,
+        name: optionNameList.slice(-1)[0] as string,
+      });
+    }
+  });
+
+  return result;
+}

--- a/src/modules/new-request-form/data-types/Field.ts
+++ b/src/modules/new-request-form/data-types/Field.ts
@@ -7,10 +7,10 @@ export interface Field {
   description: string;
   type: string;
   id: string;
-  options: Option[];
+  options: FieldOption[];
 }
 
-interface Option {
+export interface FieldOption {
   name: string;
   value: string;
 }

--- a/src/modules/new-request-form/fields/MultiSelect.tsx
+++ b/src/modules/new-request-form/fields/MultiSelect.tsx
@@ -1,0 +1,139 @@
+import type {
+  IComboboxProps,
+  OptionValue,
+} from "@zendeskgarden/react-dropdowns.next";
+
+import {
+  Field as GardenField,
+  Label,
+  Hint,
+  Combobox,
+  Option,
+  Message,
+  OptGroup,
+} from "@zendeskgarden/react-dropdowns.next";
+import type { Field } from "../data-types";
+import { useMemo, useState } from "react";
+import type { NestedOption, NestedOptions } from "../buildNestedOptions";
+import { buildNestedOptions } from "../buildNestedOptions";
+
+interface MultiSelectProps {
+  field: Field;
+}
+
+export function MultiSelect({ field }: MultiSelectProps): JSX.Element {
+  const { label, options, error, value, name, required, description } = field;
+
+  const nestedOptions: NestedOptions = useMemo(
+    () => buildNestedOptions(options),
+    [options]
+  );
+  const [selectedValues, setSelectValues] = useState<string[]>(
+    (value as unknown as string[]) || []
+  );
+  // represents the subgroup chain, for example: ['Color','Special']
+  const [subGroupStack, setSubGroupStack] = useState<string[]>([]);
+  // indicates the "selected" subgroup, for example: 'Special'
+  const [activeSubGroup, setActiveSubOption] = useState<string | null>(null);
+  // holds the available options related to the activeSubGroup or the root(default) group.
+  const [activeOptions, setActiveOptions] = useState<
+    NestedOption[] | undefined
+  >(nestedOptions.root);
+
+  const handleChange: IComboboxProps["onChange"] = (changes) => {
+    if (Array.isArray(changes.selectionValue)) {
+      // for an option like `Color::Special::Radioactive Green` the return will be `Radioactive Green`
+      const lastSelectedItem: string = (changes.selectionValue as OptionValue[])
+        .slice(-1)
+        .toString();
+
+      if (lastSelectedItem == "back") {
+        // walks back the subgroup option chain. Example: from: `Color::Special` to ``Color`
+        subGroupStack.pop();
+        const previousSubGroup: string | undefined =
+          subGroupStack.length > 0 ? subGroupStack.slice(-1)[0] : "root";
+
+        setSubGroupStack(subGroupStack);
+        previousSubGroup == "root"
+          ? setActiveSubOption(null)
+          : setActiveSubOption(previousSubGroup!);
+        setActiveOptions(nestedOptions[previousSubGroup!]);
+      } else if (nestedOptions[lastSelectedItem] !== undefined) {
+        // the selected Item represents/matches an option subgroup then move up the group chain
+        // Example: if lastSelectedItem = `Color`, the component move up the group chain from root to color
+        // and it will update the activeOptions property to display the elements inside `nestedOptions['Color']
+        if (!subGroupStack.includes(lastSelectedItem)) {
+          subGroupStack.push(lastSelectedItem);
+          setSubGroupStack(subGroupStack);
+          setActiveSubOption(lastSelectedItem);
+          setActiveOptions(nestedOptions[lastSelectedItem]);
+        }
+      } else {
+        // if the lastSelectedItem represents a option Value then we update the component state
+        setSelectValues(changes.selectionValue as string[]);
+      }
+    }
+  };
+
+  return (
+    <GardenField>
+      {(selectedValues as Array<string>).map((selectedValue) => (
+        <input
+          type="hidden"
+          key={selectedValue}
+          name={`${name}[]`}
+          value={selectedValue}
+        />
+      ))}
+      <Label>{label}</Label>
+      {description && <Hint>{description}</Hint>}
+      <Combobox
+        isMultiselectable
+        inputProps={{ required }}
+        isEditable={false}
+        validation={error ? "error" : undefined}
+        onChange={handleChange}
+        selectionValue={selectedValues}
+      >
+        {activeSubGroup && (
+          <Option value="back" type="previous">
+            Back
+          </Option>
+        )}
+
+        {activeSubGroup ? (
+          <OptGroup aria-label={activeSubGroup}>
+            {activeOptions?.map((option) => (
+              <Option
+                key={option.value}
+                value={option.value}
+                type={option.type}
+                label={option.label}
+                isSelected={(selectedValues as Array<string>).includes(
+                  option.value!.toString()
+                )}
+              >
+                {option.name}
+              </Option>
+            ))}
+          </OptGroup>
+        ) : (
+          activeOptions?.map((option) => (
+            <Option
+              key={option.value}
+              value={option.value!}
+              label={option.label}
+              type={option.type}
+              isSelected={(selectedValues as Array<string>).includes(
+                option.value!.toString()
+              )}
+            >
+              {option.name}
+            </Option>
+          ))
+        )}
+      </Combobox>
+      {error && <Message validation="error">{error}</Message>}
+    </GardenField>
+  );
+}

--- a/templates/new_request_page.hbs
+++ b/templates/new_request_page.hbs
@@ -30,7 +30,7 @@
 
   const requestForm = {{new_request_form.to_json}};
 
-  const ticketForms = [];  
+  const ticketForms = [];
   {{#each ticket_forms}}
     ticketForms.push({ id:
     {{id}}, url: "{{url}}", display_name: "{{display_name}}" });


### PR DESCRIPTION
## Description
 Render a multi-select field with Garden in the CPH Theme

This component supports `flat` and `nested` options.
To handle the nested options, we use an object/hash/dictionary data structure. 
This data structure will contain: 
  - an entry/key  named  **root**  that represents the `flat/non-nested` options
  - an entry/key for each sub-options group named accordingly with the sub-option group name.

### Know Issue (happening only for nested values)
[ The selected values are not rendered correctly after submitting a request](https://zendesk.slack.com/archives/GSHE498CE/p1692800806162799?thread_ts=1692793685.466789&cid=GSHE498CE)

<!-- a summary of the changes introduced by this PR and the motivation behind them -->

## Reference
Jira: https://zendesk.atlassian.net/browse/GG-3284

## Screenshots

https://github.com/zendesk/copenhagen_theme/assets/102560/1cd7762a-4e77-4579-b93f-2590f4af71e6


<!-- (optional) when applicable, please include some screenshots or gifs that illustrate the changes -->

## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->