### PR TITLE
i18n scripts improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,11 +178,11 @@ function MyComponent() {
 Providing the default English value in the code makes it possible to use it as a fallback value when strings are not yet translated and to extract the strings from the source code to the translations YAML file.
 
 #### Plurals 
-When using [plurals](https://www.i18next.com/translation-function/plurals), we need to provide default values for the `zero`, `one`, and `other` values, as requested by our translation system. This can be done by passing the default values in the [options](https://www.i18next.com/translation-function/essentials#overview-options) of the `t` function.
+When using [plurals](https://www.i18next.com/translation-function/plurals), you need to provide default values for at least the `one` and `other` forms. You can also pass a default value for the `zero` form, if you want it to be different from the `other` form. This can be done by passing the default values in the [options](https://www.i18next.com/translation-function/essentials#overview-options) of the `t` function.
 
 ```ts
 t("my-key", {
-  "defaultValue.zero": "{{count}} items",
+  "defaultValue.zero": "No items",
   "defaultValue.one": "{{count}} item",
   "defaultValue.other": "{{count}} items",
   count: ...
@@ -191,22 +191,41 @@ t("my-key", {
 
 #### String extraction
 
-The `bin/extract-strings.mjs` script can be used to extract translation strings from the source code and put them in the YAML file that is picked up by our internal translation system. The usage of the script is documented in the script itself.
+The `bin/extract-strings.mjs` script can be used to extract translation strings from the source code and put them in the YAML file that is picked up by our internal translation system.
+
+To extract the strings for all the modules, run:
+
+```bash
+yarn i18n:extract
+```
+
+To extract the strings for a specific module, run:
+
+```bash
+yarn i18n:extract --module=module-name
+```
+
+You can also pass the `--mark-obsolete` flag to mark removed strings as obsolete:
+
+```bash
+yarn i18n:extract --mark-obsolete
+```
+
+If you are adding a new module, you need first to create the initial `src/modules/[MODULE]/translations/en-us.yml` file with the header containing the title and package name:
+
+```yaml
+title: "My Module"
+packages:
+  - "package-name"
+```
 
 The script wraps the `i18next-parser` tool and converts its output to the YAML format used internally. It is possible to use a similar approach in a custom theme, either using the standard `i18next-parser` output as the source for translations or implementing a custom transformer.
 
 #### Updating translation files
 
-Use the `bin/update-modules-translations.mjs` to download the latest translations for all the modules. All files are then bundled by the build process in a single `[MODULE]-translations-bundle.js` file.
+You can run `yarn i18n:update-translations` to download the latest translations files for all the modules. The script downloads all the locale files for each module, fetching the package name from the `src/modules/[MODULE]/translations/en-us.yml` file, and saves them in the `src/modules/[MODULE]/translations/locales` folder.
 
-The first time that translations are added to a module, you need to add a mapping between the module folder and the package name on the translations systems to the `MODULE` variable in the script. For example, if a module is located in `src/modules/my-module` and the package name is `cph-theme-my-module`, you need to add:
-
-```js
-const MODULES = {
-  ...,
-  "my-module": "cph-theme-my-module"
-}
-```
+All files are then bundled by the build process in a single `[MODULE]-translations-bundle.js` file.
 
 # Accessibility testing
 

--- a/bin/extract-strings.mjs
+++ b/bin/extract-strings.mjs
@@ -83,10 +83,10 @@ const OUTPUT_BANNER = `#
 
 /** @type {import("i18next-parser").UserConfig} */
 const config = {
-  // Our translation system requires that we add ".zero", ".one", ".other" keys for plurals
+  // Our translation system requires that we add all 6 forms (zero, one, two, few, many, other) keys for plurals
   // i18next-parser extracts plural keys based on the target locale, so we are passing a
-  // locale that need exactly the ".zero", ".one", ".other" keys, even if we are extracting English strings
-  locales: ["lv"],
+  // locale that need exactly the 6 forms, even if we are extracting English strings
+  locales: ["ar"],
   keySeparator: false,
   namespaceSeparator: false,
   pluralSeparator: ".",
@@ -132,7 +132,9 @@ class SourceYmlTransform extends Transform {
       }
 
       // Add new keys to the source YAML or log mismatched value
-      for (const [key, value] of Object.entries(strings)) {
+      for (let [key, value] of Object.entries(strings)) {
+        value = this.#fixPluralValue(key, value, strings);
+
         const existingPart = outputContent.parts.find(
           (part) => part.translation.key === key
         );
@@ -204,6 +206,32 @@ class SourceYmlTransform extends Transform {
     }
 
     return result;
+  }
+
+  // if the key ends with .zero, .one, .two, .few, .many, .other and the value is empty
+  // find the same key with the `.other` suffix in strings and return the value
+  #fixPluralValue(key, value, strings) {
+    if (key.endsWith(".zero") && value === "") {
+      return strings[key.replace(".zero", ".other")] || "";
+    }
+
+    if (key.endsWith(".one") && value === "") {
+      return strings[key.replace(".one", ".other")] || "";
+    }
+
+    if (key.endsWith(".two") && value === "") {
+      return strings[key.replace(".two", ".other")] || "";
+    }
+
+    if (key.endsWith(".few") && value === "") {
+      return strings[key.replace(".few", ".other")] || "";
+    }
+
+    if (key.endsWith(".many") && value === "") {
+      return strings[key.replace(".many", ".other")] || "";
+    }
+
+    return value;
   }
 }
 

--- a/bin/extract-strings.mjs
+++ b/bin/extract-strings.mjs
@@ -13,7 +13,8 @@
  *       value: "My value"
  * ```
  *
- * If a string present in the source YAML file is not found in the source code, it will be marked as obsolete
+ * If a string present in the source YAML file is not found in the source code, it will be marked as obsolete if the
+ * `--mark-obsolete` flag is passed.
  *
  * If the value in the YAML file differs from the value in the source code, a warning will be printed in the console,
  * since the script cannot know which one is correct and cannot write back in the source code files. This can happen for
@@ -21,20 +22,52 @@
  *
  * The script uses the i18next-parser library for extracting the strings and it adds a custom transformer for creating
  * the file in the required YAML format.
+ *
+ * For usage instructions, run `node extract-strings.mjs --help`
  */
-// Usage:   node bin/extract-strings.mjs [PACKAGE_NAME] [SOURCE_FILES_GLOB] [OUTPUT_PATH]
-// Example: node bin/extract-strings.mjs new-request-form 'src/modules/new-request-form/**/*.{ts,tsx}' src/modules/new-request-form/translations
 import vfs from "vinyl-fs";
 import Vinyl from "vinyl";
 import { transform as I18NextTransform } from "i18next-parser";
 import { Transform } from "node:stream";
-import { existsSync, readFileSync } from "node:fs";
+import { readFileSync } from "node:fs";
 import { load, dump } from "js-yaml";
 import { resolve } from "node:path";
+import { glob } from "glob";
+import { parseArgs } from "node:util";
 
-const PACKAGE_NAME = process.argv[2];
-const INPUT_GLOB = `${process.cwd()}/${process.argv[3]}`;
-const OUTPUT_DIR = resolve(process.cwd(), process.argv[4]);
+const { values: args } = parseArgs({
+  options: {
+    "mark-obsolete": {
+      type: "boolean",
+    },
+    module: {
+      type: "string",
+    },
+    help: {
+      type: "boolean",
+    },
+  },
+});
+
+if (args.help) {
+  const helpMessage = `
+  Usage: extract-strings.mjs [options]
+
+  Options:
+    --mark-obsolete   Mark removed strings as obsolete in the source YAML file
+    --module          Extract strings only for the specified module. The module name should match the folder name in the src/modules folder
+                      If not specified, the script will extract strings for all modules
+    --help            Display this help message
+
+  Examples:
+    node extract-strings.mjs
+    node extract-strings.mjs --mark-obsolete
+    node extract-strings.mjs --module=ticket-fields
+  `;
+
+  console.log(helpMessage);
+  process.exit(0);
+}
 
 const OUTPUT_YML_FILE_NAME = "en-us.yml";
 
@@ -62,11 +95,8 @@ const config = {
 };
 
 class SourceYmlTransform extends Transform {
-  #defaultContent = {
-    title: "",
-    packages: [PACKAGE_NAME],
-    parts: [],
-  };
+  #parsedInitialContent;
+  #outputDir;
 
   #counters = {
     added: 0,
@@ -74,20 +104,30 @@ class SourceYmlTransform extends Transform {
     mismatch: 0,
   };
 
-  constructor() {
+  constructor(outputDir) {
     super({ objectMode: true });
+
+    this.#outputDir = outputDir;
+    this.#parsedInitialContent = this.#getSourceYmlContent();
   }
 
   _transform(file, encoding, done) {
     try {
       const strings = JSON.parse(file.contents.toString(encoding));
-      const outputContent = this.#getSourceYmlContent();
 
-      // Mark removed keys as obsolete
+      const outputContent = {
+        ...this.#parsedInitialContent,
+        parts: this.#parsedInitialContent.parts || [],
+      };
+
+      // Find obsolete keys
       for (const { translation } of outputContent.parts) {
         if (!(translation.key in strings) && !translation.obsolete) {
-          translation.obsolete = this.#getObsoleteDate();
           this.#counters.obsolete++;
+
+          if (args["mark-obsolete"]) {
+            translation.obsolete = this.#getObsoleteDate();
+          }
         }
       }
 
@@ -124,12 +164,7 @@ class SourceYmlTransform extends Transform {
         ),
       });
       this.push(virtualFile);
-
-      console.log(`String extraction completed!
-      Added strings: ${this.#counters.added}
-      Removed strings (marked as obsolete): ${this.#counters.obsolete}
-      Strings with mismatched value: ${this.#counters.mismatch}`);
-
+      this.#printInfo();
       done();
     } catch (e) {
       console.error(e);
@@ -138,12 +173,8 @@ class SourceYmlTransform extends Transform {
   }
 
   #getSourceYmlContent() {
-    const outputPath = resolve(OUTPUT_DIR, OUTPUT_YML_FILE_NAME);
-    if (existsSync(outputPath)) {
-      return load(readFileSync(outputPath, "utf-8"));
-    }
-
-    return this.#defaultContent;
+    const outputPath = resolve(this.#outputDir, OUTPUT_YML_FILE_NAME);
+    return load(readFileSync(outputPath, "utf-8"));
   }
 
   #getObsoleteDate() {
@@ -151,10 +182,47 @@ class SourceYmlTransform extends Transform {
     const obsolete = new Date(today.setMonth(today.getMonth() + 3));
     return obsolete.toISOString().split("T")[0];
   }
+
+  #printInfo() {
+    const message = `Package ${this.#parsedInitialContent.packages[0]}
+    Added strings: ${this.#counters.added}
+    ${this.#getObsoleteInfoMessage()}
+    Strings with mismatched value: ${this.#counters.mismatch}
+    `;
+
+    console.log(message);
+  }
+
+  #getObsoleteInfoMessage() {
+    if (args["mark-obsolete"]) {
+      return `Removed strings (marked as obsolete): ${this.#counters.obsolete}`;
+    }
+
+    let result = `Obsolete strings: ${this.#counters.obsolete}`;
+    if (this.#counters.obsolete > 0) {
+      result += " - Use --mark-obsolete to mark them as obsolete";
+    }
+
+    return result;
+  }
 }
 
-vfs
-  .src([INPUT_GLOB])
-  .pipe(new I18NextTransform(config))
-  .pipe(new SourceYmlTransform())
-  .pipe(vfs.dest(OUTPUT_DIR));
+const sourceFilesGlob = args.module
+  ? `src/modules/${args.module}/translations/en-us.yml`
+  : "src/modules/**/translations/en-us.yml";
+
+const sourceFiles = await glob(sourceFilesGlob);
+for (const sourceFile of sourceFiles) {
+  const moduleName = sourceFile.split("/")[2];
+  const inputGlob = `src/modules/${moduleName}/**/*.{ts,tsx}`;
+  const outputDir = resolve(
+    process.cwd(),
+    `src/modules/${moduleName}/translations`
+  );
+
+  vfs
+    .src([inputGlob])
+    .pipe(new I18NextTransform(config))
+    .pipe(new SourceYmlTransform(outputDir))
+    .pipe(vfs.dest(outputDir));
+}

--- a/bin/update-modules-translations.mjs
+++ b/bin/update-modules-translations.mjs
@@ -3,15 +3,10 @@
  * This script is used for downloading the latest Zendesk official translation files for the modules in the `src/module` folder.
  *
  */
-import { writeFile } from "node:fs/promises";
+import { writeFile, readFile, mkdir } from "node:fs/promises";
 import { resolve } from "node:path";
-
-/**
- *  Maps each folder in the `src/modules` directory with its package name on the translation system
- */
-const MODULES = {
-  "new-request-form": "new-request-form",
-};
+import { glob } from "glob";
+import { load } from "js-yaml";
 
 const BASE_URL = `https://static.zdassets.com/translations`;
 
@@ -38,6 +33,8 @@ async function fetchModuleTranslations(moduleName, packageName) {
       `src/modules/${moduleName}/translations/locales`
     );
 
+    await mkdir(outputDir, { recursive: true });
+
     const { json } = await manifestResponse.json();
 
     await Promise.all(
@@ -50,6 +47,23 @@ async function fetchModuleTranslations(moduleName, packageName) {
   }
 }
 
-for (const [moduleName, packageName] of Object.entries(MODULES)) {
+// search for `src/modules/**/translations/en-us.yml` files, read it contents and return a map of module names and package names
+async function getModules() {
+  const result = {};
+  const files = await glob("src/modules/**/translations/en-us.yml");
+
+  for (const file of files) {
+    const content = await readFile(file);
+    const parsedContent = load(content);
+    const moduleName = file.split("/")[2];
+    result[moduleName] = parsedContent.packages[0];
+  }
+
+  return result;
+}
+
+const modules = await getModules();
+
+for (const [moduleName, packageName] of Object.entries(modules)) {
   await fetchModuleTranslations(moduleName, packageName);
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "download-locales": "node ./bin/update-translations",
     "test": "jest",
     "test-a11y": "node bin/lighthouse/index.js",
-    "i18n:extract": "node bin/extract-strings.mjs new-request-form 'src/modules/new-request-form/**/*.{ts,tsx}' src/modules/new-request-form/translations",
+    "i18n:extract": "node bin/extract-strings.mjs",
     "i18n:update-translations": "node bin/update-modules-translations.mjs",
     "zcli": "zcli"
   },

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "eslint-plugin-prettier": "4.2.1",
     "eslint-plugin-react": "^7.32.2",
     "eslint-plugin-react-hooks": "^4.6.0",
+    "glob": "^10.4.5",
     "husky": "8.0.2",
     "i18next-parser": "^8.13.0",
     "jest": "^29.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7564,6 +7564,18 @@ glob@^10.2.2:
     minipass "^5.0.0 || ^6.0.2 || ^7.0.0"
     path-scurry "^1.10.1"
 
+glob@^10.4.5:
+  version "10.4.5"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-10.4.5.tgz#f4d9f0b90ffdbab09c9d77f5f29b4262517b0956"
+  integrity sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==
+  dependencies:
+    foreground-child "^3.1.0"
+    jackspeak "^3.1.2"
+    minimatch "^9.0.4"
+    minipass "^7.1.2"
+    package-json-from-dist "^1.0.0"
+    path-scurry "^1.11.1"
+
 glob@^7.1.3, glob@^7.1.4:
   version "7.2.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.3.tgz#b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b"
@@ -8625,6 +8637,15 @@ jackspeak@^2.3.5:
   optionalDependencies:
     "@pkgjs/parseargs" "^0.11.0"
 
+jackspeak@^3.1.2:
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/jackspeak/-/jackspeak-3.4.3.tgz#8833a9d89ab4acde6188942bd1c53b6390ed5a8a"
+  integrity sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==
+  dependencies:
+    "@isaacs/cliui" "^8.0.2"
+  optionalDependencies:
+    "@pkgjs/parseargs" "^0.11.0"
+
 jake@^10.8.5:
   version "10.8.7"
   resolved "https://registry.yarnpkg.com/jake/-/jake-10.8.7.tgz#63a32821177940c33f356e0ba44ff9d34e1c7d8f"
@@ -9633,6 +9654,11 @@ lower-case@^2.0.2:
   dependencies:
     tslib "^2.0.3"
 
+lru-cache@^10.2.0:
+  version "10.4.3"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.4.3.tgz#410fc8a17b70e598013df257c2446b7f3383f119"
+  integrity sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==
+
 lru-cache@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-5.1.1.tgz#1da27e6710271947695daf6848e847f01d84b920"
@@ -9918,6 +9944,13 @@ minimatch@^5.0.1, minimatch@^5.1.0:
   dependencies:
     brace-expansion "^2.0.1"
 
+minimatch@^9.0.4:
+  version "9.0.5"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.5.tgz#d74f9dd6b57d83d8e98cfb82133b03978bc929e5"
+  integrity sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==
+  dependencies:
+    brace-expansion "^2.0.1"
+
 minimist-options@4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/minimist-options/-/minimist-options-4.1.0.tgz#c0655713c53a8a2ebd77ffa247d342c40f010619"
@@ -10011,6 +10044,11 @@ minipass@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-7.0.3.tgz#05ea638da44e475037ed94d1c7efcc76a25e1974"
   integrity sha512-LhbbwCfz3vsb12j/WkWQPZfKTsgqIe1Nf/ti1pKjYESGLHIVjWU96G9/ljLH4F9mWNVhlQOm0VySdAWzf05dpg==
+
+minipass@^7.1.2:
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-7.1.2.tgz#93a9626ce5e5e66bd4db86849e7515e92340a707"
+  integrity sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==
 
 minizlib@^2.1.1, minizlib@^2.1.2:
   version "2.1.2"
@@ -10745,6 +10783,11 @@ p-try@^2.0.0:
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
 
+package-json-from-dist@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz#4f1471a010827a86f94cfd9b0727e36d267de505"
+  integrity sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==
+
 pacote@^13.0.3, pacote@^13.6.1, pacote@^13.6.2:
   version "13.6.2"
   resolved "https://registry.yarnpkg.com/pacote/-/pacote-13.6.2.tgz#0d444ba3618ab3e5cd330b451c22967bbd0ca48a"
@@ -10899,6 +10942,14 @@ path-scurry@^1.10.1:
   integrity sha512-MkhCqzzBEpPvxxQ71Md0b1Kk51W01lrYvlMzSUaIzNsODdd7mqhiimSZlr+VegAz5Z6Vzt9Xg2ttE//XBhH3EQ==
   dependencies:
     lru-cache "^9.1.1 || ^10.0.0"
+    minipass "^5.0.0 || ^6.0.2 || ^7.0.0"
+
+path-scurry@^1.11.1:
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/path-scurry/-/path-scurry-1.11.1.tgz#7960a668888594a0720b12a911d1a742ab9f11d2"
+  integrity sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==
+  dependencies:
+    lru-cache "^10.2.0"
     minipass "^5.0.0 || ^6.0.2 || ^7.0.0"
 
 path-to-regexp@0.1.7:


### PR DESCRIPTION
## Description

This PR adds some improvements to the scripts used for downloading and extracting translation strings for the JS modules. The scripts were added when we had only one module, so they needed some tweaks to make it easier to work with multiple modules.

### bin/update-modules-translations.mjs
- Removed the `MODULES` mapping. Now the script searches for all the files matching the `src/modules/**/translations/en-us.yml` glob and downloads the translation files.

### bin/extract-strings.mjs
- Removed the need to specify the package name, source file glob, and output file as args.  The script now searches for all the files matching the `src/modules/**/translations/en-us.yml` glob and extracts strings for each module using the `src/modules/[MODULE_NAME]/**/*.{ts,tsx}` glob.
- Added the ability to extract strings for all modules or a single module, passing a `--module` parameter.
- The script now doesn't mark removed strings as obsolete by default, but it has a new `--mark-obsolete` flag. Sometimes we remove some strings on a branch but we want to deprecate them later when we merge the branch on `master`
- We have new i18n guidelines requiring us to provide strings for all possible plural form values (zero, one, two, few, many, other). The script has been updated to extract all the needed strings for plurals.

### Note
I ran the extract-strings script on `master` and `service-catalog` branches and found some inconsistencies in the strings used in the source code and the translation files, for example:
- there is a typo here: https://github.com/zendesk/copenhagen_theme/blob/6840432aa20893fd18b5c6648217e4e403a25dcf/src/modules/new-request-form/fields/attachments/FileListItem.tsx#L104 (`arria-label`) while the key in the yml file is correct
- we are using strings from another module in some places (e.g. https://github.com/zendesk/copenhagen_theme/blob/d29494dc07c31f0d826fa4ada1515b2377648715/src/modules/service-catalog/useNotifyError.tsx#L19 where we use a string from the `new-request-form` module in the `service-catalog` module.

We will need to open other PRs to fix these issue.

## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->