### PR TITLE
feat: added CreditCard field

### DIFF
--- a/assets/vendor.js
+++ b/assets/vendor.js
@@ -157,17 +157,17 @@ var l=requireObjectAssign(),n=60103,p=60106;react_production_min.Fragment=60107;
 	return react_production_min;
 }
 
-{
-  react.exports = requireReact_production_min();
+var hasRequiredReact;
+
+function requireReact () {
+	if (hasRequiredReact) return react.exports;
+	hasRequiredReact = 1;
+
+	{
+	  react.exports = requireReact_production_min();
+	}
+	return react.exports;
 }
-
-var reactExports = react.exports;
-var React = /*@__PURE__*/getDefaultExportFromCjs(reactExports);
-
-var React$1 = /*#__PURE__*/_mergeNamespaces({
-	__proto__: null,
-	default: React
-}, [reactExports]);
 
 /** @license React v17.0.2
  * react-jsx-runtime.production.min.js
@@ -183,7 +183,7 @@ var hasRequiredReactJsxRuntime_production_min;
 function requireReactJsxRuntime_production_min () {
 	if (hasRequiredReactJsxRuntime_production_min) return reactJsxRuntime_production_min;
 	hasRequiredReactJsxRuntime_production_min = 1;
-requireObjectAssign();var f=reactExports,g=60103;reactJsxRuntime_production_min.Fragment=60107;if("function"===typeof Symbol&&Symbol.for){var h=Symbol.for;g=h("react.element");reactJsxRuntime_production_min.Fragment=h("react.fragment");}var m=f.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.ReactCurrentOwner,n=Object.prototype.hasOwnProperty,p={key:!0,ref:!0,__self:!0,__source:!0};
+requireObjectAssign();var f=requireReact(),g=60103;reactJsxRuntime_production_min.Fragment=60107;if("function"===typeof Symbol&&Symbol.for){var h=Symbol.for;g=h("react.element");reactJsxRuntime_production_min.Fragment=h("react.fragment");}var m=f.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.ReactCurrentOwner,n=Object.prototype.hasOwnProperty,p={key:!0,ref:!0,__self:!0,__source:!0};
 	function q(c,a,k){var b,d={},e=null,l=null;void 0!==k&&(e=""+k);void 0!==a.key&&(e=""+a.key);void 0!==a.ref&&(l=a.ref);for(b in a)n.call(a,b)&&!p.hasOwnProperty(b)&&(d[b]=a[b]);if(c&&c.defaultProps)for(b in a=c.defaultProps,a)void 0===d[b]&&(d[b]=a[b]);return {$$typeof:g,type:c,key:e,ref:l,props:d,_owner:m.current}}reactJsxRuntime_production_min.jsx=q;reactJsxRuntime_production_min.jsxs=q;
 	return reactJsxRuntime_production_min;
 }
@@ -259,7 +259,7 @@ var hasRequiredReactDom_production_min;
 function requireReactDom_production_min () {
 	if (hasRequiredReactDom_production_min) return reactDom_production_min;
 	hasRequiredReactDom_production_min = 1;
-var aa=reactExports,m=requireObjectAssign(),r=requireScheduler();function y(a){for(var b="https://reactjs.org/docs/error-decoder.html?invariant="+a,c=1;c<arguments.length;c++)b+="&args[]="+encodeURIComponent(arguments[c]);return "Minified React error #"+a+"; visit "+b+" for the full message or use the non-minified dev environment for full errors and additional helpful warnings."}if(!aa)throw Error(y(227));var ba=new Set,ca={};function da(a,b){ea(a,b);ea(a+"Capture",b);}
+var aa=requireReact(),m=requireObjectAssign(),r=requireScheduler();function y(a){for(var b="https://reactjs.org/docs/error-decoder.html?invariant="+a,c=1;c<arguments.length;c++)b+="&args[]="+encodeURIComponent(arguments[c]);return "Minified React error #"+a+"; visit "+b+" for the full message or use the non-minified dev environment for full errors and additional helpful warnings."}if(!aa)throw Error(y(227));var ba=new Set,ca={};function da(a,b){ea(a,b);ea(a+"Capture",b);}
 	function ea(a,b){ca[a]=b;for(a=0;a<b.length;a++)ba.add(b[a]);}
 	var fa=!("undefined"===typeof window||"undefined"===typeof window.document||"undefined"===typeof window.document.createElement),ha=/^[:A-Z_a-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD][:A-Z_a-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD\-.0-9\u00B7\u0300-\u036F\u203F-\u2040]*$/,ia=Object.prototype.hasOwnProperty,
 	ja={},ka={};function la(a){if(ia.call(ka,a))return !0;if(ia.call(ja,a))return !1;if(ha.test(a))return ka[a]=!0;ja[a]=!0;return !1}function ma(a,b,c,d){if(null!==c&&0===c.type)return !1;switch(typeof b){case "function":case "symbol":return !0;case "boolean":if(d)return !1;if(null!==c)return !c.acceptsBooleans;a=a.toLowerCase().slice(0,5);return "data-"!==a&&"aria-"!==a;default:return !1}}
@@ -575,6 +575,14 @@ function checkDCE() {
 
 var reactDomExports = reactDom.exports;
 var ReactDOM = /*@__PURE__*/getDefaultExportFromCjs(reactDomExports);
+
+var reactExports = requireReact();
+var React = /*@__PURE__*/getDefaultExportFromCjs(reactExports);
+
+var React$1 = /*#__PURE__*/_mergeNamespaces({
+	__proto__: null,
+	default: React
+}, [reactExports]);
 
 var propTypes = {exports: {}};
 
@@ -24881,7 +24889,7 @@ implementation.exports;
 
 	exports.__esModule = true;
 
-	var _react = reactExports;
+	var _react = requireReact();
 
 	_interopRequireDefault(_react);
 
@@ -25080,7 +25088,7 @@ lib.exports;
 
 	exports.__esModule = true;
 
-	var _react = reactExports;
+	var _react = requireReact();
 
 	var _react2 = _interopRequireDefault(_react);
 

--- a/src/modules/new-request-form/NewRequestForm.tsx
+++ b/src/modules/new-request-form/NewRequestForm.tsx
@@ -14,6 +14,7 @@ import { Suspense, lazy, useState } from "react";
 import { usePrefilledTicketFields } from "./usePrefilledTicketFields";
 import { Attachments } from "./fields/attachments/Attachments";
 import { useEndUserConditions } from "./useEndUserConditions";
+import { CreditCard } from "./fields/CreditCard";
 
 export interface NewRequestFormProps {
   ticketForms: TicketForm[];
@@ -55,7 +56,7 @@ export function NewRequestForm({
   const prefilledTicketFields = usePrefilledTicketFields(fields);
   const [ticketFields, setTicketFields] = useState(prefilledTicketFields);
   const visibleFields = useEndUserConditions(ticketFields, end_user_conditions);
-  const handleSubmit = useSubmitHandler();
+  const handleSubmit = useSubmitHandler(ticketFields);
 
   function handleChange(field: Field, value: Field["value"]) {
     setTicketFields(
@@ -92,10 +93,16 @@ export function NewRequestForm({
           case "integer":
           case "decimal":
           case "regexp":
-          case "partialcreditcard":
             return (
               <Input
                 key={field.name}
+                field={field}
+                onChange={(value) => handleChange(field, value)}
+              />
+            );
+          case "partialcreditcard":
+            return (
+              <CreditCard
                 field={field}
                 onChange={(value) => handleChange(field, value)}
               />

--- a/src/modules/new-request-form/fields/CreditCard.tsx
+++ b/src/modules/new-request-form/fields/CreditCard.tsx
@@ -1,0 +1,44 @@
+import {
+  Field as GardenField,
+  Hint,
+  Input,
+  Label,
+  Message,
+} from "@zendeskgarden/react-forms";
+import type { Field } from "../data-types";
+import { Span } from "@zendeskgarden/react-typography";
+import type { FocusEventHandler } from "react";
+import { redactCreditCard } from "../redactCreditCard";
+
+interface CreditCardProps {
+  field: Field;
+  onChange: (value: string) => void;
+}
+
+export function CreditCard({ field, onChange }: CreditCardProps): JSX.Element {
+  const { label, error, value, name, required, description } = field;
+
+  const handleBlur: FocusEventHandler<HTMLInputElement> = (e) => {
+    onChange(redactCreditCard(e.target.value));
+  };
+
+  return (
+    <GardenField>
+      <Label>
+        {label}
+        {required && <Span aria-hidden="true">*</Span>}
+      </Label>
+      {description && <Hint>{description}</Hint>}
+      <Input
+        name={name}
+        type="text"
+        value={value as string}
+        onChange={(e) => onChange(e.target.value)}
+        onBlur={handleBlur}
+        validation={error ? "error" : undefined}
+        required={required}
+      />
+      {error && <Message validation="error">{error}</Message>}
+    </GardenField>
+  );
+}

--- a/src/modules/new-request-form/redactCreditCard.ts
+++ b/src/modules/new-request-form/redactCreditCard.ts
@@ -1,0 +1,66 @@
+const NON_DIGITS_REGEX = /[^\d]/g;
+const CC_NUMBERS_REGEX = /[0-9]{13,19}/;
+const REDACTED_CC_NUMBER_REGEX = /^[X]{9,15}/;
+const MIN_LENGTH = 13;
+const MAX_LENGTH = 19;
+
+export function redactCreditCard(input: string) {
+  // if number is already redacted, just send it back
+  if (alreadyRedactedCCNumber(input)) {
+    return input;
+  }
+
+  const cleaned = removeNonDigits(input);
+  if (!hasValidLength(cleaned)) {
+    // if input string is not inside valid length for credit card number,
+    // such as in the case when extra text is entered beside cc number,
+    // we will remove spaces and dashes from original input,
+    // and redact credit card number if we can find it
+    // or redact everything if we can't find anything resembling cc number.
+    const ccTextWithoutSpacesAndDashes = removeSpacesAndDashes(input);
+    const ccNumber = CC_NUMBERS_REGEX.exec(
+      ccTextWithoutSpacesAndDashes.toString()
+    );
+    if (ccNumber !== null) {
+      return redactCCNumber(ccNumber.toString());
+    } else {
+      // redact everything since that is an error and not valid cc number
+      return charRepeater("X", cleaned.length);
+    }
+  } else {
+    return redactCCNumber(cleaned.toString());
+  }
+}
+
+function hasValidLength(input: string) {
+  return input.length >= MIN_LENGTH && input.length <= MAX_LENGTH;
+}
+
+function removeNonDigits(input: string) {
+  return input.replace(NON_DIGITS_REGEX, "");
+}
+
+function removeSpacesAndDashes(input: string) {
+  return input.replace(/-|\s/g, "");
+}
+
+function redactCCNumber(input: string) {
+  const length = input.length;
+  const redactEnd = length - 4;
+  const lastDigits = input.toString().substring(redactEnd, length);
+  return charRepeater("X", redactEnd) + lastDigits;
+}
+
+function alreadyRedactedCCNumber(input: string) {
+  return REDACTED_CC_NUMBER_REGEX.test(input);
+}
+
+function charRepeater(character: string, length: number) {
+  const repeatedString = [];
+
+  for (let i = 0; i < length; i++) {
+    repeatedString.push(character);
+  }
+
+  return repeatedString.join("");
+}


### PR DESCRIPTION
## Description

This PR adds a `CreditCard` field, which redacts the credit card number on blur. The redaction happens also when the form is submitted, to ensure that the number is redacted even if the input was not blurred (for example, pressing ENTER on the Credit Card field will submit the form without blurring the input).

The redaction logic is ported from the library used in Help Center.

## Screenshots


https://github.com/zendesk/copenhagen_theme/assets/13420283/6ac9db96-53ba-4799-a0d3-e97382d7ebfe



## Checklist

- [x] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [x] :arrow_left: changes are compatible with RTL direction
- [x] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [x] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [x] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->