### PR TITLE
Revert "fix: open survey response links in a new tab"

### DIFF
--- a/templates/request_page.hbs
+++ b/templates/request_page.hbs
@@ -140,7 +140,7 @@
                   {{/is}}
                 </div>
 
-                {{#link 'survey_response' id=../id target="_blank"}}
+                {{#link 'survey_response' id=../id}}
                   {{#if ../editable}}
                     {{t 'edit_feedback'}}
                   {{else}}
@@ -154,7 +154,7 @@
               <dl class="request-details">
                 <dt>{{t 'rating'}}</dt>
                 <dd>
-                  {{#link 'survey_response' id=id target="_blank"}}
+                  {{#link 'survey_response' id=id}}
                     {{t 'add_feedback'}}
                   {{/link}}
                 </dd>


### PR DESCRIPTION
Reverts zendesk/copenhagen_theme#463

Product + design decided, it was a better experience when the survey response page opened in the same window/tab.