### PR TITLE
chore: fix approval-requests translation key and add translation

### DIFF
--- a/src/modules/approval-requests/translations/en-us.yml
+++ b/src/modules/approval-requests/translations/en-us.yml
@@ -6,6 +6,7 @@
 # If you are building your own theme, you can remove this file and just load the translation JSON files, or provide
 # your translations with a different method.
 #
+
 title: "Copenhagen Theme Approval requests"
 packages:
   - "approval-requests"
@@ -71,8 +72,8 @@ parts:
       screenshot: "https://drive.google.com/file/d/1j9IzjnAa1AVXzWq6r4x4QcaQN-Y64lM5/view?usp=drive_link"
       value: "Comment"
   - translation:
-      key: "approval-requests.request.approval-request-details.decided - Subject: 'approval request'"
-      title: "Label for the decision date on an approval request"
+      key: "approval-requests.request.approval-request-details.decided"
+      title: "Label for the decision date on an approval request - Subject: 'approval request'"
       screenshot: "https://drive.google.com/file/d/1xpM_3Rt3hCD8aE-U7mEbL0Sh5dsC0ScN/view?usp=drive_link"
       value: "Decided"
   - translation:
@@ -141,10 +142,15 @@ parts:
       screenshot: "https://drive.google.com/file/d/10Mdnw0YkIq3w4CjdDOSD9efAAxDapzYr/view?usp=drive_link"
       value: "Search approval requests"
   - translation:
+      key: "approval-requests.list.no-requests"
+      title: "Text to convey that no approval requests exist on the approval requests list page."
+      screenshot: "https://drive.google.com/file/d/1rrZ1MZKAsY7mNo89McYaZNwEB5pDjKtk/view?usp=sharing"
+      value: "No approval requests found."
+  - translation:
       key: "approval-requests.list.status-dropdown.label"
       title: "Label for the status dropdown on the approval requests list page"
       screenshot: "https://drive.google.com/file/d/18_4fS0yROAMC1yVdDYLfYvjKWeUdWCDH/view?usp=drive_link"
-      value: "Status"
+      value: "Status:"
   - translation:
       key: "approval-requests.list.status-dropdown.any"
       title: "Label for any dropdown option within the status dropdown on the approval requests list page - Subject: 'status'"


### PR DESCRIPTION
## Description
https://github.com/zendesk/copenhagen_theme/pull/575 accidentally added text to a key vs. the label. This PR addresses that while also adding a translation and updating a value.
<!-- a summary of the changes introduced by this PR and the motivation behind them -->

## Screenshots

<!-- (optional) when applicable, please include some screenshots or gifs that illustrate the changes -->

## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->