### PR TITLE
Post request for service catalog item

### DIFF
--- a/assets/fetchCsrfToken-bundle.js
+++ b/assets/fetchCsrfToken-bundle.js
@@ -1,0 +1,7 @@
+async function fetchCsrfToken() {
+    const response = await fetch("/api/v2/help_center/sessions.json");
+    const { current_session } = await response.json();
+    return current_session.csrf_token;
+}
+
+export { fetchCsrfToken as f };

--- a/assets/new-request-form-bundle.js
+++ b/assets/new-request-form-bundle.js
@@ -29,7 +29,6 @@ function ParentTicketField({ field, }) {
     return jsxRuntimeExports.jsx("input", { type: "hidden", name: name, value: value });
 }
 
-// NOTE: This is a temporary handling of the CSRF token
 async function fetchCsrfToken$1() {
     const response = await fetch("/api/v2/help_center/sessions.json");
     const { current_session } = await response.json();

--- a/assets/shared-bundle.js
+++ b/assets/shared-bundle.js
@@ -578,6 +578,7 @@ var ReactDOM = /*@__PURE__*/getDefaultExportFromCjs(reactDomExports);
 
 const FLASH_NOTIFICATIONS_KEY = "HC_FLASH_NOTIFICATIONS";
 
+//These notifications are shown only on the next page when the user is redirected.
 function addFlashNotification(notification) {
     try {
         const currentValue = window.sessionStorage.getItem(FLASH_NOTIFICATIONS_KEY);

--- a/src/modules/new-request-form/fetchCsrfToken.ts
+++ b/src/modules/new-request-form/fetchCsrfToken.ts
@@ -1,4 +1,3 @@
-// NOTE: This is a temporary handling of the CSRF token
 export async function fetchCsrfToken() {
   const response = await fetch("/api/v2/help_center/sessions.json");
   const { current_session } = await response.json();

--- a/src/modules/service-catalog/components/service-catalog-item/ItemRequestForm.tsx
+++ b/src/modules/service-catalog/components/service-catalog-item/ItemRequestForm.tsx
@@ -1,15 +1,86 @@
 import styled from "styled-components";
 import { TicketField } from "../../../ticket-fields";
 import type { Field } from "../../../ticket-fields";
+import { Button } from "@zendeskgarden/react-buttons";
+import { getColorV8 } from "@zendeskgarden/react-theming";
+import { useTranslation } from "react-i18next";
+import { CollapsibleDescription } from "./CollapsibleDescription";
+import type { ServiceCatalogItem } from "../../data-types/ServiceCatalogItem";
 
 const Form = styled.form`
   display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  gap: ${(props) => props.theme.space.md};
+
+  @media (max-width: ${(props) => props.theme.breakpoints.md}) {
+    flex-direction: column;
+  }
+`;
+
+const FieldsContainer = styled.div`
+  flex: 2;
+  display: flex;
   flex-direction: column;
   gap: ${(props) => props.theme.space.md};
+  margin-right: ${(props) => props.theme.space.xl};
+
+  @media (max-width: ${(props) => props.theme.breakpoints.md}) {
+    margin-right: 0;
+  }
+`;
+
+const ButtonWrapper = styled.div`
+  flex: 1;
+  margin-left: ${(props) => props.theme.space.xl};
+  padding: ${(props) => props.theme.space.lg};
+  border: ${(props) => props.theme.borders.sm}
+    ${(props) => getColorV8("grey", 300, props.theme)};
+  height: fit-content;
+
+  @media (max-width: ${(props) => props.theme.breakpoints.md}) {
+    position: sticky;
+    top: 0;
+    background: ${(props) => props.theme.colors.background};
+    padding: ${(props) => props.theme.space.lg};
+    border: none;
+    border-top: ${(props) => props.theme.borders.sm}
+      ${(props) => getColorV8("grey", 300, props.theme)};
+    width: 100vw;
+    margin-left: 0;
+  }
+`;
+
+const RightColumn = styled.div`
+  flex: 1;
+  margin-left: ${(props) => props.theme.space.xl};
+
+  @media (max-width: ${(props) => props.theme.breakpoints.md}) {
+    position: sticky;
+    bottom: 0;
+    margin-left: 0;
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
+`;
+
+const LeftColumn = styled.div`
+  flex: 2;
+  display: flex;
+  flex-direction: column;
+  gap: ${(props) => props.theme.space.lg};
+  margin-right: ${(props) => props.theme.space.xl};
+
+  @media (max-width: ${(props) => props.theme.breakpoints.md}) {
+    margin-right: 0;
+  }
 `;
 
 interface ItemRequestFormProps {
   requestFields: Field[];
+  serviceCatalogItem: ServiceCatalogItem;
   baseLocale: string;
   hasAtMentions: boolean;
   userRole: string;
@@ -20,10 +91,12 @@ interface ItemRequestFormProps {
     field: Field,
     value: string | string[] | boolean | undefined
   ) => void;
+  onSubmit: (e: React.FormEvent<HTMLFormElement>) => void;
 }
 
-export const ItemRequestForm = ({
+export function ItemRequestForm({
   requestFields,
+  serviceCatalogItem,
   baseLocale,
   hasAtMentions,
   userRole,
@@ -31,22 +104,39 @@ export const ItemRequestForm = ({
   brandId,
   defaultOrganizationId,
   handleChange,
-}: ItemRequestFormProps) => {
+  onSubmit,
+}: ItemRequestFormProps) {
+  const { t } = useTranslation();
   return (
-    <Form>
-      {requestFields.map((field) => (
-        <TicketField
-          key={field.id}
-          field={field}
-          baseLocale={baseLocale}
-          hasAtMentions={hasAtMentions}
-          userRole={userRole}
-          userId={userId}
-          brandId={brandId}
-          defaultOrganizationId={defaultOrganizationId}
-          handleChange={handleChange}
+    <Form onSubmit={onSubmit} noValidate>
+      <LeftColumn>
+        <CollapsibleDescription
+          title={serviceCatalogItem.name}
+          description={serviceCatalogItem.description}
         />
-      ))}
+        <FieldsContainer>
+          {requestFields.map((field) => (
+            <TicketField
+              key={field.id}
+              field={field}
+              baseLocale={baseLocale}
+              hasAtMentions={hasAtMentions}
+              userRole={userRole}
+              userId={userId}
+              brandId={brandId}
+              defaultOrganizationId={defaultOrganizationId}
+              handleChange={handleChange}
+            />
+          ))}
+        </FieldsContainer>
+      </LeftColumn>
+      <RightColumn>
+        <ButtonWrapper>
+          <Button isPrimary size="large" isStretched type="submit">
+            {t("service-catalog.item.submit-button", "Submit request")}
+          </Button>
+        </ButtonWrapper>
+      </RightColumn>
     </Form>
   );
-};
+}

--- a/src/modules/service-catalog/data-types/ServiceRequestResponse.ts
+++ b/src/modules/service-catalog/data-types/ServiceRequestResponse.ts
@@ -1,0 +1,13 @@
+export interface ServiceRequestResponse {
+  error: string;
+  description: string;
+  details: {
+    base: [
+      {
+        description: string;
+        error: string;
+        field_key: number;
+      }
+    ];
+  };
+}

--- a/src/modules/service-catalog/submitServiceItemRequest.tsx
+++ b/src/modules/service-catalog/submitServiceItemRequest.tsx
@@ -1,0 +1,55 @@
+import type { Field } from "../ticket-fields";
+import type { ServiceCatalogItem } from "./data-types/ServiceCatalogItem";
+
+export async function submitServiceItemRequest(
+  serviceCatalogItem: ServiceCatalogItem,
+  requestFields: Field[],
+  associatedLookupField: Field,
+  baseLocale: string
+) {
+  try {
+    const currentUserRequest = await fetch("/api/v2/users/me.json");
+    if (!currentUserRequest.ok) {
+      throw new Error("Error fetching current user data");
+    }
+    const currentUser = await currentUserRequest.json();
+
+    const customFields = requestFields.map((field) => {
+      return {
+        id: field.id,
+        value: field.value,
+      };
+    });
+    const response = await fetch("/api/v2/requests", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-CSRF-Token": currentUser.user.authenticity_token,
+      },
+      body: JSON.stringify({
+        request: {
+          subject: `Service request: ${serviceCatalogItem.name}`,
+          comment: {
+            body: `Hi, I would like to request ${
+              serviceCatalogItem.name
+            }. ${serviceCatalogItem.description.substring(0, 100)}`,
+          },
+          ticket_form_id: serviceCatalogItem.form_id,
+          custom_fields: [
+            ...customFields,
+            { id: associatedLookupField.id, value: serviceCatalogItem.id },
+          ],
+          via: {
+            channel: "web form",
+            source: 50,
+          },
+          locale: baseLocale,
+        },
+      }),
+    });
+    return response;
+  } catch (error) {
+    console.error("Error submitting service request:", error);
+    return;
+  }
+}

--- a/src/modules/service-catalog/translations/en-us.yml
+++ b/src/modules/service-catalog/translations/en-us.yml
@@ -54,4 +54,24 @@ parts:
       key: "service-catalog.item.submit-button"
       title: "Button to submit a request for service catalog item"
       screenshot: "https://drive.google.com/file/d/1kuv7v6Vtx787TdVz8AOmD6v0ow79Xd6c/view?usp=drive_link"
-      value: "Submit request"            
+      value: "Submit request"   
+  - translation:
+      key: "service-catalog.item.service-request-submitted"
+      title: "Success notification after submitting request for service catalog item"
+      screenshot: "https://drive.google.com/file/d/1aQ1IdVF-RzhWslCtIAsYb3vAL9kt4gUE/view?usp=drive_link"
+      value: "Service request submitted"
+  - translation:
+      key: "service-catalog.item.service-request-error-title"
+      title: "Error notification title after unsuccessfulsubmitting request for service catalog item"
+      screenshot: "https://drive.google.com/file/d/1KlkSK4FQiAYn2ERUJwy1tSYfr1gtjW0E/view?usp=drive_link"
+      value: "Service couldn't be submitted"           
+  - translation:
+      key: "service-catalog.item.service-request-error-message"
+      title: "Error notification after unsuccessfulsubmitting request for service catalog item"
+      screenshot: "https://drive.google.com/file/d/1KlkSK4FQiAYn2ERUJwy1tSYfr1gtjW0E/view?usp=drive_link"
+      value: "Give it a moment and try it again"  
+  - translation:
+      key: "service-catalog.item.service-request-error.close-label"
+      title: "[A11Y] Hidden label for screen readers for close buttons (e.g. in modals and notifications)"
+      screenshot: ""
+      value: "Close"  

--- a/src/modules/shared/notifications/addFlashNotification.ts
+++ b/src/modules/shared/notifications/addFlashNotification.ts
@@ -1,6 +1,6 @@
 import type { ToastNotification } from "./ToastNotification";
 import { FLASH_NOTIFICATIONS_KEY } from "./constants";
-
+//These notifications are shown only on the next page when the user is redirected.
 export function addFlashNotification(notification: ToastNotification) {
   try {
     const currentValue = window.sessionStorage.getItem(FLASH_NOTIFICATIONS_KEY);

--- a/templates/header.hbs
+++ b/templates/header.hbs
@@ -14,7 +14,7 @@
     <nav class="user-nav" id="user-nav" aria-label="{{t 'user_navigation'}}">
       <ul class="user-nav-list">
         <li>{{link 'community'}}</li>
-        <li><a href="/hc/en-us/services">Request a service</a></li>
+        <li><a href="/hc/en-us/services">Services</a></li>
         <li>{{link 'new_request' class='submit-a-request'}}</li>
         {{#unless signed_in}}
           <li>


### PR DESCRIPTION
## Description
Added a functionality to submit a service catalog item request. Added validation to the form. Reorganize the structure of `ServiceCatalogItemPage.tsx` so the submit button is with the corresponding form. We have fixed values for subject and description in the request and it is in English only. This is probably only for EAP.
<!-- a summary of the changes introduced by this PR and the motivation behind them -->
[GG-3862](https://zendesk.atlassian.net/browse/GG-3862?atlOrigin=eyJpIjoiMmQxZjUzYWQ5NmMwNGM2OGEyYjJjOTA5NWM2ZDM2NjAiLCJwIjoiaiJ9)
## Screenshots
Form with validation: 
![Screenshot 2024-11-22 at 16 47 45](https://github.com/user-attachments/assets/f02b13d6-de24-48b1-a818-0b44f138949b)

Requested service view:
![Screenshot 2024-11-22 at 16 55 34](https://github.com/user-attachments/assets/ee962f78-a426-489c-9bcc-e4acb0501d2c)

<!-- (optional) when applicable, please include some screenshots or gifs that illustrate the changes -->

## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->

[GG-3796]: https://zendesk.atlassian.net/browse/GG-3796?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[GG-3881]: https://zendesk.atlassian.net/browse/GG-3881?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[GG-3862]: https://zendesk.atlassian.net/browse/GG-3862?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ