### PR TITLE
feat: validate CC tag when leaving the field

### DIFF
--- a/assets/new-request-form-bundle.js
+++ b/assets/new-request-form-bundle.js
@@ -781,6 +781,16 @@ function useTagsInputContainer({ tags, onTagsChange, inputValue, onInputValueCha
         onTagsChange([...tags, ...values]);
         setAnnouncement(i18n.addedTags([...values]));
     };
+    const handleInputOnBlur = (e) => {
+        const target = e.target;
+        const tag = target.value;
+        if (tag) {
+            if (!hasTag(tag)) {
+                addTag(tag);
+            }
+            onInputValueChange("");
+        }
+    };
     const handleTagKeyDown = (index) => (e) => {
         if (e.code === "Backspace") {
             e.preventDefault();
@@ -806,6 +816,7 @@ function useTagsInputContainer({ tags, onTagsChange, inputValue, onInputValueCha
         onChange: handleInputChange,
         onKeyDown: handleInputKeyDown,
         onPaste: handleInputPaste,
+        onBlur: handleInputOnBlur,
     });
     const getAnnouncementProps = () => ({
         "aria-live": "polite",

--- a/assets/shared-bundle.js
+++ b/assets/shared-bundle.js
@@ -32957,7 +32957,7 @@ function useGrid(_ref) {
 });
 
 var _path$3, _circle$1;
-function _extends$5() { return _extends$5 = Object.assign ? Object.assign.bind() : function (n) { for (var e = 1; e < arguments.length; e++) { var t = arguments[e]; for (var r in t) ({}).hasOwnProperty.call(t, r) && (n[r] = t[r]); } return n; }, _extends$5.apply(null, arguments); }
+function _extends$5() { _extends$5 = Object.assign ? Object.assign.bind() : function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends$5.apply(this, arguments); }
 var SvgAlertWarningStroke = function SvgAlertWarningStroke(props) {
   return /*#__PURE__*/reactExports.createElement("svg", _extends$5({
     xmlns: "http://www.w3.org/2000/svg",
@@ -32978,7 +32978,7 @@ var SvgAlertWarningStroke = function SvgAlertWarningStroke(props) {
 };
 
 var _rect, _path$2;
-function _extends$4() { return _extends$4 = Object.assign ? Object.assign.bind() : function (n) { for (var e = 1; e < arguments.length; e++) { var t = arguments[e]; for (var r in t) ({}).hasOwnProperty.call(t, r) && (n[r] = t[r]); } return n; }, _extends$4.apply(null, arguments); }
+function _extends$4() { _extends$4 = Object.assign ? Object.assign.bind() : function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends$4.apply(this, arguments); }
 var SvgCreditCardStroke = function SvgCreditCardStroke(props) {
   return /*#__PURE__*/reactExports.createElement("svg", _extends$4({
     xmlns: "http://www.w3.org/2000/svg",
@@ -35256,7 +35256,7 @@ Accordion.Panel = Panel;
 Accordion.Section = Section;
 
 var _g;
-function _extends() { return _extends = Object.assign ? Object.assign.bind() : function (n) { for (var e = 1; e < arguments.length; e++) { var t = arguments[e]; for (var r in t) ({}).hasOwnProperty.call(t, r) && (n[r] = t[r]); } return n; }, _extends.apply(null, arguments); }
+function _extends() { _extends = Object.assign ? Object.assign.bind() : function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends.apply(this, arguments); }
 var SvgCheckCircleStroke = function SvgCheckCircleStroke(props) {
   return /*#__PURE__*/reactExports.createElement("svg", _extends({
     xmlns: "http://www.w3.org/2000/svg",

--- a/src/modules/new-request-form/fields/cc-field/useTagsInputContainer.ts
+++ b/src/modules/new-request-form/fields/cc-field/useTagsInputContainer.ts
@@ -7,6 +7,7 @@ import type {
   HTMLAttributes,
   InputHTMLAttributes,
   ChangeEventHandler,
+  FocusEventHandler,
 } from "react";
 import { useCallback, useState } from "react";
 import { useGrid } from "@zendeskgarden/container-grid";
@@ -138,6 +139,18 @@ export function useTagsInputContainer({
     setAnnouncement(i18n.addedTags([...values]));
   };
 
+  const handleInputOnBlur: FocusEventHandler<HTMLInputElement> = (e) => {
+    const target = e.target as HTMLInputElement;
+    const tag = target.value;
+
+    if (tag) {
+      if (!hasTag(tag)) {
+        addTag(tag);
+      }
+      onInputValueChange("");
+    }
+  };
+
   const handleTagKeyDown =
     (index: number): KeyboardEventHandler =>
     (e) => {
@@ -174,6 +187,7 @@ export function useTagsInputContainer({
     onChange: handleInputChange,
     onKeyDown: handleInputKeyDown,
     onPaste: handleInputPaste,
+    onBlur: handleInputOnBlur,
   });
 
   const getAnnouncementProps = <T extends Element>(): HTMLAttributes<T> => ({


### PR DESCRIPTION
## Description

When we updated for v4, we changed the behavior of the CC field slightly. Before, if we clicked outside the input box, we would validate the current string and turn it into a tag, when valid. Currently, we are not doing that and we are just saving the input.

Since this feature is useful for our users, we are re-adding this feature in this PR. 

JIRA: [GG-3804](https://zendesk.atlassian.net/browse/GG-3804)

## Screenshots

Need to convert this to a gif


https://github.com/user-attachments/assets/e14acd12-db72-40be-9346-f3142cfa9587


## Checklist

- [x] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [x] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [x] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->

[GG-3804]: https://zendesk.atlassian.net/browse/GG-3804?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ