### PR TITLE
Use the public deflection endpoint URL instead of the internal one

### DIFF
--- a/assets/new-request-form.js
+++ b/assets/new-request-form.js
@@ -630,7 +630,6 @@ function useEndUserConditions(fields, endUserConditions) {
         if (conditions.length === 0 || !!metCondition) {
             accumulator.push({
                 ...field,
-                // required: !!childField?.is_required,
                 required: childField ? childField.is_required : field.required,
             });
         }
@@ -741,7 +740,7 @@ function SuggestedArticles({ query: inputQuery, locale, }) {
             setArticles([]);
             return;
         }
-        const requestUrl = new URL(`${window.location.origin}/hc/api/internal/deflection/suggestions.json`);
+        const requestUrl = new URL(`${window.location.origin}/api/v2/help_center/deflection/suggestions.json`);
         requestUrl.searchParams.append("locale", locale);
         requestUrl.searchParams.append("query", query);
         const cachedResponse = requestsCache.current[requestUrl.toString()];

--- a/src/modules/new-request-form/suggested-articles/SuggestedArticles.tsx
+++ b/src/modules/new-request-form/suggested-articles/SuggestedArticles.tsx
@@ -80,7 +80,7 @@ export function SuggestedArticles({
     }
 
     const requestUrl = new URL(
-      `${window.location.origin}/hc/api/internal/deflection/suggestions.json`
+      `${window.location.origin}/api/v2/help_center/deflection/suggestions.json`
     );
     requestUrl.searchParams.append("locale", locale);
     requestUrl.searchParams.append("query", query);


### PR DESCRIPTION
## Description

There is now a public endpoint for ticket deflection suggestions. Let's use it.

## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->