### PR TITLE
fix: allow empty credit card value

### DIFF
--- a/assets/new-request-form-bundle.js
+++ b/assets/new-request-form-bundle.js
@@ -360,7 +360,8 @@ function useFormSubmit(ticketFields) {
                     for (const creditCardField of creditCardFields) {
                         const creditCardInput = ref.querySelector(`input[name="${creditCardField.name}"]`);
                         if (creditCardInput &&
-                            creditCardInput instanceof HTMLInputElement) {
+                            creditCardInput instanceof HTMLInputElement &&
+                            creditCardInput.value.length === 4) {
                             creditCardInput.value = `XXXXXXXXX${creditCardInput.value}`;
                         }
                     }

--- a/src/modules/new-request-form/useFormSubmit.tsx
+++ b/src/modules/new-request-form/useFormSubmit.tsx
@@ -54,7 +54,8 @@ export function useFormSubmit(ticketFields: Field[]): UseFormSubmit {
               );
               if (
                 creditCardInput &&
-                creditCardInput instanceof HTMLInputElement
+                creditCardInput instanceof HTMLInputElement &&
+                creditCardInput.value.length === 4
               ) {
                 creditCardInput.value = `XXXXXXXXX${creditCardInput.value}`;
               }


### PR DESCRIPTION
## Description

This PR fixes the issue that prevented form submission when the Credit Card field contained an empty value

## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->