### PR TITLE
fix: fixed organization dropdown and ticket prefilling

### DIFF
--- a/src/modules/new-request-form/NewRequestForm.tsx
+++ b/src/modules/new-request-form/NewRequestForm.tsx
@@ -81,8 +81,24 @@ export function NewRequestForm({
     description_mimetype_field,
   } = requestForm;
   const { answerBot } = answerBotModal;
-  const prefilledTicketFields = usePrefilledTicketFields(ticket_fields);
+  const {
+    ticketFields: prefilledTicketFields,
+    emailField,
+    ccField,
+    organizationField: prefilledOrganizationField,
+    dueDateField,
+  } = usePrefilledTicketFields({
+    ticketFields: ticket_fields,
+    emailField: email_field,
+    ccField: cc_field,
+    organizationField: organization_field,
+    dueDateField: due_date_field,
+  });
+
   const [ticketFields, setTicketFields] = useState(prefilledTicketFields);
+  const [organizationField, setOrganizationField] = useState(
+    prefilledOrganizationField
+  );
   const visibleFields = useEndUserConditions(ticketFields, end_user_conditions);
   const { formRefCallback, handleSubmit } = useFormSubmit(ticketFields);
   const { t } = useTranslation();
@@ -95,6 +111,14 @@ export function NewRequestForm({
           : ticketField
       )
     );
+  }
+
+  function handleOrganizationChange(value: string) {
+    if (organizationField === null) {
+      return;
+    }
+
+    setOrganizationField({ ...organizationField, value });
   }
 
   return (
@@ -131,19 +155,15 @@ export function NewRequestForm({
         {ticket_form_field.options.length > 0 && (
           <TicketFormField field={ticket_form_field} />
         )}
-        {email_field && (
-          <Input
-            key={email_field.name}
-            field={email_field}
-            onChange={(value) => handleChange(email_field, value)}
-          />
-        )}
-        {cc_field && <CcField field={cc_field} />}
-        {organization_field && (
+        {emailField && <Input key={emailField.name} field={emailField} />}
+        {ccField && <CcField field={ccField} />}
+        {organizationField && (
           <DropDown
-            key={organization_field.name}
-            field={organization_field}
-            onChange={(value) => handleChange(organization_field, value)}
+            key={organizationField.name}
+            field={organizationField}
+            onChange={(value) => {
+              handleOrganizationChange(value);
+            }}
           />
         )}
         {visibleFields.map((field) => {
@@ -216,7 +236,7 @@ export function NewRequestForm({
                   />
                   {field.value === "task" && (
                     <DatePicker
-                      field={due_date_field}
+                      field={dueDateField}
                       locale={baseLocale}
                       valueFormat="dateTime"
                     />

--- a/src/modules/new-request-form/data-types/RequestForm.tsx
+++ b/src/modules/new-request-form/data-types/RequestForm.tsx
@@ -10,9 +10,9 @@ export interface RequestForm {
   errors: string | null;
   ticket_form_field: Field;
   parent_id_field: Field;
-  email_field: Field;
-  cc_field: Field;
-  organization_field: Field;
+  email_field: Field | null;
+  cc_field: Field | null;
+  organization_field: Field | null;
   due_date_field: Field;
   ticket_fields: Field[];
   end_user_conditions: EndUserCondition[];

--- a/src/modules/new-request-form/fields/Input.tsx
+++ b/src/modules/new-request-form/fields/Input.tsx
@@ -10,7 +10,7 @@ import type { Field } from "../data-types";
 
 interface InputProps {
   field: Field;
-  onChange: (value: string) => void;
+  onChange?: (value: string) => void;
 }
 
 export function Input({ field, onChange }: InputProps): JSX.Element {
@@ -40,7 +40,9 @@ export function Input({ field, onChange }: InputProps): JSX.Element {
         defaultValue={value as string}
         validation={error ? "error" : undefined}
         required={required}
-        onChange={(e) => onChange(e.target.value)}
+        onChange={(e) => {
+          onChange && onChange(e.target.value);
+        }}
         autoComplete={autocomplete}
         {...stepProp}
       />


### PR DESCRIPTION
## Description

This PR fixes the value selection and the prefilling of the organization field and the prefilling of the CC field, the anonymous requester email, and the due date field.

These issues were introduced when [we moved some fields out of the ticket_fields array](https://github.com/zendesk/copenhagen_theme/pull/457). Those features stopped working since the value tracking of the controlled components and the prefilling were still working only on the ticket_fields array.

Prefill changes:
- Passing down and returning also the fields that are outside the `ticket_fields` array
- Wrapped the function in a `useMemo` since we don't need to recalculate them on each rerender
  - Changed `usePrefilledTicketFields` to a normal function called  `prefillTicketFields` - it doesn't need to be a hook since we are not using any other hook inside it

Added a new `useState` to keep track of the organization field value. We don't need it for the other fields since they are implemented as uncontrolled components.

## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->