### PR TITLE
fix: prevent text overflow in Japanese

### DIFF
--- a/style.css
+++ b/style.css
@@ -3494,6 +3494,7 @@ ul {
   white-space: pre;
 }
 .request-details dt {
+  line-break: strict;
   color: lighten($text_color, 20%);
   width: 40%;
 }

--- a/styles/_request.scss
+++ b/styles/_request.scss
@@ -150,6 +150,7 @@
     }
 
     dt {
+      line-break: strict;
       color: $secondary-text-color;
       width: 40%;
     }


### PR DESCRIPTION
## Description
In Japanese, having the single character broken into another line, provides another word meaning. We want to make sure the text is only broken at points that still preserve the message meaning of "Last activity"

## Screenshots

Before

![image](https://github.com/user-attachments/assets/b10bba9e-96e4-4824-ab3e-0053a225e890)

After

![image](https://github.com/user-attachments/assets/9e154a69-cb88-4cb5-943f-5a7530721d58)


## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->