### PR TITLE
chore: added suport for beta branch on CI

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - master
+      - beta
 
 jobs:
   commitlint:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches: 
       - master
+      - beta
 jobs:
   release:
     name: Release

--- a/.releaserc
+++ b/.releaserc
@@ -1,6 +1,9 @@
 {
     "branches": [
-        "master"
+        "master",
+        {
+            "name": "beta", "prerelease": true
+        }
     ],
     "plugins": [
         "@semantic-release/commit-analyzer",


### PR DESCRIPTION
## Description

I created a new [beta branch](https://github.com/zendesk/copenhagen_theme/tree/beta) from master, where we are going to merge features that are not ready to be merged on master. We will soon merge the `service-catalog-eap` on this branch. The branch has been protected on GitHub as the master, to avoid pushes without approved PRs and so on.

With this PR I am adding support for this branch on CI. We will start to run the `checks` and `release` on pushes to this branch like we do on master, and `semantic-release` has been configured to update the changelog and create a release on this branch. The releases will be created as beta releases. For example, now we are on `v4.2.7` on `master`, and when we merge something on the beta branch we should have a new `v4.3.0-beta.X` version

## Screenshots

<!-- (optional) when applicable, please include some screenshots or gifs that illustrate the changes -->

## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->