### PR TITLE
fix: fix 'required' state and prefilling of multiselect fields

### DIFF
--- a/assets/new-request-form.js
+++ b/assets/new-request-form.js
@@ -249,8 +249,8 @@ function MultiSelect({ field }) {
     return (jsxRuntimeExports.jsxs(Field$1, { children: [selectedValues.map((selectedValue) => (jsxRuntimeExports.jsx("input", { type: "hidden", name: `${name}[]`, value: selectedValue }, selectedValue))), jsxRuntimeExports.jsxs(Label, { children: [label, required && jsxRuntimeExports.jsx(Span, { "aria-hidden": "true", children: "*" })] }), description && jsxRuntimeExports.jsx(Hint$1, { children: description }), jsxRuntimeExports.jsxs(Combobox, { ref: wrapperRef, isMultiselectable: true, inputProps: { required }, isEditable: false, validation: error ? "error" : undefined, onChange: handleChange, selectionValue: selectedValues, maxHeight: "auto", children: [currentGroup.type === "SubGroup" && (jsxRuntimeExports.jsx(Option, { ...currentGroup.backOption })), currentGroup.type === "SubGroup" ? (jsxRuntimeExports.jsx(OptGroup, { "aria-label": currentGroup.name, children: currentGroup.options.map((option) => (jsxRuntimeExports.jsx(Option, { ...option, children: option.menuLabel ?? option.label }, option.value))) })) : (currentGroup.options.map((option) => (jsxRuntimeExports.jsx(Option, { ...option }, option.value))))] }), error && jsxRuntimeExports.jsx(Message$1, { validation: "error", children: error })] }));
 }
 
+const key = "return-focus-to-ticket-form-field";
 function TicketFormField({ label, ticketFormField, ticketForms, }) {
-    const key = ticketFormField.name;
     const ref = reactExports.createRef();
     const handleChange = ({ selectionValue }) => {
         if (selectionValue && typeof selectionValue === "string") {
@@ -260,7 +260,7 @@ function TicketFormField({ label, ticketFormField, ticketForms, }) {
             for (const [key, value] of currentSearchParams) {
                 newUrl.searchParams.append(key, value);
             }
-            sessionStorage.setItem(key, crypto.randomUUID());
+            sessionStorage.setItem(key, "true");
             window.location.href = newUrl.toString();
         }
     };
@@ -455,7 +455,10 @@ function usePrefilledTicketFields(fields) {
             case "partialcreditcard":
                 continue;
             case "multiselect":
-                field.value = JSON.stringify(sanitizedValue.split(","));
+                field.value = sanitizedValue
+                    .split(",")
+                    // filter out prefilled options that don't exist
+                    .filter((value) => field.options.some((option) => option.value === value));
                 break;
             case "checkbox":
                 if (ALLOWED_BOOLEAN_VALUES.includes(sanitizedValue)) {
@@ -627,7 +630,8 @@ function useEndUserConditions(fields, endUserConditions) {
         if (conditions.length === 0 || !!metCondition) {
             accumulator.push({
                 ...field,
-                required: !!childField?.is_required,
+                // required: !!childField?.is_required,
+                required: childField ? childField.is_required : field.required,
             });
         }
         return accumulator;

--- a/src/modules/new-request-form/useEndUserConditions.tsx
+++ b/src/modules/new-request-form/useEndUserConditions.tsx
@@ -22,7 +22,7 @@ export function useEndUserConditions(
     if (conditions.length === 0 || !!metCondition) {
       accumulator.push({
         ...field,
-        required: !!childField?.is_required,
+        required: childField ? childField.is_required : field.required,
       });
     }
 

--- a/src/modules/new-request-form/usePrefilledTicketFields.tsx
+++ b/src/modules/new-request-form/usePrefilledTicketFields.tsx
@@ -67,7 +67,12 @@ export function usePrefilledTicketFields(fields: Field[]): Field[] {
       case "partialcreditcard":
         continue;
       case "multiselect":
-        field.value = JSON.stringify(sanitizedValue.split(","));
+        field.value = sanitizedValue
+          .split(",")
+          // filter out prefilled options that don't exist
+          .filter((value) =>
+            field.options.some((option) => option.value === value)
+          );
         break;
       case "checkbox":
         if (ALLOWED_BOOLEAN_VALUES.includes(sanitizedValue)) {


### PR DESCRIPTION
## Description

- [x] Fixes a bug where fields without child field conditions would always have `required: false`
- [x] Fixes a bug where pre-filing the multiselect fields would throw an exception and break the form

## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->