### PR TITLE
fix: added aria-current attribute to articles list

### DIFF
--- a/templates/article_page.hbs
+++ b/templates/article_page.hbs
@@ -30,7 +30,11 @@
             <ul>
               {{#each section.articles}}
                 <li>
-                  <a href="{{url}}" class="sidenav-item {{#is id ../article.id}}current-article{{/is}}">{{title}}</a>
+                  <a href="{{url}}" 
+                     class="sidenav-item {{#is id ../article.id}}current-article{{/is}}"
+                     {{#is id ../article.id}}aria-current="page"{{/is}}>
+                       {{title}}
+                  </a>
                 </li>
               {{/each}}
             </ul>


### PR DESCRIPTION
## Description

This PR adds an `aria-current="page"` attribute to the current article link in the articles' sidebar, to let screen readers announce that the link is pointing to the current page.

## Checklist

- [X] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [X] :arrow_left: changes are compatible with RTL direction
- [X] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [X] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [X] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->