### PR TITLE
feat: added strings for translations for lookup field

### DIFF
--- a/src/modules/new-request-form/translations/en-us.yml
+++ b/src/modules/new-request-form/translations/en-us.yml
@@ -156,3 +156,13 @@ parts:
       title: "Additional label shown above the credit card field, informing the user that only the last 4 digits are required."
       screenshot: "https://drive.google.com/file/d/13Pz2p5q7FHX9FKT6MUR6Sg5vWy55X0kP/view?usp=drive_link"
       value: "(Last 4 digits)"
+  - translation:
+      key: "new-request-form.lookup-field.loading-options"
+      title: "Message shown in combobox when searched options are loading"
+      screenshot: "https://drive.google.com/file/d/1_TeqU5hihEJb03q6adVI0-nuklYask1d/view?usp=drive_link"
+      value: "Loading items..."
+  - translation:
+      key: "new-request-form.lookup-field.no-matches-found"
+      title: "Message shown in combobox when searched option is not found"
+      screenshot: "https://drive.google.com/file/d/1zwRLhFj0I0N0JV07O7wpoEZO5tBBK8JF/view?usp=drive_link"
+      value: "No matches found"


### PR DESCRIPTION
## Description

We are introducingLookup fields for custom objects in the Copenhagen Theme v4 in new request form and we need to add two short strings for translation.

[Jira epic](https://zendesk.atlassian.net/jira/software/c/projects/GG/boards/1258?selectedIssue=GG-3522)
[Figma design](https://www.figma.com/design/y9oQEXp0WSp1HAAqRcrhF3/End-User-Lookup-Fields-2024-Q1?node-id=695-37365&t=BXTZ6vkX87j1qudn-0)

## Screenshots
![Screenshot 2024-08-07 at 16 53 52](https://github.com/user-attachments/assets/4c0f92ee-75a4-4aa8-a831-0d31d93c8307)
![Screenshot 2024-08-07 at 16 53 30](https://github.com/user-attachments/assets/891defd8-7961-4da5-881a-eea4e999dbd7)

<!-- (optional) when applicable, please include some screenshots or gifs that illustrate the changes -->

## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->