### PR TITLE
feat: added custom date field

### DIFF
--- a/assets/DatePicker.js
+++ b/assets/DatePicker.js
@@ -1,13 +1,20 @@
 import { r as reactExports, j as jsxRuntimeExports, F as Field, L as Label$1, H as Hint, h as Datepicker, I as Input, M as Message } from 'vendor';
 
-function DatePicker({ field, locale, }) {
+function DatePicker({ field, locale, valueFormat, }) {
     const { label, error, value, name, required, description } = field;
     const [date, setDate] = reactExports.useState(value ? new Date(value) : undefined);
     const handleChange = (date) => {
-        // Set the time to 12:00:00 as this is also the expected behavior behavior across Support and the API
+        // Set the time to 12:00:00 as this is also the expected behavior across Support and the API
         setDate(new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate(), 12, 0, 0)));
     };
-    return (jsxRuntimeExports.jsxs(Field, { children: [jsxRuntimeExports.jsx(Label$1, { children: label }), description && jsxRuntimeExports.jsx(Hint, { children: description }), jsxRuntimeExports.jsx(Datepicker, { value: date, onChange: handleChange, locale: locale, children: jsxRuntimeExports.jsx(Input, { required: required, lang: locale }) }), error && jsxRuntimeExports.jsx(Message, { validation: "error", children: error }), jsxRuntimeExports.jsx("input", { type: "hidden", name: name, value: date ? date.toISOString() : "" })] }));
+    const formatDate = (value) => {
+        if (value === undefined) {
+            return "";
+        }
+        const isoString = value.toISOString();
+        return valueFormat === "dateTime" ? isoString : isoString.split("T")[0];
+    };
+    return (jsxRuntimeExports.jsxs(Field, { children: [jsxRuntimeExports.jsx(Label$1, { children: label }), description && jsxRuntimeExports.jsx(Hint, { children: description }), jsxRuntimeExports.jsx(Datepicker, { value: date, onChange: handleChange, locale: locale, children: jsxRuntimeExports.jsx(Input, { required: required, lang: locale }) }), error && jsxRuntimeExports.jsx(Message, { validation: "error", children: error }), jsxRuntimeExports.jsx("input", { type: "hidden", name: name, value: formatDate(date) })] }));
 }
 
 export { DatePicker as default };

--- a/assets/new-request-form.js
+++ b/assets/new-request-form.js
@@ -127,13 +127,13 @@ function NewRequestForm({ ticketForms, requestForm, parentId, locale, }) {
                     case "checkbox":
                         return jsxRuntimeExports.jsx(Checkbox, { field: field });
                     case "date":
-                        return jsxRuntimeExports.jsx("div", { children: "date" });
+                        return (jsxRuntimeExports.jsx(reactExports.Suspense, { fallback: jsxRuntimeExports.jsx(jsxRuntimeExports.Fragment, {}), children: jsxRuntimeExports.jsx(DatePicker, { field: field, locale: locale, valueFormat: "date" }) }));
                     case "multiselect":
                         return jsxRuntimeExports.jsx("div", { children: "multiselect" });
                     case "tagger":
                         return jsxRuntimeExports.jsx("div", { children: "tagger" });
                     case "due_at":
-                        return (showDueDate && (jsxRuntimeExports.jsx(reactExports.Suspense, { fallback: jsxRuntimeExports.jsx(jsxRuntimeExports.Fragment, {}), children: jsxRuntimeExports.jsx(DatePicker, { field: field, locale: locale }) })));
+                        return (showDueDate && (jsxRuntimeExports.jsx(reactExports.Suspense, { fallback: jsxRuntimeExports.jsx(jsxRuntimeExports.Fragment, {}), children: jsxRuntimeExports.jsx(DatePicker, { field: field, locale: locale, valueFormat: "dateTime" }) })));
                     default:
                         return jsxRuntimeExports.jsx(jsxRuntimeExports.Fragment, {});
                 }

--- a/src/modules/new-request-form/NewRequestForm.tsx
+++ b/src/modules/new-request-form/NewRequestForm.tsx
@@ -97,7 +97,11 @@ export function NewRequestForm({
           case "checkbox":
             return <Checkbox field={field} />;
           case "date":
-            return <div>date</div>;
+            return (
+              <Suspense fallback={<></>}>
+                <DatePicker field={field} locale={locale} valueFormat="date" />
+              </Suspense>
+            );
           case "multiselect":
             return <div>multiselect</div>;
           case "tagger":
@@ -106,7 +110,11 @@ export function NewRequestForm({
             return (
               showDueDate && (
                 <Suspense fallback={<></>}>
-                  <DatePicker field={field} locale={locale} />
+                  <DatePicker
+                    field={field}
+                    locale={locale}
+                    valueFormat="dateTime"
+                  />
                 </Suspense>
               )
             );

--- a/src/modules/new-request-form/fields/DatePicker.tsx
+++ b/src/modules/new-request-form/fields/DatePicker.tsx
@@ -12,11 +12,13 @@ import { useState } from "react";
 interface DatePickerProps {
   field: Field;
   locale: string;
+  valueFormat: "date" | "dateTime";
 }
 
 export default function DatePicker({
   field,
   locale,
+  valueFormat,
 }: DatePickerProps): JSX.Element {
   const { label, error, value, name, required, description } = field;
   const [date, setDate] = useState(value ? new Date(value) : undefined);
@@ -30,6 +32,14 @@ export default function DatePicker({
     );
   };
 
+  const formatDate = (value: Date | undefined) => {
+    if (value === undefined) {
+      return "";
+    }
+    const isoString = value.toISOString();
+    return valueFormat === "dateTime" ? isoString : isoString.split("T")[0];
+  };
+
   return (
     <GardenField>
       <Label>{label}</Label>
@@ -38,7 +48,7 @@ export default function DatePicker({
         <Input required={required} lang={locale} />
       </GardenDatepicker>
       {error && <Message validation="error">{error}</Message>}
-      <input type="hidden" name={name} value={date ? date.toISOString() : ""} />
+      <input type="hidden" name={name} value={formatDate(date)} />
     </GardenField>
   );
 }


### PR DESCRIPTION
## Description

This PR adds support for the custom date field, using the DatePicker component introduced in #422.
The backend seems to accept an ISO string with a date only (like `2023-08-24`), while the Due Date field was implemented by setting an ISO string with time (like `2023-08-24T12:00:00.000Z`). 

It seems possible to pass a date only for the Due Date field as well, but the current implementation in HC sets an ISO string with time for it, and Support has the same behavior, so I decided to be consistent here. The DatePicker can be now configured to set a date-time value or a date-only value.

## Screenshots


https://github.com/zendesk/copenhagen_theme/assets/13420283/2cdb9641-2f8c-424d-b6af-e1bf2497b91d



## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->