### PR TITLE
chore: avoid updating obsolete date in the extract-string script

### DIFF
--- a/bin/extract-strings.mjs
+++ b/bin/extract-strings.mjs
@@ -85,7 +85,7 @@ class SourceYmlTransform extends Transform {
 
       // Mark removed keys as obsolete
       for (const { translation } of outputContent.parts) {
-        if (!(translation.key in strings)) {
+        if (!(translation.key in strings) && !translation.obsolete) {
           translation.obsolete = this.#getObsoleteDate();
           this.#counters.obsolete++;
         }


### PR DESCRIPTION
## Description

The `extract-strings` script updates the `obsolete` date for removed strings every time we run it. This PR fixes the issue by adding the `obsolete` date for removed strings only if the string is not already marked as obsolete.