### PR TITLE
feat: add new template and module for service catalog

### DIFF
--- a/assets/service-catalog-bundle.js
+++ b/assets/service-catalog-bundle.js
@@ -1,0 +1,11 @@
+import { j as jsxRuntimeExports, S as Span, a6 as reactDomExports } from 'shared';
+
+function ServiceCatalog() {
+    return jsxRuntimeExports.jsx(Span, { children: "Hello from module" });
+}
+
+async function renderServiceCatalog(container) {
+    reactDomExports.render(jsxRuntimeExports.jsx(ServiceCatalog, {}), container);
+}
+
+export { renderServiceCatalog };

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -35,6 +35,7 @@ export default defineConfig([
     input: {
       "new-request-form": "src/modules/new-request-form/index.tsx",
       "flash-notifications": "src/modules/flash-notifications/index.ts",
+      "service-catalog": "src/modules/service-catalog/index.tsx",
     },
     output: {
       dir: "assets",

--- a/src/modules/service-catalog/ServiceCatalog.tsx
+++ b/src/modules/service-catalog/ServiceCatalog.tsx
@@ -1,0 +1,5 @@
+import { Span } from "@zendeskgarden/react-typography";
+
+export function ServiceCatalog() {
+  return <Span>Hello from module</Span>;
+}

--- a/src/modules/service-catalog/index.tsx
+++ b/src/modules/service-catalog/index.tsx
@@ -1,0 +1,1 @@
+export { renderServiceCatalog } from "./renderServiceCatalog";

--- a/src/modules/service-catalog/renderServiceCatalog.tsx
+++ b/src/modules/service-catalog/renderServiceCatalog.tsx
@@ -1,0 +1,7 @@
+import { render } from "react-dom";
+
+import { ServiceCatalog } from "./ServiceCatalog";
+
+export async function renderServiceCatalog(container: HTMLElement) {
+  render(<ServiceCatalog />, container);
+}

--- a/templates/custom_pages/service_catalog.hbs
+++ b/templates/custom_pages/service_catalog.hbs
@@ -1,0 +1,20 @@
+<div class="container-divider"></div>
+<div class="container">
+  <div class="sub-nav">
+  </div>
+
+  <h1>Service Catalog</h1>
+
+  <div id="main-content">
+     <div id="service-catalog"></div>
+    <div>Hello from template</div>
+  </div>
+</div>
+
+<script type="module">
+  import { renderServiceCatalog } from "service-catalog";
+
+  const container = document.getElementById("service-catalog");
+
+  renderServiceCatalog(container);
+</script>

--- a/templates/document_head.hbs
+++ b/templates/document_head.hbs
@@ -13,6 +13,7 @@
   "imports": {
     "new-request-form": "{{asset 'new-request-form-bundle.js'}}",
     "flash-notifications": "{{asset 'flash-notifications-bundle.js'}}",
+    "service-catalog": "{{asset 'service-catalog-bundle.js'}}",
     "new-request-form-translations": "{{asset 'new-request-form-translations-bundle.js'}}",
     "shared": "{{asset 'shared-bundle.js'}}",
     "wysiwyg": "{{asset 'wysiwyg-bundle.js'}}"

--- a/templates/header.hbs
+++ b/templates/header.hbs
@@ -14,6 +14,7 @@
     <nav class="user-nav" id="user-nav" aria-label="{{t 'user_navigation'}}">
       <ul class="user-nav-list">
         <li>{{link 'community'}}</li>
+        <li><a href="/hc/en-us/p/service_catalog">Request a service</a></li>
         <li>{{link 'new_request' class='submit-a-request'}}</li>
         {{#unless signed_in}}
           <li>


### PR DESCRIPTION
## Description
Added template and new module in custom pages for service catalog. It is now initialized only with an “Hello World“ placeholder app. Added a button on the header to open a new page, the link to it is now hardcoded and will be changed later (it needs to be added in HC). 

Jira: [Setting up a new "Hello World" app in the Copenhagen theme for Service Catalog](https://zendesk.atlassian.net/browse/GG-3853)
<!-- a summary of the changes introduced by this PR and the motivation behind them -->

## Screenshots
![Screenshot 2024-09-30 at 15 38 04](https://github.com/user-attachments/assets/255a847c-5603-46a9-bd5a-e683e31a7a85)

![Screenshot 2024-09-30 at 15 38 16](https://github.com/user-attachments/assets/12772df5-a18c-4141-9c95-925a84d98bd3)

<!-- (optional) when applicable, please include some screenshots or gifs that illustrate the changes -->

## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->