### PR TITLE
[ROSETTA-3640] Add i18n validator

### DIFF
--- a/.github/workflows/i18n-validator.yml
+++ b/.github/workflows/i18n-validator.yml
@@ -1,0 +1,25 @@
+name: i18n validator
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  main:
+    name: English Strings Static Validations
+    runs-on: [self-hosted, zendesk-stable]
+    env:
+      BUNDLE_ZDREPO__JFROG__IO: "${{ secrets.BUNDLE_ZDREPO__JFROG__IO }}"
+    steps:
+    - uses: zendesk/checkout@v4
+    - name: Set up Ruby
+      uses: zendesk/setup-ruby@v1
+      with:
+        ruby-version: 3.2.2
+    - run: bundle init
+    - run: gem install zendesk_i18n_dev_tools --source https://$BUNDLE_ZDREPO__JFROG__IO@zdrepo.jfrog.io/zdrepo/api/gems/gems-local/
+    - run: validate_string_sweep_files 'translations.yml' 'src/modules/new-request-form/translations'


### PR DESCRIPTION
## Description

* Following the i18n Standard to add the i18n validator for those Repositories that are been integrated with the String Sweep process.
* Jira: https://zendesk.atlassian.net/browse/ROSETTA-3640
* ADR: https://techmenu.zende.sk/standards/i18n-standards/#repositories-containing-source-translations-run-yaml-and-localizability-validations
## Screenshots

<!-- (optional) when applicable, please include some screenshots or gifs that illustrate the changes -->

## Checklist

- [x] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->