### PR TITLE
fix: ensure we handle null values on description

### DIFF
--- a/__mocks__/svgMock.js
+++ b/__mocks__/svgMock.js
@@ -1,0 +1,1 @@
+export default 'SvgMock';

--- a/assets/service-catalog-bundle.js
+++ b/assets/service-catalog-bundle.js
@@ -312,11 +312,14 @@ const ToggleButton = styled(Button) `
     text-decoration: none;
   }
 `;
-const DESCRIPTION_LENGTH_THRESHOLD = 270;
+const shouldShowToggleButton = (description) => {
+    const DESCRIPTION_LENGTH_THRESHOLD = 270;
+    return typeof description === 'string' && description.length > DESCRIPTION_LENGTH_THRESHOLD;
+};
 const CollapsibleDescription = ({ title, description, }) => {
     const [isExpanded, setIsExpanded] = reactExports.useState(false);
     const { t } = useTranslation();
-    const showToggleButton = description.length > DESCRIPTION_LENGTH_THRESHOLD;
+    const showToggleButton = shouldShowToggleButton(description);
     const toggleDescription = () => {
         setIsExpanded(!isExpanded);
     };

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -5,6 +5,9 @@ const config = {
   transform: {
     "^.+.tsx?$": ["ts-jest", {}],
   },
+  moduleNameMapper: {
+    '\\.svg$': '<rootDir>/__mocks__/svgMock.js',
+  },
   setupFilesAfterEnv: ["@testing-library/jest-dom"],
 };
 

--- a/src/modules/service-catalog/components/service-catalog-item/CollapsibleDescription.tsx
+++ b/src/modules/service-catalog/components/service-catalog-item/CollapsibleDescription.tsx
@@ -50,11 +50,14 @@ interface CollapsibleDescriptionProps {
   description: string;
 }
 
-const DESCRIPTION_LENGTH_THRESHOLD = 270;
-
-export const shouldShowToggleButton = (description: string | null | undefined): boolean => {
+export const shouldShowToggleButton = (
+  description: string | null | undefined
+): boolean => {
   const DESCRIPTION_LENGTH_THRESHOLD = 270;
-  return typeof description === 'string' && description.length > DESCRIPTION_LENGTH_THRESHOLD;
+  return (
+    typeof description === "string" &&
+    description.length > DESCRIPTION_LENGTH_THRESHOLD
+  );
 };
 
 export const CollapsibleDescription = ({

--- a/src/modules/service-catalog/components/service-catalog-item/CollapsibleDescription.tsx
+++ b/src/modules/service-catalog/components/service-catalog-item/CollapsibleDescription.tsx
@@ -52,6 +52,11 @@ interface CollapsibleDescriptionProps {
 
 const DESCRIPTION_LENGTH_THRESHOLD = 270;
 
+export const shouldShowToggleButton = (description: string | null | undefined): boolean => {
+  const DESCRIPTION_LENGTH_THRESHOLD = 270;
+  return typeof description === 'string' && description.length > DESCRIPTION_LENGTH_THRESHOLD;
+};
+
 export const CollapsibleDescription = ({
   title,
   description,
@@ -59,8 +64,7 @@ export const CollapsibleDescription = ({
   const [isExpanded, setIsExpanded] = useState<boolean>(false);
   const { t } = useTranslation();
 
-  const showToggleButton = description.length > DESCRIPTION_LENGTH_THRESHOLD;
-
+  const showToggleButton = shouldShowToggleButton(description);
   const toggleDescription = () => {
     setIsExpanded(!isExpanded);
   };

--- a/src/modules/service-catalog/components/service-catalog-item/shouldShowToggleButton.spec.js
+++ b/src/modules/service-catalog/components/service-catalog-item/shouldShowToggleButton.spec.js
@@ -1,0 +1,24 @@
+import { shouldShowToggleButton } from './CollapsibleDescription';
+
+describe('shouldShowToggleButton', () => {
+  test('returns false for empty string', () => {
+    expect(shouldShowToggleButton("")).toBe(false);
+  });
+
+  test('returns false for null', () => {
+    expect(shouldShowToggleButton(null)).toBe(false);
+  });
+
+  test('returns false for undefined', () => {
+    expect(shouldShowToggleButton(undefined)).toBe(false);
+  });
+
+  test('returns false for short description', () => {
+    expect(shouldShowToggleButton("Short description")).toBe(false);
+  });
+
+  test('returns true for long description', () => {
+    const longDescription = "A".repeat(300);
+    expect(shouldShowToggleButton(longDescription)).toBe(true);
+  });
+});

--- a/src/modules/service-catalog/components/service-catalog-item/shouldShowToggleButton.spec.js
+++ b/src/modules/service-catalog/components/service-catalog-item/shouldShowToggleButton.spec.js
@@ -1,23 +1,24 @@
-import { shouldShowToggleButton } from './CollapsibleDescription';
+import { describe, expect, test } from "@jest/globals";
+import { shouldShowToggleButton } from "./CollapsibleDescription";
 
-describe('shouldShowToggleButton', () => {
-  test('returns false for empty string', () => {
+describe("shouldShowToggleButton", () => {
+  test("returns false for empty string", () => {
     expect(shouldShowToggleButton("")).toBe(false);
   });
 
-  test('returns false for null', () => {
+  test("returns false for null", () => {
     expect(shouldShowToggleButton(null)).toBe(false);
   });
 
-  test('returns false for undefined', () => {
+  test("returns false for undefined", () => {
     expect(shouldShowToggleButton(undefined)).toBe(false);
   });
 
-  test('returns false for short description', () => {
+  test("returns false for short description", () => {
     expect(shouldShowToggleButton("Short description")).toBe(false);
   });
 
-  test('returns true for long description', () => {
+  test("returns true for long description", () => {
     const longDescription = "A".repeat(300);
     expect(shouldShowToggleButton(longDescription)).toBe(true);
   });


### PR DESCRIPTION
## Description

Currently the page crashes when a description does not exist, due to a length check on a null value.
Have changed the logic to handle nulls and abstracted the function to be able to test it in isolation.


JIRA: https://zendesk.atlassian.net/jira/software/c/projects/GG/boards/1258?selectedIssue=GG-4011

## Screenshots

Before, service without description:

![image](https://github.com/user-attachments/assets/d8938276-216e-4bc7-b0b7-ecbfa57471b1)

Now
![image](https://github.com/user-attachments/assets/73096bd7-979d-4dec-8f9e-6e72a022409a)


## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->