### PR TITLE
feat: adding support for conditional fields

### DIFF
--- a/src/modules/new-request-form/data-types/EndUserCondition.ts
+++ b/src/modules/new-request-form/data-types/EndUserCondition.ts
@@ -1,0 +1,11 @@
+export interface EndUserCondition {
+  parent_field_id: number;
+  parent_field_type: string;
+  value: string | boolean;
+  child_fields: ChildField[];
+}
+
+interface ChildField {
+  id: number;
+  is_required: boolean;
+}

--- a/src/modules/new-request-form/data-types/Field.ts
+++ b/src/modules/new-request-form/data-types/Field.ts
@@ -1,12 +1,12 @@
 export interface Field {
+  id: number;
   name: string;
-  value: string;
+  value?: string | boolean;
   error: string;
   label: string;
   required: boolean;
   description: string;
   type: string;
-  id: string;
   options: FieldOption[];
   attachments?: Attachment[];
 }

--- a/src/modules/new-request-form/data-types/RequestForm.tsx
+++ b/src/modules/new-request-form/data-types/RequestForm.tsx
@@ -1,4 +1,5 @@
 import type { Field } from "./Field";
+import type { EndUserCondition } from "./EndUserCondition";
 
 export interface RequestForm {
   accept_charset: string;
@@ -9,4 +10,5 @@ export interface RequestForm {
   ticket_form_field: Field;
   parent_id_field: Field;
   fields: Field[];
+  end_user_conditions: EndUserCondition[];
 }

--- a/src/modules/new-request-form/data-types/index.ts
+++ b/src/modules/new-request-form/data-types/index.ts
@@ -1,3 +1,4 @@
 export * from "./Field";
 export * from "./TicketForm";
 export * from "./RequestForm";
+export * from "./EndUserCondition";

--- a/src/modules/new-request-form/fields/Checkbox.tsx
+++ b/src/modules/new-request-form/fields/Checkbox.tsx
@@ -11,14 +11,17 @@ import {
 
 interface CheckboxProps {
   field: Field;
+  onChange: (value: boolean) => void;
 }
 
-export function Checkbox({ field }: CheckboxProps): JSX.Element {
+export function Checkbox({ field, onChange }: CheckboxProps): JSX.Element {
   const { label, error, value, name, required, description } = field;
-  const [checkboxValue, setCheckboxValue] = useState(value);
+  const [checkboxValue, setCheckboxValue] = useState(value as boolean);
 
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
-    setCheckboxValue(e.target.checked ? "on" : "off");
+    const { checked } = e.target;
+    setCheckboxValue(checked);
+    onChange(checked);
   };
 
   return (
@@ -27,8 +30,8 @@ export function Checkbox({ field }: CheckboxProps): JSX.Element {
       <GardenCheckbox
         name={name}
         required={required}
-        defaultChecked={value === "on"}
-        value={checkboxValue}
+        defaultChecked={value as boolean}
+        value={checkboxValue ? "on" : "off"}
         onChange={handleChange}
       >
         <Label>{label}</Label>

--- a/src/modules/new-request-form/fields/DatePicker.tsx
+++ b/src/modules/new-request-form/fields/DatePicker.tsx
@@ -21,7 +21,9 @@ export default function DatePicker({
   valueFormat,
 }: DatePickerProps): JSX.Element {
   const { label, error, value, name, required, description } = field;
-  const [date, setDate] = useState(value ? new Date(value) : undefined);
+  const [date, setDate] = useState(
+    value ? new Date(value as string) : undefined
+  );
 
   const handleChange = (date: Date) => {
     // Set the time to 12:00:00 as this is also the expected behavior across Support and the API

--- a/src/modules/new-request-form/fields/DropDown.tsx
+++ b/src/modules/new-request-form/fields/DropDown.tsx
@@ -10,11 +10,13 @@ import type { Field } from "../data-types";
 
 interface DropDownProps {
   field: Field;
-  onChange?: (value: string) => void;
+  onChange: (value: string) => void;
 }
 
 export function DropDown({ field, onChange }: DropDownProps): JSX.Element {
   const { label, options, error, value, name, required, description } = field;
+  const selectionValue = options.find((option) => option.value === value);
+
   return (
     <GardenField>
       <Label>{label}</Label>
@@ -23,13 +25,10 @@ export function DropDown({ field, onChange }: DropDownProps): JSX.Element {
         inputProps={{ name, required }}
         isEditable={false}
         validation={error ? "error" : undefined}
-        renderValue={({ selection }) =>
-          selection && "value" in selection
-            ? options.find((option) => option.value === selection.value)?.name
-            : "-"
-        }
+        selectionValue={selectionValue}
+        renderValue={() => selectionValue?.name || "-"}
         onChange={({ selectionValue }) => {
-          if (selectionValue !== undefined && onChange !== undefined) {
+          if (selectionValue !== undefined) {
             onChange(selectionValue as string);
           }
         }}
@@ -38,7 +37,7 @@ export function DropDown({ field, onChange }: DropDownProps): JSX.Element {
           <Option
             key={option.value}
             value={option.value}
-            isSelected={option.value?.toString() === value?.toString()}
+            isSelected={option.value === value}
           >
             {option.name}
           </Option>

--- a/src/modules/new-request-form/fields/Input.tsx
+++ b/src/modules/new-request-form/fields/Input.tsx
@@ -9,9 +9,10 @@ import type { Field } from "../data-types";
 
 interface InputProps {
   field: Field;
+  onChange: (value: string) => void;
 }
 
-export function Input({ field }: InputProps): JSX.Element {
+export function Input({ field, onChange }: InputProps): JSX.Element {
   const { label, error, value, name, required, description, type } = field;
   const stepProp: { step?: string } = {};
   const inputType =
@@ -27,9 +28,10 @@ export function Input({ field }: InputProps): JSX.Element {
       <GardenInput
         name={name}
         type={inputType}
-        defaultValue={value}
+        defaultValue={value as string}
         validation={error ? "error" : undefined}
         required={required}
+        onChange={(e) => onChange(e.target.value)}
         {...stepProp}
       />
       {error && <Message validation="error">{error}</Message>}

--- a/src/modules/new-request-form/fields/TextArea.tsx
+++ b/src/modules/new-request-form/fields/TextArea.tsx
@@ -9,9 +9,10 @@ import type { Field } from "../data-types";
 
 interface TextAreaProps {
   field: Field;
+  onChange: (value: string) => void;
 }
 
-export function TextArea({ field }: TextAreaProps): JSX.Element {
+export function TextArea({ field, onChange }: TextAreaProps): JSX.Element {
   const { label, error, value, name, required, description } = field;
   return (
     <GardenField>
@@ -19,9 +20,10 @@ export function TextArea({ field }: TextAreaProps): JSX.Element {
       {description && <Hint>{description}</Hint>}
       <Textarea
         name={name}
-        defaultValue={value}
+        defaultValue={value as string}
         validation={error ? "error" : undefined}
         required={required}
+        onChange={(e) => onChange(e.target.value)}
       />
       {error && <Message validation="error">{error}</Message>}
     </GardenField>

--- a/src/modules/new-request-form/fields/cc-field/CcField.tsx
+++ b/src/modules/new-request-form/fields/cc-field/CcField.tsx
@@ -81,7 +81,7 @@ const AnnouncementMessage = styled.span`
 export default function CcField({ field }: CcFieldProps): JSX.Element {
   const { label, value, name, error, description } = field;
   const initialValue = value
-    ? value.split(",").map((email) => email.trim())
+    ? (value as string).split(",").map((email) => email.trim())
     : [];
   const [tags, setTags] = useState(initialValue);
   const [inputValue, setInputValue] = useState("");

--- a/src/modules/new-request-form/parent-ticket-field/ParentTicketField.tsx
+++ b/src/modules/new-request-form/parent-ticket-field/ParentTicketField.tsx
@@ -8,5 +8,5 @@ export function ParentTicketField({
   field,
 }: ParentTicketFieldProps): JSX.Element {
   const { value, name } = field;
-  return <input type="hidden" name={name} value={value} />;
+  return <input type="hidden" name={name} value={value as string} />;
 }

--- a/src/modules/new-request-form/ticket-form-field/TicketFormField.tsx
+++ b/src/modules/new-request-form/ticket-form-field/TicketFormField.tsx
@@ -39,7 +39,7 @@ export function TicketFormField({
       <input
         type="hidden"
         name={ticketFormField.name}
-        value={ticketFormField.value}
+        value={ticketFormField.value as string}
       />
       {ticketForms.length > 1 && (
         <GardenField>

--- a/src/modules/new-request-form/useEndUserConditions.tsx
+++ b/src/modules/new-request-form/useEndUserConditions.tsx
@@ -1,0 +1,21 @@
+import type { EndUserCondition, Field } from "./data-types";
+
+export function useEndUserConditions(
+  fields: Field[],
+  endUserConditions: EndUserCondition[]
+): Field[] {
+  return fields.filter((field) => {
+    const conditions = endUserConditions.filter((condition) =>
+      condition.child_fields.some((childField) => childField.id === field.id)
+    );
+
+    const hasNoConditions = conditions.length === 0;
+    const meetsAnyCondition = conditions.some(
+      (condition) =>
+        fields.find((field) => field.id === condition.parent_field_id)
+          ?.value === condition.value
+    );
+
+    return hasNoConditions || meetsAnyCondition;
+  });
+}


### PR DESCRIPTION
## Description

- [x] Introduces `end_user_conditions`
- [x] Aligns the types for the field `value` between ticket form fields and enduser condition child fields.
  - This means the value of checkboxes is now a `boolean` instead of `string` (`"on" | "off"`)
- [x] We must now keep `ticketFields` in local state so we can filter out conditional fields
- [x] Filtering logic for the visibility of ticket fields is encapsulated within `useEndUserConditions` hook

Still missing displaying `optional` conditional fields as we're waiting for a decision on the UI.

## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->