### PR TITLE
[GG-3938] Fixed date fields prefilling

### DIFF
--- a/src/modules/new-request-form/NewRequestForm.tsx
+++ b/src/modules/new-request-form/NewRequestForm.tsx
@@ -120,6 +120,7 @@ export function NewRequestForm({
     organizations.length > 0 && organizations[0]?.id
       ? organizations[0]?.id?.toString()
       : null;
+
   const handleChange = useCallback(
     (field: Field, value: Field["value"]) => {
       setTicketFields(
@@ -141,13 +142,16 @@ export function NewRequestForm({
     setOrganizationField({ ...organizationField, value });
   }
 
-  function handleDueDateChange(value: string) {
-    if (dueDateField === null) {
-      return;
-    }
+  const handleDueDateChange = useCallback(
+    (value: string) => {
+      if (dueDateField === null) {
+        return;
+      }
 
-    setDueDateField({ ...dueDateField, value });
-  }
+      setDueDateField({ ...dueDateField, value });
+    },
+    [dueDateField]
+  );
 
   return (
     <>

--- a/src/modules/new-request-form/fields/DatePicker.tsx
+++ b/src/modules/new-request-form/fields/DatePicker.tsx
@@ -9,7 +9,7 @@ import {
 import { Span } from "@zendeskgarden/react-typography";
 import type { Field } from "../data-types";
 import type { ChangeEventHandler } from "react";
-import { useMemo, useState } from "react";
+import { useCallback, useState } from "react";
 
 interface DatePickerProps {
   field: Field;
@@ -29,44 +29,48 @@ export function DatePicker({
     value ? new Date(value as string) : undefined
   );
 
-  const dateTimeFormat = useMemo(
-    () =>
-      new Intl.DateTimeFormat(locale, {
-        month: "long",
-        day: "numeric",
-        year: "numeric",
-        timeZone: "UTC",
-      }),
-    [locale]
-  );
-
   /* Formats the date using the UTC time zone to prevent timezone-related issues.
    * By creating a new Date object with only the date, the time defaults to 00:00:00 UTC.
    * This avoids date shifts that can occur if formatted with the local time zone, as Garden does by default.
    */
-  const formatDateInput = (date: Date) => {
-    return dateTimeFormat.format(date);
-  };
+  const formatDateInput = useCallback(
+    (date: Date) => {
+      const dateTimeFormat = new Intl.DateTimeFormat(locale, {
+        month: "long",
+        day: "numeric",
+        year: "numeric",
+        timeZone: "UTC",
+      });
+      return dateTimeFormat.format(date);
+    },
+    [locale]
+  );
 
-  const formatDateValue = (value: Date | undefined) => {
-    if (value === undefined) {
-      return "";
-    }
-    const isoString = value.toISOString();
-    return valueFormat === "dateTime" ? isoString : isoString.split("T")[0];
-  };
+  const formatDateValue = useCallback(
+    (value: Date | undefined) => {
+      if (value === undefined) {
+        return "";
+      }
+      const isoString = value.toISOString();
+      return valueFormat === "dateTime" ? isoString : isoString.split("T")[0];
+    },
+    [valueFormat]
+  );
 
-  const handleChange = (date: Date) => {
-    // Set the time to 12:00:00 as this is also the expected behavior across Support and the API
-    const newDate = new Date(
-      Date.UTC(date.getFullYear(), date.getMonth(), date.getDate(), 12, 0, 0)
-    ) as Date;
-    setDate(newDate);
-    const dateString = formatDateValue(newDate);
-    if (dateString !== undefined) {
-      onChange(dateString);
-    }
-  };
+  const handleChange = useCallback(
+    (date: Date) => {
+      // Set the time to 12:00:00 as this is also the expected behavior across Support and the API
+      const newDate = new Date(
+        Date.UTC(date.getFullYear(), date.getMonth(), date.getDate(), 12, 0, 0)
+      ) as Date;
+      setDate(newDate);
+      const dateString = formatDateValue(newDate);
+      if (dateString !== undefined) {
+        onChange(dateString);
+      }
+    },
+    [onChange, formatDateValue]
+  );
 
   const handleInputChange: ChangeEventHandler<HTMLInputElement> = (e) => {
     // Allow field to be cleared

--- a/src/modules/new-request-form/usePrefilledTicketFields.tsx
+++ b/src/modules/new-request-form/usePrefilledTicketFields.tsx
@@ -4,6 +4,7 @@ import DOMPurify from "dompurify";
 
 const MAX_URL_LENGTH = 2048;
 const TICKET_FIELD_PREFIX = "tf_";
+const DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
 
 const ALLOWED_BOOLEAN_VALUES = ["true", "false"];
 const ALLOWED_HTML_TAGS = [
@@ -57,6 +58,20 @@ function getFieldFromId(id: string, prefilledTicketFields: Fields) {
   }
 }
 
+function isValidDate(dateString: string) {
+  if (!DATE_REGEX.test(dateString)) {
+    return false;
+  }
+
+  const date = new Date(dateString);
+  const [year, month, day] = dateString.split("-").map(Number);
+  return (
+    date.getUTCFullYear() === year &&
+    date.getUTCMonth() + 1 === month &&
+    date.getUTCDate() === day
+  );
+}
+
 function getPrefilledTicketFields(fields: Fields): Fields {
   const { href } = location;
   const params = new URL(href).searchParams;
@@ -100,6 +115,12 @@ function getPrefilledTicketFields(fields: Fields): Fields {
               : sanitizedValue === "false"
               ? "off"
               : "";
+        }
+        break;
+      case "due_at":
+      case "date":
+        if (isValidDate(sanitizedValue)) {
+          field.value = sanitizedValue;
         }
         break;
       default:


### PR DESCRIPTION
## Description

This PR fixes the prefilling of date fields in the Request Form.

### Proper handling of time zones
The prefill value for date fields uses the `YYYY-MM-DD` format. We create a new Date object from that value in the Datepicker component, and this [creates a date with the time at 00:00:00 UTC](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#date_time_string_format).

For example, for a user in the `GMT-7` timezone, `new Date('2025-10-25')` returns `Fri Oct 25 2025 00:00:00 UTC` or `Fri Oct 24 2025 17:00:00 GMT-0700`  in his timezone.

Garden by default formats the date using the user timezone, so in this case we were showing `October 24, 2024`. This PR changes the formatting using UTC as a timezone.

### Added validation of date format
We were not validating the date passed in the URL. If the user passed a value like `2025-30-12` the form was breaking without any notice.

## Screenshots

Before:
<img width="887" alt="Screenshot 2024-10-25 at 05 38 51" src="https://github.com/user-attachments/assets/bb91de83-3092-4cf0-9e06-7fab1ac237ba">

<img width="887" alt="Screenshot 2024-10-25 at 05 42 47" src="https://github.com/user-attachments/assets/cf21195a-531d-4f8e-b283-bd82e6d8d53b">

After:
<img width="887" alt="Screenshot 2024-10-25 at 05 45 11" src="https://github.com/user-attachments/assets/ecf3c113-e1bc-4cd3-9804-647867266b4c">

<img width="887" alt="Screenshot 2024-10-25 at 05 45 52" src="https://github.com/user-attachments/assets/bf261eef-f56b-48a5-88a5-7b3bb9eafdbf">



## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->