### PR TITLE
feat: [A11y] Add a button to skip to web widget

### DIFF
--- a/src/navigation.js
+++ b/src/navigation.js
@@ -30,6 +30,36 @@ window.addEventListener("DOMContentLoaded", () => {
     }
   });
 
+  // Hide Skip to Web Widget button if Web Widget is not present
+  const skipToWidgetButton = document.body.querySelector(".skip-to-web-widget");
+
+  let webWidgetLoadingCounter = 20;
+  let handleSkipToWidgetButtonIntervalId;
+  const handleSkipToWidgetButtonIntervalDuration = 500;
+
+  skipToWidgetButton.style.display = "none";
+
+  const handleSkipToWidgetButton = () => {
+    if ("zE" in window && window.zE("webWidget:get", "display") !== "hidden") {
+      skipToWidgetButton.addEventListener("click", () =>
+        window.zE(
+          window.zE.widget === "classic" ? "webWidget" : "messenger",
+          "open"
+        )
+      );
+      skipToWidgetButton.style.display = "inline-block";
+      clearInterval(handleSkipToWidgetButtonIntervalId);
+    }
+    if (webWidgetLoadingCounter-- <= 0) {
+      clearInterval(handleSkipToWidgetButtonIntervalId);
+    }
+  };
+
+  handleSkipToWidgetButtonIntervalId = setInterval(
+    handleSkipToWidgetButton,
+    handleSkipToWidgetButtonIntervalDuration
+  );
+
   // Toggles expanded aria to collapsible elements
   const collapsible = document.querySelectorAll(
     ".collapsible-nav, .collapsible-sidebar"

--- a/style.css
+++ b/style.css
@@ -845,6 +845,9 @@ ul {
   top: auto;
   z-index: -999;
 }
+.skip-navigation:visited {
+  color: white;
+}
 [dir=rtl] .skip-navigation {
   left: initial;
   right: -999px;

--- a/styles/_header.scss
+++ b/styles/_header.scss
@@ -259,3 +259,32 @@ $header-height: 71px;
 #zd-modal-container ~ .skip-navigation {
   display: none;
 }
+
+.skip-to-web-widget {
+  align-items: center;
+  background-color: black;
+  color: white;
+  display: flex;
+  font-size: 14px;
+  justify-content: center;
+  left: -919px;
+  margin: 20px;
+  padding: 20px;
+  overflow: hidden;
+  position: absolute;
+  top: auto;
+  z-index: -999;
+}
+
+.skip-to-web-widget:focus, .skip-to-web-widget:active {
+  left: auto;
+  overflow: auto;
+  text-align: center;
+  text-decoration: none;
+  top: auto;
+  z-index: 999;
+}
+[dir=rtl] .skip-to-web-widget {
+  left: initial;
+  right: -919px;
+}

--- a/styles/_header.scss
+++ b/styles/_header.scss
@@ -275,6 +275,9 @@ $header-height: 71px;
   top: auto;
   z-index: -999;
 }
+.skip-to-web-widget:visited {
+  color: white;
+}
 
 .skip-to-web-widget:focus, .skip-to-web-widget:active {
   left: auto;

--- a/templates/header.hbs
+++ b/templates/header.hbs
@@ -1,4 +1,5 @@
 <a class="skip-navigation" tabindex="1" href="#main-content">{{t 'skip_navigation' }}</a>
+<a class="skip-to-web-widget" tabindex="2" href="#launcher" >{{t 'skip_to_web_widget'}}</a>
 
 <header class="header">
   <div class="logo">


### PR DESCRIPTION
## Description


This PR adds a button to skip to web widget using keyboard navigation. 
The last commit is to make the skip navigations links to not change color after clicking as this was requested from accessibility team.
The js code checks if the widget doesn't exist after 500 ms then it hides the skip button but I had to add a timeout since the widget is loaded after some delay. There might be some slow widgets that load after 500ms and then the skip button is not rendered or we can increase the delay to 1s to decrease this chance.


https://github.com/zendesk/copenhagen_theme/assets/12232798/76b67ccc-b9d1-46ba-92ae-aa612ed2168a




Jira: https://zendesk.atlassian.net/browse/GS-2485

 

<!-- (optional) when applicable, please include some screenshots or gifs that illustrate the changes -->

## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->