### PR TITLE
Return focus to ticket form field dropdown

### DIFF
--- a/assets/new-request-form.js
+++ b/assets/new-request-form.js
@@ -250,6 +250,8 @@ function MultiSelect({ field }) {
 }
 
 function TicketFormField({ label, ticketFormField, ticketForms, }) {
+    const key = ticketFormField.name;
+    const ref = reactExports.createRef();
     const handleChange = ({ selectionValue }) => {
         if (selectionValue && typeof selectionValue === "string") {
             const newUrl = new URL(window.location.origin + selectionValue);
@@ -258,10 +260,19 @@ function TicketFormField({ label, ticketFormField, ticketForms, }) {
             for (const [key, value] of currentSearchParams) {
                 newUrl.searchParams.append(key, value);
             }
+            sessionStorage.setItem(key, crypto.randomUUID());
             window.location.href = newUrl.toString();
         }
     };
-    return (jsxRuntimeExports.jsxs(jsxRuntimeExports.Fragment, { children: [jsxRuntimeExports.jsx("input", { type: "hidden", name: ticketFormField.name, value: ticketFormField.value }), ticketForms.length > 1 && (jsxRuntimeExports.jsxs(Field$1, { children: [jsxRuntimeExports.jsx(Label, { children: label }), jsxRuntimeExports.jsx(Combobox, { isEditable: false, onChange: handleChange, children: ticketForms.map(({ id, url, display_name }) => (jsxRuntimeExports.jsx(Option, { value: url, label: display_name, isSelected: ticketFormField.value === id, children: display_name }, id))) })] }))] }));
+    reactExports.useEffect(() => {
+        if (sessionStorage.getItem(key)) {
+            sessionStorage.removeItem(key);
+            // return focus to the ticket form field dropdown
+            // after the page reloads for better a11y
+            ref.current?.firstChild?.focus();
+        }
+    }, []); // eslint-disable-line react-hooks/exhaustive-deps
+    return (jsxRuntimeExports.jsxs(jsxRuntimeExports.Fragment, { children: [jsxRuntimeExports.jsx("input", { type: "hidden", name: ticketFormField.name, value: ticketFormField.value }), ticketForms.length > 1 && (jsxRuntimeExports.jsxs(Field$1, { children: [jsxRuntimeExports.jsx(Label, { children: label }), jsxRuntimeExports.jsx(Combobox, { isEditable: false, onChange: handleChange, ref: ref, children: ticketForms.map(({ id, url, display_name }) => (jsxRuntimeExports.jsx(Option, { value: url, label: display_name, isSelected: ticketFormField.value === id, children: display_name }, id))) })] }))] }));
 }
 
 function ParentTicketField({ field, }) {

--- a/src/modules/new-request-form/ticket-form-field/TicketFormField.tsx
+++ b/src/modules/new-request-form/ticket-form-field/TicketFormField.tsx
@@ -1,4 +1,5 @@
 import type { IComboboxProps } from "@zendeskgarden/react-dropdowns.next";
+import { createRef, useEffect } from "react";
 import {
   Combobox,
   Field as GardenField,
@@ -14,11 +15,15 @@ interface TicketFormFieldProps {
   ticketForms: TicketForm[];
 }
 
+const key = "return-focus-to-ticket-form-field";
+
 export function TicketFormField({
   label,
   ticketFormField,
   ticketForms,
 }: TicketFormFieldProps) {
+  const ref = createRef<HTMLDivElement>();
+
   const handleChange: IComboboxProps["onChange"] = ({ selectionValue }) => {
     if (selectionValue && typeof selectionValue === "string") {
       const newUrl = new URL(window.location.origin + selectionValue);
@@ -30,9 +35,20 @@ export function TicketFormField({
         newUrl.searchParams.append(key, value);
       }
 
+      sessionStorage.setItem(key, "true");
+
       window.location.href = newUrl.toString();
     }
   };
+
+  useEffect(() => {
+    if (sessionStorage.getItem(key)) {
+      sessionStorage.removeItem(key);
+      // return focus to the ticket form field dropdown
+      // after the page reloads for better a11y
+      (ref.current?.firstChild as HTMLElement)?.focus();
+    }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <>
@@ -44,7 +60,7 @@ export function TicketFormField({
       {ticketForms.length > 1 && (
         <GardenField>
           <Label>{label}</Label>
-          <Combobox isEditable={false} onChange={handleChange}>
+          <Combobox isEditable={false} onChange={handleChange} ref={ref}>
             {ticketForms.map(({ id, url, display_name }) => (
               <Option
                 key={id}


### PR DESCRIPTION
## Description

There is a full page reload after the user selects a new ticket form. We want to return the focus to the dropdown for a better a11y.

## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->