### PR TITLE
fix: apply end user conditions for checkbox fields correctly

### DIFF
--- a/src/modules/new-request-form/data-types/Field.ts
+++ b/src/modules/new-request-form/data-types/Field.ts
@@ -1,7 +1,7 @@
 export interface Field {
   id: number;
   name: string;
-  value?: string | string[] | boolean;
+  value: string | string[] | boolean | null;
   error: string | null;
   label: string;
   required: boolean;

--- a/src/modules/new-request-form/getVisibleFields.test.tsx
+++ b/src/modules/new-request-form/getVisibleFields.test.tsx
@@ -13,6 +13,7 @@ const dropdownField: Field = {
     { name: "One", value: "one" },
     { name: "Two", value: "two" },
   ],
+  value: null,
 };
 
 const secondDropdownField: Field = {
@@ -27,6 +28,7 @@ const secondDropdownField: Field = {
     { name: "Three", value: "three" },
     { name: "Four", value: "four" },
   ],
+  value: null,
 };
 
 const textField: Field = {
@@ -38,6 +40,7 @@ const textField: Field = {
   description: "",
   type: "text",
   options: [],
+  value: null,
 };
 
 const integerField: Field = {
@@ -49,6 +52,43 @@ const integerField: Field = {
   description: "",
   type: "number",
   options: [],
+  value: null,
+};
+
+const defaultValueCheckboxField: Field = {
+  id: 102,
+  name: "request[custom_fields][102]",
+  required: false,
+  error: null,
+  label: "Checkbox Field",
+  description: "",
+  type: "checkbox",
+  options: [],
+  value: null,
+};
+
+const unselectedCheckboxField: Field = {
+  id: 103,
+  name: "request[custom_fields][103]",
+  required: false,
+  error: null,
+  label: "Checkbox Field",
+  description: "",
+  type: "checkbox",
+  options: [],
+  value: false,
+};
+
+const selectedCheckboxField: Field = {
+  id: 104,
+  name: "request[custom_fields][104]",
+  required: false,
+  error: null,
+  label: "Checkbox Field",
+  description: "",
+  type: "checkbox",
+  options: [],
+  value: true,
 };
 
 describe("getVisibleFields", () => {
@@ -265,5 +305,53 @@ describe("getVisibleFields", () => {
       { ...textField, value: "text" },
       { ...integerField, required: true },
     ]);
+  });
+
+  it("should show fields for unselected checkbox condition when the field has a default null value", () => {
+    const fields = [defaultValueCheckboxField, textField];
+    const endUserConditions: EndUserCondition[] = [
+      {
+        parent_field_id: defaultValueCheckboxField.id,
+        parent_field_type: "checkbox",
+        value: false,
+        child_fields: [{ id: textField.id, is_required: false }],
+      },
+    ];
+
+    const result = getVisibleFields(fields, endUserConditions);
+
+    expect(result).toEqual([defaultValueCheckboxField, textField]);
+  });
+
+  it("should show fields for unselected checkbox condition when the field has a false value", () => {
+    const fields = [unselectedCheckboxField, textField];
+    const endUserConditions: EndUserCondition[] = [
+      {
+        parent_field_id: unselectedCheckboxField.id,
+        parent_field_type: "checkbox",
+        value: false,
+        child_fields: [{ id: textField.id, is_required: false }],
+      },
+    ];
+
+    const result = getVisibleFields(fields, endUserConditions);
+
+    expect(result).toEqual([unselectedCheckboxField, textField]);
+  });
+
+  it("should show fields for selected checkbox condition when the field has a true value", () => {
+    const fields = [selectedCheckboxField, textField];
+    const endUserConditions: EndUserCondition[] = [
+      {
+        parent_field_id: selectedCheckboxField.id,
+        parent_field_type: "checkbox",
+        value: true,
+        child_fields: [{ id: textField.id, is_required: false }],
+      },
+    ];
+
+    const result = getVisibleFields(fields, endUserConditions);
+
+    expect(result).toEqual([selectedCheckboxField, textField]);
   });
 });

--- a/src/modules/new-request-form/getVisibleFields.tsx
+++ b/src/modules/new-request-form/getVisibleFields.tsx
@@ -9,6 +9,17 @@ function getFieldConditions(
   });
 }
 
+function isMatchingValue(
+  fieldValue: Field["value"],
+  condition: EndUserCondition
+): boolean {
+  if (condition.parent_field_type === "checkbox" && condition.value === false) {
+    return fieldValue === false || fieldValue === null;
+  }
+
+  return fieldValue === condition.value;
+}
+
 function getAppliedConditions(
   fieldConditions: EndUserCondition[],
   allConditions: EndUserCondition[],
@@ -31,7 +42,7 @@ function getAppliedConditions(
     // the condition is applied if the parent field value matches the condition value
     // and if the parent field has no conditions or if the parent field conditions are met
     return (
-      parentField.value === condition.value &&
+      isMatchingValue(parentField.value, condition) &&
       (parentFieldConditions.length === 0 ||
         getAppliedConditions(parentFieldConditions, allConditions, fields)
           .length > 0)


### PR DESCRIPTION
## Description

The end-user conditions for checkbox fields with unselected values were not being applied correctly.
This was due to the fact that the conditions were not being applied at the first page load, when the field value has a default value of null, because we were comparing it with the condition value of false.

## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->