### PR TITLE
fix: open survey response links in a new tab

### DIFF
--- a/templates/request_page.hbs
+++ b/templates/request_page.hbs
@@ -140,7 +140,7 @@
                   {{/is}}
                 </div>
 
-                {{#link 'survey_response' id=../id}}
+                {{#link 'survey_response' id=../id target="_blank"}}
                   {{#if ../editable}}
                     {{t 'edit_feedback'}}
                   {{else}}
@@ -154,7 +154,7 @@
               <dl class="request-details">
                 <dt>{{t 'rating'}}</dt>
                 <dd>
-                  {{#link 'survey_response' id=id}}
+                  {{#link 'survey_response' id=id target="_blank"}}
                     {{t 'add_feedback'}}
                   {{/link}}
                 </dd>


### PR DESCRIPTION
## Description

The `Add/Edit/View feedback` links were meant to be opened in a new tab. This PR fixes that.

## Screenshots

<!-- (optional) when applicable, please include some screenshots or gifs that illustrate the changes -->

## Checklist

- [x] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [x] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [x] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [x] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->