### PR TITLE
fix: priority field by handling basic_priority

### DIFF
--- a/src/modules/new-request-form/NewRequestForm.tsx
+++ b/src/modules/new-request-form/NewRequestForm.tsx
@@ -254,6 +254,7 @@ export function NewRequestForm({
                 />
               );
             case "priority":
+            case "basic_priority":
             case "tickettype":
               return (
                 <>


### PR DESCRIPTION
## Description

When the Priority system field is configured with `Normal, High` field values (plus `Customer can edit` permission and `Required to submit a request` enabled), the Priority field is not shown in the Help Center ticket form. 
So, when end users try to submit tickets via Help Center, the request fails with `422` response and error `Validation failed: Priority: cannot be blank`. 

This is caused because the `Priority` ticket field `type` changes to `basic_priority` when Priority field is configured with `Normal, High`. Simply handling `basic_priority` seems to address the issue.



## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->