### PR TITLE
feat: increase textarea size and make it resizable

### DIFF
--- a/assets/new-request-form-bundle.js
+++ b/assets/new-request-form-bundle.js
@@ -60,7 +60,7 @@ function TextArea({ field, hasWysiwyg, baseLocale, hasAtMentions, userRole, bran
         userRole,
         brandId,
     });
-    return (jsxRuntimeExports.jsxs(Field, { children: [jsxRuntimeExports.jsxs(Label$1, { children: [label, required && jsxRuntimeExports.jsx(Span, { "aria-hidden": "true", children: "*" })] }), description && (jsxRuntimeExports.jsx(Hint, { dangerouslySetInnerHTML: { __html: description } })), jsxRuntimeExports.jsx(Textarea, { ref: ref, name: name, defaultValue: value, validation: error ? "error" : undefined, required: required, onChange: (e) => onChange(e.target.value) }), error && jsxRuntimeExports.jsx(Message, { validation: "error", children: error })] }));
+    return (jsxRuntimeExports.jsxs(Field, { children: [jsxRuntimeExports.jsxs(Label$1, { children: [label, required && jsxRuntimeExports.jsx(Span, { "aria-hidden": "true", children: "*" })] }), description && (jsxRuntimeExports.jsx(Hint, { dangerouslySetInnerHTML: { __html: description } })), jsxRuntimeExports.jsx(Textarea, { ref: ref, name: name, defaultValue: value, validation: error ? "error" : undefined, required: required, onChange: (e) => onChange(e.target.value), rows: 6, isResizable: true }), error && jsxRuntimeExports.jsx(Message, { validation: "error", children: error })] }));
 }
 
 const HideVisually = styled.span `

--- a/src/modules/new-request-form/fields/textarea/TextArea.tsx
+++ b/src/modules/new-request-form/fields/textarea/TextArea.tsx
@@ -53,6 +53,8 @@ export function TextArea({
         validation={error ? "error" : undefined}
         required={required}
         onChange={(e) => onChange(e.target.value)}
+        rows={6}
+        isResizable
       />
       {error && <Message validation="error">{error}</Message>}
     </GardenField>


### PR DESCRIPTION
## Description

This PR increases the height of the `Textarea` component to 6 rows (similar height to the textarea in v3), and it adds the resize handle to it

## Screenshots

Before:
![Screenshot 2024-04-25 at 15 38 20](https://github.com/zendesk/copenhagen_theme/assets/13420283/aa517d58-becf-4d87-9877-ce4a7d8342db)

After:
![Screenshot 2024-04-25 at 15 36 25](https://github.com/zendesk/copenhagen_theme/assets/13420283/8ca1afc7-df96-47f6-af16-3be5100f3e49)

## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->