### PR TITLE
Fixing RTL in the new request form

### DIFF
--- a/assets/useModalContainer.js
+++ b/assets/useModalContainer.js
@@ -4,6 +4,7 @@ let theme = DEFAULT_THEME;
 function setupGardenTheme({ textColor, brandColor, linkColor, hoverLinkColor, visitedLinkColor, }) {
     theme = {
         ...DEFAULT_THEME,
+        rtl: document.dir === "rtl",
         colors: {
             ...DEFAULT_THEME.colors,
             foreground: textColor,

--- a/src/modules/theming/setupGardenTheme.ts
+++ b/src/modules/theming/setupGardenTheme.ts
@@ -20,6 +20,7 @@ export function setupGardenTheme({
 }: SetupGardenThemeProps) {
   theme = {
     ...DEFAULT_THEME,
+    rtl: document.dir === "rtl",
     colors: {
       ...DEFAULT_THEME.colors,
       foreground: textColor,


### PR DESCRIPTION
## Description

We were not setting `rtl` when setting up the garden theme.

## Screenshots

_before_

<img width="710" alt="Screenshot 2024-02-27 at 14 35 58" src="https://github.com/zendesk/copenhagen_theme/assets/1159544/32f1a031-57f7-404c-b4a9-7c122fb21e99">

_after_

<img width="710" alt="Screenshot 2024-02-27 at 14 36 43" src="https://github.com/zendesk/copenhagen_theme/assets/1159544/0e87a585-b410-48f4-82a1-3872701b4aa9">