### PR TITLE
feat: override colors for zd-summary-block elements

### DIFF
--- a/style.css
+++ b/style.css
@@ -4710,3 +4710,14 @@ html[dir=rtl] .notification-left-aligned {
 .upload-dropzone {
   border: 1px solid #87929D;
 }
+
+/***** Summary component *****/
+zd-summary-block {
+  background: #f3f6f6;
+}
+[dir=ltr] zd-summary-block {
+  border-left-color: #859fa1;
+}
+[dir=rtl] zd-summary-block {
+  border-right-color: #859fa1;
+}

--- a/styles/_summary.scss
+++ b/styles/_summary.scss
@@ -1,0 +1,14 @@
+/***** Summary component *****/
+zd-summary-block {
+    // As the Help Center already provides the base styling in a theme agnostic
+    // way, we will only override the colors here.
+    background: #f3f6f6;
+
+    [dir="ltr"] & {
+        border-left-color: #859fa1;
+    }
+
+    [dir="rtl"] & {
+        border-right-color: #859fa1;
+    }
+}

--- a/styles/index.scss
+++ b/styles/index.scss
@@ -43,3 +43,4 @@
 @import "content-tags";
 @import "wysiwyg";
 @import "upload_dropzone";
+@import "summary";


### PR DESCRIPTION
## Description

A summary feature will be introduced for articles, the base styling is provided by the Help Center codebase, this PR overrides the colors of the summary to match the appearance of the Copenhagen Theme.
 
## Screenshots

*Before* 
<img width="1920" alt="Screenshot 2024-05-30 at 10 28 01" src="https://github.com/zendesk/copenhagen_theme/assets/90802/f072f0b5-d041-4310-bc52-57a45302add2">

*After* 

<img width="1920" alt="Screenshot 2024-05-30 at 10 57 35" src="https://github.com/zendesk/copenhagen_theme/assets/90802/ccff5ba0-d248-4b9c-9ff0-79ed356caad1">


## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->