### PR TITLE
fix: change section page header flex wrap

### DIFF
--- a/style.css
+++ b/style.css
@@ -1153,7 +1153,7 @@ ul {
   .page-header {
     align-items: baseline;
     flex-direction: row;
-    flex-wrap: nowrap;
+    flex-wrap: wrap;
     gap: 16px;
     margin: 0;
   }

--- a/styles/_page_header.scss
+++ b/styles/_page_header.scss
@@ -4,7 +4,7 @@
   @include tablet {
     align-items: baseline;
     flex-direction: row;
-    flex-wrap: nowrap;
+    flex-wrap: wrap;
     gap: 16px;
     margin: 0;
   }


### PR DESCRIPTION
## Description
Simple change in style to fix wrapping the content on section page header.
<!-- a summary of the changes introduced by this PR and the motivation behind them -->

## Screenshots
Before:
![Screenshot 2024-10-03 at 15 08 00](https://github.com/user-attachments/assets/d64e0c2c-3f0d-466f-a705-3f694f8c3407)

After:
![Screenshot 2024-10-03 at 15 07 49](https://github.com/user-attachments/assets/cff40556-e5b8-48b6-be66-407683074199)

<!-- (optional) when applicable, please include some screenshots or gifs that illustrate the changes -->

## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->