### PR TITLE
chore: translation string for lookup field placeholder

### DIFF
--- a/src/modules/new-request-form/translations/en-us.yml
+++ b/src/modules/new-request-form/translations/en-us.yml
@@ -166,3 +166,8 @@ parts:
       title: "Message shown in combobox when searched option is not found"
       screenshot: "https://drive.google.com/file/d/1zwRLhFj0I0N0JV07O7wpoEZO5tBBK8JF/view?usp=drive_link"
       value: "No matches found"
+  - translation:
+      key: "new-request-form.lookup-field.placeholder"
+      title: "Placeholder shown in combobox, {{label}} will be replaced by field label"
+      screenshot: "https://drive.google.com/file/d/1nlnj_I-L7bkIs9Hn93Btrl8bh_HJfL6h/view?usp=drive_link"
+      value: "Search {{label}}"        


### PR DESCRIPTION
## Description

Translation string for lookup field placeholder. Support for Lookup fields for custom objects in the Copenhagen Theme v4 will be added soon. 

## Screenshots
<img width="671" alt="Screenshot 2024-08-29 at 11 51 29" src="https://github.com/user-attachments/assets/6f60f60c-7bbb-455b-80d8-b5130cb30df8">

<!-- (optional) when applicable, please include some screenshots or gifs that illustrate the changes -->

## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->