### PR TITLE
Revert "chore(release): 4.1.0"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,3 @@
-# [4.1.0](https://github.com/zendesk/copenhagen_theme/compare/v4.0.5...v4.1.0) (2024-08-08)
-
-
-### Features
-
-* added strings for translations for lookup field ([bc5c41f](https://github.com/zendesk/copenhagen_theme/commit/bc5c41ffc168102f93f8decaf20f9afe636d77bd))
-
 ## [4.0.5](https://github.com/zendesk/copenhagen_theme/compare/v4.0.4...v4.0.5) (2024-08-02)
 
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Copenhagen",
   "author": "Zendesk",
-  "version": "4.1.0",
+  "version": "4.0.5",
   "api_version": 4,
   "default_locale": "en-us",
   "settings": [


### PR DESCRIPTION
This reverts commit 317dfd838a8b50bf333c3ae6e76c1e7cd03622ce.

## Description

We triggered a wrong release containing just an update for the source translation file. This PR reverts the commit to go back to the v4.0.5 version. I already deleted the relative git tag and github release

## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->