### PR TITLE
feat: add proper link to service catalog list

### DIFF
--- a/templates/header.hbs
+++ b/templates/header.hbs
@@ -14,7 +14,7 @@
     <nav class="user-nav" id="user-nav" aria-label="{{t 'user_navigation'}}">
       <ul class="user-nav-list">
         <li>{{link 'community'}}</li>
-        <li><a href="/hc/en-us/services">Services</a></li>
+        <li>{{link 'service_catalog'}}</li>
         <li>{{link 'new_request' class='submit-a-request'}}</li>
         {{#unless signed_in}}
           <li>
@@ -85,7 +85,7 @@
         {{/if}}
         <li class="item">{{link 'community' role="menuitem"}}</li>
         <li class="item">{{link 'new_request' role="menuitem" class='submit-a-request'}}</li>
-        <li class="item"><a href="/hc/en-us/services">Request a service</a></li>
+        <li class="item">{{link 'service_catalog' role="menuitem"}}</li>
         <li class="nav-divider"></li>
         {{#if signed_in}}
           <li class="item">


### PR DESCRIPTION
## Description
We added Service Catalog linker in this PR: https://github.com/zendesk/help_center/pull/30861 so now we need to use this link in Copenhagen Theme. 
<!-- a summary of the changes introduced by this PR and the motivation behind them -->

## Screenshots
<img width="1226" alt="Screenshot 2024-12-03 at 12 18 51" src="https://github.com/user-attachments/assets/df7b65d5-c9d0-46c6-90d8-e4bde7ab5ac4">
<img width="871" alt="Screenshot 2024-12-02 at 18 05 22" src="https://github.com/user-attachments/assets/526bde32-42c0-47bf-87f0-916e833c11af">

<!-- (optional) when applicable, please include some screenshots or gifs that illustrate the changes -->

## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->