### PR TITLE
fix: added empty option for priority and type fields

### DIFF
--- a/assets/new-request-form.js
+++ b/assets/new-request-form.js
@@ -19,12 +19,12 @@ function TextArea({ field, onChange }) {
 
 function DropDown({ field, onChange }) {
     const { label, options, error, value, name, required, description } = field;
-    const selectedOption = options.find((option) => option.value.toString() === value?.toString());
-    return (jsxRuntimeExports.jsxs(Field$1, { children: [jsxRuntimeExports.jsxs(Label, { children: [label, required && jsxRuntimeExports.jsx(Span, { "aria-hidden": "true", children: "*" })] }), description && jsxRuntimeExports.jsx(Hint$1, { children: description }), jsxRuntimeExports.jsx(Combobox, { inputProps: { name, required }, isEditable: false, validation: error ? "error" : undefined, inputValue: selectedOption?.value.toString(), selectionValue: selectedOption?.value.toString(), renderValue: () => selectedOption?.name || "-", onChange: ({ selectionValue }) => {
+    const selectionValue = value == null ? "" : value.toString();
+    return (jsxRuntimeExports.jsxs(Field$1, { children: [jsxRuntimeExports.jsxs(Label, { children: [label, required && jsxRuntimeExports.jsx(Span, { "aria-hidden": "true", children: "*" })] }), description && jsxRuntimeExports.jsx(Hint$1, { children: description }), jsxRuntimeExports.jsxs(Combobox, { inputProps: { name, required }, isEditable: false, validation: error ? "error" : undefined, inputValue: selectionValue, selectionValue: selectionValue, renderValue: ({ selection }) => selection?.label || "-", onChange: ({ selectionValue }) => {
                     if (selectionValue !== undefined) {
                         onChange(selectionValue);
                     }
-                }, children: options.map((option) => (jsxRuntimeExports.jsx(Option, { value: option.value.toString(), children: option.name }, option.value))) }), error && jsxRuntimeExports.jsx(Message$1, { validation: "error", children: error })] }));
+                }, children: [!required && jsxRuntimeExports.jsx(Option, { value: "", label: "-" }), options.map((option) => (jsxRuntimeExports.jsx(Option, { value: option.value.toString(), label: option.name }, option.value)))] }), error && jsxRuntimeExports.jsx(Message$1, { validation: "error", children: error })] }));
 }
 
 function Checkbox({ field, onChange }) {
@@ -640,9 +640,8 @@ function NewRequestForm({ ticketForms, requestForm, parentId, locale, }) {
                     case "description":
                     case "textarea":
                         return (jsxRuntimeExports.jsx(TextArea, { field: field, onChange: (value) => handleChange(field, value) }, field.name));
-                    case "priority":
                     case "organization_id":
-                        return (jsxRuntimeExports.jsx(DropDown, { field: field, onChange: (value) => handleChange(field, value) }, field.name));
+                    case "priority":
                     case "tickettype":
                         return (jsxRuntimeExports.jsx(DropDown, { field: field, onChange: (value) => handleChange(field, value) }, field.name));
                     case "due_at": {

--- a/src/modules/new-request-form/NewRequestForm.tsx
+++ b/src/modules/new-request-form/NewRequestForm.tsx
@@ -117,15 +117,8 @@ export function NewRequestForm({
                 onChange={(value) => handleChange(field, value)}
               />
             );
-          case "priority":
           case "organization_id":
-            return (
-              <DropDown
-                key={field.name}
-                field={field}
-                onChange={(value) => handleChange(field, value)}
-              />
-            );
+          case "priority":
           case "tickettype":
             return (
               <DropDown

--- a/src/modules/new-request-form/fields/DropDown.tsx
+++ b/src/modules/new-request-form/fields/DropDown.tsx
@@ -1,3 +1,4 @@
+import type { ISelectedOption } from "@zendeskgarden/react-dropdowns.next";
 import {
   Field as GardenField,
   Label,
@@ -16,9 +17,7 @@ interface DropDownProps {
 
 export function DropDown({ field, onChange }: DropDownProps): JSX.Element {
   const { label, options, error, value, name, required, description } = field;
-  const selectedOption = options.find(
-    (option) => option.value.toString() === value?.toString()
-  );
+  const selectionValue = value == null ? "" : value.toString();
 
   return (
     <GardenField>
@@ -31,19 +30,24 @@ export function DropDown({ field, onChange }: DropDownProps): JSX.Element {
         inputProps={{ name, required }}
         isEditable={false}
         validation={error ? "error" : undefined}
-        inputValue={selectedOption?.value.toString()}
-        selectionValue={selectedOption?.value.toString()}
-        renderValue={() => selectedOption?.name || "-"}
+        inputValue={selectionValue}
+        selectionValue={selectionValue}
+        renderValue={({ selection }) =>
+          (selection as ISelectedOption | null)?.label || "-"
+        }
         onChange={({ selectionValue }) => {
           if (selectionValue !== undefined) {
             onChange(selectionValue as string);
           }
         }}
       >
+        {!required && <Option value="" label="-" />}
         {options.map((option) => (
-          <Option key={option.value} value={option.value.toString()}>
-            {option.name}
-          </Option>
+          <Option
+            key={option.value}
+            value={option.value.toString()}
+            label={option.name}
+          />
         ))}
       </Combobox>
       {error && <Message validation="error">{error}</Message>}


### PR DESCRIPTION
## Description

The `priority` and `type` fields have a default null value, which is displayed as `-` in the input. The same value was not listed in the options menu, so when a value was selected from the dropdown, it wasn't possible to go back to the null value.

This PR fixes this issue, adding the null option to the menu, only for optional fields.

## Screenshots

https://github.com/zendesk/copenhagen_theme/assets/13420283/7224223c-1e20-4830-acfd-7a3d1476d080


<!-- (optional) when applicable, please include some screenshots or gifs that illustrate the changes -->

## Checklist

- [x] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [x] :arrow_left: changes are compatible with RTL direction
- [x] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [x] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [x] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->