### PR TITLE
Use the public sessions endpoint URL instead of the internal one

### DIFF
--- a/assets/new-request-form.js
+++ b/assets/new-request-form.js
@@ -339,7 +339,7 @@ function charRepeater(character, length) {
 
 // NOTE: This is a temporary handling of the CSRF token
 async function fetchCsrfToken$1() {
-    const response = await fetch("/hc/api/internal/csrf_token.json");
+    const response = await fetch("/api/v2/help_center/sessions.json");
     const { current_session } = await response.json();
     return current_session.csrf_token;
 }

--- a/src/modules/new-request-form/fetchCsrfToken.ts
+++ b/src/modules/new-request-form/fetchCsrfToken.ts
@@ -1,6 +1,6 @@
 // NOTE: This is a temporary handling of the CSRF token
 export async function fetchCsrfToken() {
-  const response = await fetch("/hc/api/internal/csrf_token.json");
+  const response = await fetch("/api/v2/help_center/sessions.json");
   const { current_session } = await response.json();
   return current_session.csrf_token as string;
 }


### PR DESCRIPTION
## Description

There is now a public endpoint for help center sessions and access to its csrf token. Let's use it.


## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->