### PR TITLE
fix: Avoid Global styles / Garden styles clash

### DIFF
--- a/assets/new-request-form-bundle.js
+++ b/assets/new-request-form-bundle.js
@@ -841,11 +841,6 @@ const StyledInput = styled(Input$1) `
   left: 0;
   height: var(--line-height);
   line-height: var(--line-height);
-
-  // override CPH default style. Can be removed once global styles are removed
-  &:focus {
-    border: none !important;
-  }
 `;
 const AnnouncementMessage = styled.span `
   ${hideVisually()}
@@ -894,12 +889,6 @@ function CcField({ field }) {
 function getLastDigits(value) {
     return value ? value.replaceAll("X", "") : "";
 }
-// override CPH default style. Can be removed once global styles are removed
-const StyledMediaInput = styled(MediaInput) `
-  &:focus {
-    border: none !important;
-  }
-`;
 const DigitsHintSpan = styled(Span) `
   margin-left: ${(props) => props.theme.space.xxs};
 `;
@@ -907,7 +896,7 @@ function CreditCard({ field, onChange }) {
     const { t } = useTranslation();
     const { label, error, value, name, required, description } = field;
     const digits = getLastDigits(value);
-    return (jsxRuntimeExports.jsxs(Field, { children: [jsxRuntimeExports.jsxs(Label$1, { children: [label, required && jsxRuntimeExports.jsx(Span, { "aria-hidden": "true", children: "*" }), jsxRuntimeExports.jsx(DigitsHintSpan, { children: t("new-request-form.credit-card-digits-hint", "(Last 4 digits)") })] }), description && (jsxRuntimeExports.jsx(Hint, { dangerouslySetInnerHTML: { __html: description } })), jsxRuntimeExports.jsx(StyledMediaInput, { start: jsxRuntimeExports.jsx(SvgCreditCardStroke, {}), name: name, type: "text", value: digits, onChange: (e) => onChange(e.target.value), validation: error ? "error" : undefined, required: required, maxLength: 4 }), error && jsxRuntimeExports.jsx(Message, { validation: "error", children: error })] }));
+    return (jsxRuntimeExports.jsxs(Field, { children: [jsxRuntimeExports.jsxs(Label$1, { children: [label, required && jsxRuntimeExports.jsx(Span, { "aria-hidden": "true", children: "*" }), jsxRuntimeExports.jsx(DigitsHintSpan, { children: t("new-request-form.credit-card-digits-hint", "(Last 4 digits)") })] }), description && (jsxRuntimeExports.jsx(Hint, { dangerouslySetInnerHTML: { __html: description } })), jsxRuntimeExports.jsx(MediaInput, { start: jsxRuntimeExports.jsx(SvgCreditCardStroke, {}), name: name, type: "text", value: digits, onChange: (e) => onChange(e.target.value), validation: error ? "error" : undefined, required: required, maxLength: 4 }), error && jsxRuntimeExports.jsx(Message, { validation: "error", children: error })] }));
 }
 
 function Tagger({ field, onChange }) {

--- a/src/modules/new-request-form/fields/CreditCard.tsx
+++ b/src/modules/new-request-form/fields/CreditCard.tsx
@@ -27,13 +27,6 @@ function getLastDigits(value: string): string {
   return value ? value.replaceAll("X", "") : "";
 }
 
-// override CPH default style. Can be removed once global styles are removed
-const StyledMediaInput = styled(MediaInput)`
-  &:focus {
-    border: none !important;
-  }
-`;
-
 const DigitsHintSpan = styled(Span)`
   margin-left: ${(props) => props.theme.space.xxs};
 `;
@@ -55,7 +48,7 @@ export function CreditCard({ field, onChange }: CreditCardProps): JSX.Element {
       {description && (
         <Hint dangerouslySetInnerHTML={{ __html: description }} />
       )}
-      <StyledMediaInput
+      <MediaInput
         start={<CreditCardIcon />}
         name={name}
         type="text"

--- a/src/modules/new-request-form/fields/cc-field/CcField.tsx
+++ b/src/modules/new-request-form/fields/cc-field/CcField.tsx
@@ -71,11 +71,6 @@ const StyledInput = styled(Input)`
   left: 0;
   height: var(--line-height);
   line-height: var(--line-height);
-
-  // override CPH default style. Can be removed once global styles are removed
-  &:focus {
-    border: none !important;
-  }
 `;
 
 const AnnouncementMessage = styled.span`

--- a/style.css
+++ b/style.css
@@ -238,29 +238,28 @@ a:hover, a:active, a:focus {
   text-decoration: underline;
 }
 
-input,
-textarea {
+.hbs-form input,
+.hbs-form textarea, .search input,
+.search textarea {
   color: #000;
   font-size: 14px;
 }
-
-input {
+.hbs-form input, .search input {
   max-width: 100%;
   box-sizing: border-box;
   transition: border 0.12s ease-in-out;
+  /* We use the :where selector to not increase the specificity of the selector */
 }
-input:not([type=checkbox]) {
+.hbs-form input:where(:not([type=checkbox])), .search input:where(:not([type=checkbox])) {
   outline: none;
 }
-input:not([type=checkbox]):focus {
+.hbs-form input:where(:not([type=checkbox])):focus, .search input:where(:not([type=checkbox])):focus {
   border: 1px solid $brand_color;
 }
-
-input[disabled] {
+.hbs-form input[disabled], .search input[disabled] {
   background-color: #ddd;
 }
-
-select {
+.hbs-form select, .search select {
   -webkit-appearance: none;
   -moz-appearance: none;
   background: url("data:image/svg+xml,%3C%3Fxml version='1.0' encoding='UTF-8'%3F%3E%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'%3E%3Cpath fill='%23CCC' d='M0 0h10L5 6 0 0z'/%3E%3C/svg%3E%0A") no-repeat #fff;
@@ -272,14 +271,13 @@ select {
   color: #555;
   width: 100%;
 }
-select:focus {
+.hbs-form select:focus, .search select:focus {
   border: 1px solid $brand_color;
 }
-select::-ms-expand {
+.hbs-form select::-ms-expand, .search select::-ms-expand {
   display: none;
 }
-
-textarea {
+.hbs-form textarea, .search textarea {
   border: 1px solid #87929D;
   border-radius: 2px;
   resize: vertical;
@@ -287,7 +285,7 @@ textarea {
   outline: none;
   padding: 10px;
 }
-textarea:focus {
+.hbs-form textarea:focus, .search textarea:focus {
   border: 1px solid $brand_color;
 }
 
@@ -380,7 +378,7 @@ ul {
   cursor: default;
 }
 
-.button-large, input[type=submit] {
+.button-large, .hbs-form input[type=submit] {
   cursor: pointer;
   background-color: $brand_color;
   border: 0;
@@ -393,17 +391,17 @@ ul {
   width: 100%;
 }
 @media (min-width: 768px) {
-  .button-large, input[type=submit] {
+  .button-large, .hbs-form input[type=submit] {
     width: auto;
   }
 }
-.button-large:visited, input[type=submit]:visited {
+.button-large:visited, .hbs-form input[type=submit]:visited {
   color: $brand_text_color;
 }
-.button-large:hover, .button-large:active, .button-large:focus, input[type=submit]:hover, input[type=submit]:active, input[type=submit]:focus {
+.button-large:hover, .button-large:active, .button-large:focus, .hbs-form input[type=submit]:hover, .hbs-form input[type=submit]:active, .hbs-form input[type=submit]:focus {
   background-color: darken($brand_color, 20%);
 }
-.button-large[disabled], input[type=submit][disabled] {
+.button-large[disabled], .hbs-form input[type=submit][disabled] {
   background-color: #ddd;
 }
 

--- a/styles/_base.scss
+++ b/styles/_base.scss
@@ -60,64 +60,68 @@ a {
   }
 }
 
-input,
-textarea {
-  color: #000;
-  font-size: $input-font-size;
-}
-
-input {
-  max-width: 100%;
-  box-sizing: border-box;
-  transition: $input-transition;
-
-  &:not([type="checkbox"]) {
+.hbs-form, .search {
+  input,
+  textarea {
+    color: #000;
+    font-size: $input-font-size;
+  }
+  
+  input {
+    max-width: 100%;
+    box-sizing: border-box;
+    transition: $input-transition;
+  
+    /* We use the :where selector to not increase the specificity of the selector */
+    &:where(:not([type="checkbox"])) {
+      outline: none;
+  
+      &:focus {
+        border: 1px solid $brand_color;
+      }
+    }
+  }
+  
+  input[disabled] {
+    background-color: #ddd;
+  }
+  
+  select {
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    background: url("data:image/svg+xml,%3C%3Fxml version='1.0' encoding='UTF-8'%3F%3E%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'%3E%3Cpath fill='%23CCC' d='M0 0h10L5 6 0 0z'/%3E%3C/svg%3E%0A")
+      no-repeat #fff;
+    background-position: right 10px center;
+    border: 1px solid $high-contrast-border-color;
+    border-radius: 4px;
+    padding: 8px 30px 8px 10px;
     outline: none;
-
+    color: $field-text-focus-color;
+    width: 100%;
+  
+    &:focus {
+      border: 1px solid $brand_color;
+    }
+  
+    &::-ms-expand {
+      display: none;
+    }
+  }
+  
+  textarea {
+    border: 1px solid $high-contrast-border-color;
+    border-radius: 2px;
+    resize: vertical;
+    width: 100%;
+    outline: none;
+    padding: 10px;
+  
     &:focus {
       border: 1px solid $brand_color;
     }
   }
 }
 
-input[disabled] {
-  background-color: #ddd;
-}
-
-select {
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  background: url("data:image/svg+xml,%3C%3Fxml version='1.0' encoding='UTF-8'%3F%3E%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'%3E%3Cpath fill='%23CCC' d='M0 0h10L5 6 0 0z'/%3E%3C/svg%3E%0A")
-    no-repeat #fff;
-  background-position: right 10px center;
-  border: 1px solid $high-contrast-border-color;
-  border-radius: 4px;
-  padding: 8px 30px 8px 10px;
-  outline: none;
-  color: $field-text-focus-color;
-  width: 100%;
-
-  &:focus {
-    border: 1px solid $brand_color;
-  }
-
-  &::-ms-expand {
-    display: none;
-  }
-}
-
-textarea {
-  border: 1px solid $high-contrast-border-color;
-  border-radius: 2px;
-  resize: vertical;
-  width: 100%;
-  outline: none;
-  padding: 10px;
-
-  &:focus {
-    border: 1px solid $brand_color;
-  }
-}
 
 .container {
   @include max-width-container;

--- a/styles/_buttons.scss
+++ b/styles/_buttons.scss
@@ -46,7 +46,7 @@
   }
 }
 
-.button-large, input[type="submit"] {
+.button-large, .hbs-form input[type="submit"] {
   @include tablet {
     width: auto;
   }

--- a/templates/article_page.hbs
+++ b/templates/article_page.hbs
@@ -308,7 +308,7 @@
 
             {{pagination}}
 
-            {{#form 'comment' class='comment-form'}}
+            {{#form 'comment' class='comment-form hbs-form'}}
               <div class="avatar comment-avatar">
                 {{user_avatar class='user-avatar'}}
               </div>

--- a/templates/community_post_page.hbs
+++ b/templates/community_post_page.hbs
@@ -303,7 +303,7 @@
       {{pagination}}
 
       <section class="post-comments">
-        {{#form 'comment' class='comment-form'}}
+        {{#form 'comment' class='comment-form hbs-form'}}
           <div class="avatar comment-avatar">
             {{user_avatar class='user-avatar'}}
           </div>

--- a/templates/new_community_post_page.hbs
+++ b/templates/new_community_post_page.hbs
@@ -16,7 +16,7 @@
   </h1>
 
   <div id="main-content" class="form">
-    {{#form 'post' class='new_community_post'}}
+    {{#form 'post' class='new_community_post hbs-form'}}
       <div class="form-field">
         {{#required 'title'}}
           {{label 'title'}}

--- a/templates/request_page.hbs
+++ b/templates/request_page.hbs
@@ -64,7 +64,7 @@
         {{comment_callout}}
       </div>
 
-      {{#form 'comment' class='comment-form'}}
+      {{#form 'comment' class='comment-form hbs-form'}}
         <div class="avatar comment-avatar">
           {{user_avatar class='user-avatar'}}
         </div>
@@ -160,7 +160,7 @@
           <dt>{{t 'id'}}</dt>
           <dd>#{{request.id}}</dd>
 
-          {{#form 'organization' id='request-organization'}}
+          {{#form 'organization' id='request-organization' class='hbs-form'}}
             <dt>{{t 'organization'}}</dt>
             <dd>{{select 'organization'}}</dd>
           {{/form}}

--- a/templates/requests_page.hbs
+++ b/templates/requests_page.hbs
@@ -36,7 +36,7 @@
       </div>
     </header>
 
-    {{#form 'requests_filter' id="main-content" class='requests-table-toolbar'}}
+    {{#form 'requests_filter' id="main-content" class='requests-table-toolbar hbs-form'}}
       <div class="search">
         <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" focusable="false" viewBox="0 0 12 12" class="search-icon" aria-hidden="true">
           <circle cx="4.5" cy="4.5" r="4" fill="none" stroke="currentColor"/>


### PR DESCRIPTION
## Description

This PR fixes the conflict between the global styles defined in the global CSS files with the styles defined by Garden.

There were some issues caused by the global styles applied to form elements that were also applied to Garden components. 

- All forms rendered in Curlybars now have the `hbs-form` class applied
- All form element styles are scoped inside the `hbs-form` class or the `search` class for the form associated to the [search helper](https://developer.zendesk.com/api-reference/help_center/help-center-templates/helpers/#search-helper)
- Removed ad-hoc fixes in the New Request Form components

## Checklist

- [x] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [x] :arrow_left: changes are compatible with RTL direction
- [x] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [x] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [x] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->