### PR TITLE
Revert release 4.1 - Second attempt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,3 @@
-# [4.1.0](https://github.com/zendesk/copenhagen_theme/compare/v4.0.5...v4.1.0) (2024-08-08)
-
-
-### Features
-
-* added strings for translations for lookup field ([bc5c41f](https://github.com/zendesk/copenhagen_theme/commit/bc5c41ffc168102f93f8decaf20f9afe636d77bd))
-
 ## [4.0.5](https://github.com/zendesk/copenhagen_theme/compare/v4.0.4...v4.0.5) (2024-08-02)
 
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Copenhagen",
   "author": "Zendesk",
-  "version": "4.1.0",
+  "version": "4.0.5",
   "api_version": 4,
   "default_locale": "en-us",
   "settings": [

--- a/src/modules/new-request-form/translations/en-us.yml
+++ b/src/modules/new-request-form/translations/en-us.yml
@@ -156,3 +156,13 @@ parts:
       title: "Additional label shown above the credit card field, informing the user that only the last 4 digits are required."
       screenshot: "https://drive.google.com/file/d/13Pz2p5q7FHX9FKT6MUR6Sg5vWy55X0kP/view?usp=drive_link"
       value: "(Last 4 digits)"
+  - translation:
+      key: "new-request-form.lookup-field.loading-options"
+      title: "Message shown in combobox when searched options are loading"
+      screenshot: "https://drive.google.com/file/d/1_TeqU5hihEJb03q6adVI0-nuklYask1d/view?usp=drive_link"
+      value: "Loading items..."
+  - translation:
+      key: "new-request-form.lookup-field.no-matches-found"
+      title: "Message shown in combobox when searched option is not found"
+      screenshot: "https://drive.google.com/file/d/1zwRLhFj0I0N0JV07O7wpoEZO5tBBK8JF/view?usp=drive_link"
+      value: "No matches found"

--- a/src/modules/new-request-form/translations/en-us.yml
+++ b/src/modules/new-request-form/translations/en-us.yml
@@ -156,13 +156,3 @@ parts:
       title: "Additional label shown above the credit card field, informing the user that only the last 4 digits are required."
       screenshot: "https://drive.google.com/file/d/13Pz2p5q7FHX9FKT6MUR6Sg5vWy55X0kP/view?usp=drive_link"
       value: "(Last 4 digits)"
-  - translation:
-      key: "new-request-form.lookup-field.loading-options"
-      title: "Message shown in combobox when searched options are loading"
-      screenshot: "https://drive.google.com/file/d/1_TeqU5hihEJb03q6adVI0-nuklYask1d/view?usp=drive_link"
-      value: "Loading items..."
-  - translation:
-      key: "new-request-form.lookup-field.no-matches-found"
-      title: "Message shown in combobox when searched option is not found"
-      screenshot: "https://drive.google.com/file/d/1zwRLhFj0I0N0JV07O7wpoEZO5tBBK8JF/view?usp=drive_link"
-      value: "No matches found"


### PR DESCRIPTION
## Description

This is a second attempt to revert the 4.1 release. A similar approach to #510 but I also reverted the original commit and I am not deleting the v4.1.0 tag to avoid the release of a new version 