### PR TITLE
fix: display translated error messages for service submission

### DIFF
--- a/src/modules/service-catalog/submitServiceItemRequest.tsx
+++ b/src/modules/service-catalog/submitServiceItemRequest.tsx
@@ -20,7 +20,7 @@ export async function submitServiceItemRequest(
         value: field.value,
       };
     });
-    const response = await fetch("/api/v2/requests", {
+    const response = await fetch(`/api/v2/requests?locale=${baseLocale}`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -43,7 +43,6 @@ export async function submitServiceItemRequest(
             channel: "web form",
             source: 50,
           },
-          locale: baseLocale,
         },
       }),
     });


### PR DESCRIPTION
## Description

This PR fixes the display of error messages on the Service item page. We were passing the `locale` parameter in the body instead of as a query parameter, so the messages were not translated

## Screenshots

Before:

![Screenshot 2025-02-11 at 17 41 56](https://github.com/user-attachments/assets/4b80d7e2-ebdc-40a0-b6e1-c98deb84f70d)

After:

![Screenshot 2025-02-11 at 17 41 23](https://github.com/user-attachments/assets/8666f4f0-2ba7-4c86-bf05-bf99cbe7ace4)


## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->