### PR TITLE
chore: fixed lighthouse check on CI

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -11,6 +11,10 @@ jobs:
         uses: zendesk/setup-node@v3
         with:
           node-version-file: '.nvmrc'
+      # The following step is needed to run puppeteer with ubuntu >= 23.10
+      # ref: https://pptr.dev/troubleshooting#issues-with-apparmor-on-ubuntu
+      - name: Disable AppArmor
+        run: echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
       - name: Install node_modules
         run: yarn install --frozen-lockfile
       - name: Build


### PR DESCRIPTION
## Description

The `lighthouse` check started to fail recently, and it is caused by the fact that the `ubuntu-latest` image on Github Actions has been automatically upgraded to 24.04, and we need to pass an additional config to make `puppeteer` work on this version.

Ref: https://pptr.dev/troubleshooting#issues-with-apparmor-on-ubuntu

The same approach is used by Puppeteer itself in their repo: https://github.com/puppeteer/puppeteer/pull/13196

## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->