### PR TITLE
Use <ul> element to render list of posts (a11y fix)

### DIFF
--- a/templates/community_post_list_page.hbs
+++ b/templates/community_post_list_page.hbs
@@ -76,55 +76,56 @@
   </div>
 
   <div id="main-content" class="posts-list striped-list">
-    {{#unless posts}}
-      <div class="no-posts-with-filter">
-        {{t 'no_posts_with_filter'}}
-      </div>
-    {{/unless}}
-    {{#each posts}}
-      <section role="region" aria-labelledby="title-{{id}}">
-        <div class="striped-list-item {{#if featured}}post-featured{{/if}}">
-          <span class="striped-list-info">
-            <a href="{{url}}" id="title-{{id}}" class="striped-list-title">{{title}}</a>
-            <span class="post-overview-item">
-              {{#if pinned}}
-                <span class="status-label status-label-pinned">{{t 'pinned'}}</span>
-              {{/if}}
+    {{#if posts}}
+      <ul>
+        {{#each posts}}
+          <li>
+            <section role="region" aria-labelledby="title-{{id}}" class="striped-list-item {{#if featured}}post-featured{{/if}}">
+              <span class="striped-list-info">
+                <a href="{{url}}" id="title-{{id}}" class="striped-list-title">{{title}}</a>
+                <span class="post-overview-item">
+                  {{#if pinned}}
+                    <span class="status-label status-label-pinned">{{t 'pinned'}}</span>
+                  {{/if}}
 
-              {{#if featured}}
-                <span class="status-label status-label-featured">{{t 'featured'}}</span>
-              {{/if}}
+                  {{#if featured}}
+                    <span class="status-label status-label-featured">{{t 'featured'}}</span>
+                  {{/if}}
 
-              {{#is status 'none'}}
-              {{else}}
-                <span class="status-label-{{status_dasherized}} status-label striped-list-status">{{status_name}}</span>
-              {{/is}}
-            </span>
+                  {{#is status 'none'}}
+                  {{else}}
+                    <span class="status-label-{{status_dasherized}} status-label striped-list-status">{{status_name}}</span>
+                  {{/is}}
+                </span>
 
-            <div class="meta-group">
-              <span class="meta-data">{{author.name}}</span>
-              {{#if editor}}
-                <span class="meta-data">{{date edited_at timeago=true}}</span>
-                <span class="meta-data">{{t 'edited'}}</span>
-              {{else}}
-                <span class="meta-data">{{date created_at timeago=true}}</span>
-              {{/if}}
-            </div>
-          </span>
+                <div class="meta-group">
+                  <span class="meta-data">{{author.name}}</span>
+                  {{#if editor}}
+                    <span class="meta-data">{{date edited_at timeago=true}}</span>
+                    <span class="meta-data">{{t 'edited'}}</span>
+                  {{else}}
+                    <span class="meta-data">{{date created_at timeago=true}}</span>
+                  {{/if}}
+                </div>
+              </span>
 
-          <div class="post-overview-count striped-list-count">
-            <span class="striped-list-count-item">
-              <span class="striped-list-number">{{vote_sum}}</span>
-              {{t 'vote' count=vote_sum}}
-            </span>
-            <span class="striped-list-count-item">
-              <span class="striped-list-number">{{comment_count}}</span>
-              {{t 'comment' count=comment_count}}
-            </span>
-          </div>
-        </div>
-      </section>
-    {{/each}}
+              <div class="post-overview-count striped-list-count">
+                <span class="striped-list-count-item">
+                  <span class="striped-list-number">{{vote_sum}}</span>
+                  {{t 'vote' count=vote_sum}}
+                </span>
+                <span class="striped-list-count-item">
+                  <span class="striped-list-number">{{comment_count}}</span>
+                  {{t 'comment' count=comment_count}}
+                </span>
+              </div>
+            </section>
+          </li>
+        {{/each}}
+      </ul>
+    {{else}}
+      <div class="no-posts-with-filter">{{t 'no_posts_with_filter'}}</div>
+    {{/if}}
   </div>
 
   {{pagination}}

--- a/templates/community_topic_page.hbs
+++ b/templates/community_topic_page.hbs
@@ -70,52 +70,60 @@
   </div>
 
   <div id="main-content" class="posts-list striped-list">
-    {{#each posts}}
-      <section role="region" aria-labelledby="title-{{id}}">
-        <div class="striped-list-item {{#if featured}}post-featured{{/if}}">
-          <span class="striped-list-info">
-            <a href="{{url}}" id="title-{{id}}" class="striped-list-title">{{title}}</a>
-            <span class="post-overview-item">
-              {{#if pinned}}
-                <span class="status-label status-label-pinned">{{t 'pinned'}}</span>
-              {{/if}}
+    {{#if posts}}
+      <ul>
+        {{#each posts}}
+          <li>
+            <section role="region" aria-labelledby="title-{{id}}" class="striped-list-item {{#if featured}}post-featured{{/if}}">
+              <span class="striped-list-info">
+                <a href="{{url}}" id="title-{{id}}" class="striped-list-title">{{title}}</a>
+                <span class="post-overview-item">
+                  {{#if pinned}}
+                    <span class="status-label status-label-pinned">{{t 'pinned'}}</span>
+                  {{/if}}
 
-              {{#if featured}}
-                <span class="status-label status-label-featured">{{t 'featured'}}</span>
-              {{/if}}
+                  {{#if featured}}
+                    <span class="status-label status-label-featured">{{t 'featured'}}</span>
+                  {{/if}}
 
-              {{#is status 'none'}}
-              {{else}}
-                <span class="status-label-{{status_dasherized}} status-label striped-list-status">{{status_name}}</span>
-              {{/is}}
-            </span>
+                  {{#is status 'none'}}
+                  {{else}}
+                    <span class="status-label-{{status_dasherized}} status-label striped-list-status">{{status_name}}</span>
+                  {{/is}}
+                </span>
 
-            <div class="meta-group">
-              <span class="meta-data">{{author.name}}</span>
-              {{#if editor}}
-                <span class="meta-data">{{date edited_at timeago=true}}</span>
-                <span class="meta-data">{{t 'edited'}}</span>
-              {{else}}
-                <span class="meta-data">{{date created_at timeago=true}}</span>
-              {{/if}}
-            </div>
-          </span>
+                <div class="meta-group">
+                  <span class="meta-data">{{author.name}}</span>
+                  {{#if editor}}
+                    <span class="meta-data">{{date edited_at timeago=true}}</span>
+                    <span class="meta-data">{{t 'edited'}}</span>
+                  {{else}}
+                    <span class="meta-data">{{date created_at timeago=true}}</span>
+                  {{/if}}
+                </div>
+              </span>
 
-          <div class="post-overview-count striped-list-count">
-            <span class="striped-list-count-item">
-              <span class="striped-list-number">{{vote_sum}}</span>
-              {{t 'vote' count=vote_sum}}
-            </span>
-            <span class="striped-list-count-item">
-              <span class="striped-list-number">{{comment_count}}</span>
-              {{t 'comment' count=comment_count}}
-            </span>
-          </div>
-        </div>
-      </section>
-    {{/each}}
+              <div class="post-overview-count striped-list-count">
+                <span class="striped-list-count-item">
+                  <span class="striped-list-number">{{vote_sum}}</span>
+                  {{t 'vote' count=vote_sum}}
+                </span>
+                <span class="striped-list-count-item">
+                  <span class="striped-list-number">{{comment_count}}</span>
+                  {{t 'comment' count=comment_count}}
+                </span>
+              </div>
+            </section>
+          </li>
+        {{/each}}
+      </ul>
+    {{else}}
+      <div class="no-posts-with-filter">{{t 'no_posts_with_filter'}}</div>
+    {{/if}}
   </div>
+
   {{pagination}}
+
 </div>
 
 <section class="container community-footer">


### PR DESCRIPTION
## Description

This PR updates both the `community_post_list_page` and `community_topic_page` templates so that:
- `<ul>` and `<li>` elements are used to render the list of posts;
- A message is shown when there are no posts in the list;
- Removes an extra `div` element inside the `section` element;

Note: this PR easier to review by hiding whitespace ([link](https://github.com/zendesk/copenhagen_theme/pull/439/files?w=1));

## Screenshots

<details>
<summary>See the screenshots bellow</summary>

### Community post list page
![posts-list-page-full](https://github.com/zendesk/copenhagen_theme/assets/1172767/05fd128e-2cf1-4194-8308-2836a09267f8)


### Community post list page (empty)
![post-list-page-empty](https://github.com/zendesk/copenhagen_theme/assets/1172767/0c7508e0-b88d-4e0f-8915-b8bbe36ed722)

### Community topic page
![topic-page-full](https://github.com/zendesk/copenhagen_theme/assets/1172767/7f6032d3-f1b5-4410-b51a-6fd2a4b3f435)

### Community topic page (empty)
![topic-page-empty](https://github.com/zendesk/copenhagen_theme/assets/1172767/a3048471-d598-4a1a-8db4-5ad766a7d693)

</details>

## Checklist

- [x] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [x] :arrow_left: changes are compatible with RTL direction
- [x] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [x] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [x] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->