### PR TITLE
fix: use 'required' value from end user conditon

### DIFF
--- a/assets/new-request-form.js
+++ b/assets/new-request-form.js
@@ -608,13 +608,19 @@ function Attachments({ field }) {
 }
 
 function useEndUserConditions(fields, endUserConditions) {
-    return fields.filter((field) => {
+    return fields.reduce((accumulator, field) => {
         const conditions = endUserConditions.filter((condition) => condition.child_fields.some((childField) => childField.id === field.id));
-        const hasNoConditions = conditions.length === 0;
-        const meetsAnyCondition = conditions.some((condition) => fields.find((field) => field.id === condition.parent_field_id)
+        const metCondition = conditions.find((condition) => fields.find((field) => field.id === condition.parent_field_id)
             ?.value === condition.value);
-        return hasNoConditions || meetsAnyCondition;
-    });
+        const childField = metCondition?.child_fields.find((childField) => childField.id === field.id);
+        if (conditions.length === 0 || !!metCondition) {
+            accumulator.push({
+                ...field,
+                required: !!childField?.is_required,
+            });
+        }
+        return accumulator;
+    }, []);
 }
 
 function CreditCard({ field, onChange }) {

--- a/src/modules/new-request-form/useEndUserConditions.tsx
+++ b/src/modules/new-request-form/useEndUserConditions.tsx
@@ -4,18 +4,28 @@ export function useEndUserConditions(
   fields: Field[],
   endUserConditions: EndUserCondition[]
 ): Field[] {
-  return fields.filter((field) => {
+  return fields.reduce((accumulator: Field[], field) => {
     const conditions = endUserConditions.filter((condition) =>
       condition.child_fields.some((childField) => childField.id === field.id)
     );
 
-    const hasNoConditions = conditions.length === 0;
-    const meetsAnyCondition = conditions.some(
+    const metCondition = conditions.find(
       (condition) =>
         fields.find((field) => field.id === condition.parent_field_id)
           ?.value === condition.value
     );
 
-    return hasNoConditions || meetsAnyCondition;
-  });
+    const childField = metCondition?.child_fields.find(
+      (childField) => childField.id === field.id
+    );
+
+    if (conditions.length === 0 || !!metCondition) {
+      accumulator.push({
+        ...field,
+        required: !!childField?.is_required,
+      });
+    }
+
+    return accumulator;
+  }, []);
 }


### PR DESCRIPTION
## Description

*context*:

When configuring end user conditions, one can "override" the field's `required` value.
We must respect the `is_required` value set int the condition's child field and copy it over into the request `field` so it can be rendered with/out the asterisk (*).

## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->