### PR TITLE
[A11y] Add aria-label to user navigation, wrap breadcrumbs in div

### DIFF
--- a/templates/article_page.hbs
+++ b/templates/article_page.hbs
@@ -1,6 +1,6 @@
 <div class="container-divider"></div>
 <div class="container">
-  <nav class="sub-nav">
+  <div class="sub-nav">
     {{breadcrumbs}}
     <div class="search-container">
       <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" focusable="false" viewBox="0 0 12 12" class="search-icon" aria-hidden="true">
@@ -9,7 +9,7 @@
       </svg>
       {{search scoped=settings.scoped_kb_search submit=false}}
     </div>
-  </nav>
+  </div>
 
   <div class="article-container" id="article-container">
     <aside class="article-sidebar" aria-labelledby="section-articles-title">

--- a/templates/category_page.hbs
+++ b/templates/category_page.hbs
@@ -1,6 +1,6 @@
 <div class="container-divider"></div>
 <div class="container">
-  <nav class="sub-nav">
+  <div class="sub-nav">
     {{breadcrumbs}}
     <div class="search-container">
       <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" focusable="false" viewBox="0 0 12 12" class="search-icon" aria-hidden="true">
@@ -9,7 +9,7 @@
       </svg>
       {{search scoped=settings.scoped_kb_search submit=false}}
     </div>
-  </nav>
+  </div>
 
   <div class="category-container">
     <div class="category-content">

--- a/templates/community_post_list_page.hbs
+++ b/templates/community_post_list_page.hbs
@@ -12,9 +12,9 @@
 </section>
 
 <div class="container">
-  <nav class="sub-nav">
+  <div class="sub-nav">
     {{breadcrumbs}}
-  </nav>
+  </div>
 
   <header class="page-header community-header">
       <span class="dropdown">

--- a/templates/community_post_page.hbs
+++ b/templates/community_post_page.hbs
@@ -1,6 +1,6 @@
 <div class="container-divider"></div>
 <div class="container">
-  <nav class="sub-nav">
+  <div class="sub-nav">
     {{breadcrumbs}}
     <div class="search-container">
       <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" focusable="false" viewBox="0 0 12 12" class="search-icon" aria-hidden="true">
@@ -9,7 +9,7 @@
       </svg>
       {{search scoped=settings.scoped_community_search submit=false}}
     </div>
-  </nav>
+  </div>
 
   <div class="post-container">
     <div class="post">

--- a/templates/community_topic_list_page.hbs
+++ b/templates/community_topic_list_page.hbs
@@ -12,9 +12,9 @@
 </section>
 
 <div class="container">
-  <nav class="sub-nav">
+  <div class="sub-nav">
     {{breadcrumbs}}
-  </nav>
+  </div>
 
   <header class="page-header community-header">
       <span class="dropdown">

--- a/templates/community_topic_page.hbs
+++ b/templates/community_topic_page.hbs
@@ -1,6 +1,6 @@
 <div class="container-divider"></div>
 <div class="container">
-   <nav class="sub-nav">
+   <div class="sub-nav">
     {{breadcrumbs}}
     <div class="search-container">
       <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" focusable="false" viewBox="0 0 12 12" class="search-icon" aria-hidden="true">
@@ -9,7 +9,7 @@
       </svg>
       {{search scoped=settings.scoped_community_search submit=false}}
     </div>
-  </nav>
+  </div>
 
   <header class="page-header">
     <h1>

--- a/templates/header.hbs
+++ b/templates/header.hbs
@@ -11,7 +11,7 @@
   </div>
 
   <div class="nav-wrapper-desktop">
-    <nav class="user-nav" id="user-nav">
+    <nav class="user-nav" id="user-nav" aria-label="{{t 'user_navigation'}}">
       <ul class="user-nav-list">
         <li>{{link 'community'}}</li>
         <li>{{link 'new_request' class='submit-a-request'}}</li>

--- a/templates/new_community_post_page.hbs
+++ b/templates/new_community_post_page.hbs
@@ -1,6 +1,6 @@
 <div class="container-divider"></div>
 <div class="container">
-  <nav class="sub-nav">
+  <div class="sub-nav">
     {{breadcrumbs}}
     <div class="search-container">
       <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" focusable="false" viewBox="0 0 12 12" class="search-icon" aria-hidden="true">
@@ -9,7 +9,7 @@
       </svg>
       {{search submit=false}}
     </div>
-  </nav>
+  </div>
 
   <h1 class="form-header">
     {{t 'what_is_your_post_about'}}

--- a/templates/new_request_page.hbs
+++ b/templates/new_request_page.hbs
@@ -1,6 +1,6 @@
 <div class="container-divider"></div>
 <div class="container">
-  <nav class="sub-nav">
+  <div class="sub-nav">
     {{breadcrumbs}}
     <div class="search-container">
       <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" focusable="false" viewBox="0 0 12 12" class="search-icon" aria-hidden="true">
@@ -9,7 +9,7 @@
       </svg>
       {{search submit=false}}
     </div>
-  </nav>
+  </div>
 
   <h1>
     {{t 'submit_a_request'}}

--- a/templates/search_results.hbs
+++ b/templates/search_results.hbs
@@ -1,6 +1,6 @@
 <div class="container-divider"></div>
 <div class="container">
-  <nav class="sub-nav">
+  <div class="sub-nav">
     {{breadcrumbs}}
     <div class="search-container">
       <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" focusable="false" viewBox="0 0 12 12" class="search-icon" aria-hidden="true">
@@ -9,7 +9,7 @@
       </svg>
       {{search submit=false}}
     </div>
-  </nav>
+  </div>
 
   <div class="search-results">
     <aside class="search-results-sidebar">

--- a/templates/section_page.hbs
+++ b/templates/section_page.hbs
@@ -1,6 +1,6 @@
 <div class="container-divider"></div>
 <div class="container">
-  <nav class="sub-nav">
+  <div class="sub-nav">
     {{breadcrumbs}}
     <div class="search-container">
       <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" focusable="false" viewBox="0 0 12 12" class="search-icon" aria-hidden="true">
@@ -9,7 +9,7 @@
       </svg>
       {{search scoped=settings.scoped_kb_search submit=false}}
     </div>
-  </nav>
+  </div>
 
   <div class="section-container">
     <section id="main-content" class="section-content">


### PR DESCRIPTION
## Description

> When ARIA regions, landmarks or HTML5 section elements are provided, users must be able to distinguish them from other regions, landmarks or sections in the page, particularly when two or more instances of the same type are used. When such an element does not provide a descriptive label to clearly identify itself, users of screen readers may have trouble locating the correct section or understanding its purpose.

This PR adds a localized aria-label for the header User Navigation. It also changes the breadcrumbs wrapping `nav` to a `div`, since the breadcrumbs helper itself provides an aria-labelled `nav`.

## Screenshots

<img width="1102" alt="Screenshot 2023-08-08 at 10 14 30" src="https://github.com/zendesk/copenhagen_theme/assets/8034580/13a5441a-2cf6-4595-9ced-1ab2163d385c">

## Checklist

- [x] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [x] :arrow_left: changes are compatible with RTL direction
- [x] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->