### PR TITLE
fix: remove aria-controls on follow button if it exists

### DIFF
--- a/script.js
+++ b/script.js
@@ -57,6 +57,12 @@
       });
     });
 
+    // remove aria-controls if it exists to fix an accessibility issue
+    const followButton = document.querySelector("#follow-menu-button");
+    if (followButton) {
+      followButton.removeAttribute("aria-controls");
+    }
+
     // If multibrand search has more than 5 help centers or categories collapse the list
     const multibrandFilterLists = document.querySelectorAll(
       ".multibrand-filter-list"


### PR DESCRIPTION
## Description

<!-- a summary of the changes introduced by this PR and the motivation behind them -->

The newest version of `reach/menu-button. This attribute is [not that well supported](https://a11ysupport.io/tech/aria/aria-controls_attribute) by screen readers. Although accessibility experts were a bit surprised that this check is failing because the zendesk a11y checks don't show any error for the new markup. This PR tries to remove aria-controls to resolve this error.


The other option I can think of is switching to garden menu.

## Screenshots

<!-- (optional) when applicable, please include some screenshots or gifs that illustrate the changes -->

## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->