### PR TITLE
chore(i18n): added shared translation string

### DIFF
--- a/src/modules/shared/translations/en-us.yml
+++ b/src/modules/shared/translations/en-us.yml
@@ -6,6 +6,7 @@
 # If you are building your own theme, you can remove this file and just load the translation JSON files, or provide
 # your translations with a different method.
 #
+
 title: "Copenhagen Theme Shared Translations"
 packages:
   - "cph-theme-shared"
@@ -25,3 +26,7 @@ parts:
       title: "Error state go to the homepage link"
       screenshot: "https://drive.google.com/file/d/1rJ9c4mW0YWnL5d6KWWZaY9TJBEH5otLL/view?usp=drive_link"
       value: "Go to the homepage"
+  - translation:
+      key: "cph-theme-shared.close-label"
+      title: "[A11Y] Hidden label for screen readers for close buttons (e.g. in modals and notifications)"
+      value: "Close"


### PR DESCRIPTION
## Description

This PR adds the new `cph-theme-shared.close-label` translation string on `master`, so it can be translated

## Screenshots

<!-- (optional) when applicable, please include some screenshots or gifs that illustrate the changes -->

## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->