### PR TITLE
chore: add new string for translations

### DIFF
--- a/src/modules/shared/translations/en-us.yml
+++ b/src/modules/shared/translations/en-us.yml
@@ -1,0 +1,27 @@
+#
+# This file is used for the internal Zendesk translation system, and it is generated from the extract-strings.mjs script.
+# It contains the English strings to be translated, which are used for generating the JSON files containing the translation strings
+# for each language.
+#
+# If you are building your own theme, you can remove this file and just load the translation JSON files, or provide
+# your translations with a different method.
+#
+title: "Copenhagen Theme Shared Translations"
+packages:
+  - "cph-theme-shared"
+parts:
+  - translation:
+      key: "cph-theme-error-boundary.title"
+      title: "Message shown when an error occurs"
+      screenshot: "https://drive.google.com/file/d/1rJ9c4mW0YWnL5d6KWWZaY9TJBEH5otLL/view?usp=drive_link"
+      value: "Something went wrong."
+  - translation:
+      key: "cph-theme-error-boundary.message"
+      title: "Message shown when an error occurs"
+      screenshot: "https://drive.google.com/file/d/1rJ9c4mW0YWnL5d6KWWZaY9TJBEH5otLL/view?usp=drive_link"
+      value: "Give it a moment and try again later"
+  - translation:
+      key: "cph-theme-error-boundary.go-to-homepage"
+      title: "Error state go to the homepage link"
+      screenshot: "https://drive.google.com/file/d/1rJ9c4mW0YWnL5d6KWWZaY9TJBEH5otLL/view?usp=drive_link"
+      value: "Go to the homepage"


### PR DESCRIPTION
## Description
Added ErrorBoundary component with default error screen so we need translations for it.
<!-- a summary of the changes introduced by this PR and the motivation behind them -->

## Screenshots
<img width="1076" alt="Screenshot 2024-12-11 at 11 09 24" src="https://github.com/user-attachments/assets/ddd31082-1772-46ff-a4fe-931df4284113">

<!-- (optional) when applicable, please include some screenshots or gifs that illustrate the changes -->

## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->