### PR TITLE
fix(a11y): removed menuitem role from user mobile navbar

### DIFF
--- a/templates/header.hbs
+++ b/templates/header.hbs
@@ -61,7 +61,7 @@
       <ul class="menu-list-mobile-items">
         {{#if signed_in}}
           <li class="user-avatar-item item">
-            {{#my_profile role="menuitem" class="my-profile"}}
+            {{#my_profile class="my-profile"}}
               {{user_avatar class="menu-profile-avatar"}}
               <div class="menu-profile-name">
                 <div>{{user_name}}</div>
@@ -69,25 +69,25 @@
               </div>
             {{/my_profile}}
           </li>
-          <li class="item">{{link "requests" role="menuitem"}}</li>
-          <li class="item">{{#link "contributions" role="menuitem"}}{{t "activities"}}{{/link}}</li>
-          <li class="item">{{contact_details role="menuitem"}}</li>
-          <li class="item">{{change_password role="menuitem" class='change-password'}}</li>
+          <li class="item">{{link "requests"}}</li>
+          <li class="item">{{#link "contributions"}}{{t "activities"}}{{/link}}</li>
+          <li class="item">{{contact_details}}</li>
+          <li class="item">{{change_password class='change-password'}}</li>
           <li class="nav-divider"></li>
         {{else}}
           <li class="item">
-            {{#link "sign_in" role="menuitem"}}
+            {{#link "sign_in"}}
               {{t 'sign_in'}}
             {{/link}}
           </li>
           <li class="nav-divider"></li>
         {{/if}}
-        <li class="item">{{link 'community' role="menuitem"}}</li>
-        <li class="item">{{link 'new_request' role="menuitem" class='submit-a-request'}}</li>
+        <li class="item">{{link 'community'}}</li>
+        <li class="item">{{link 'new_request' class='submit-a-request'}}</li>
         <li class="nav-divider"></li>
         {{#if signed_in}}
           <li class="item">
-            {{link "sign_out" role="menuitem"}}
+            {{link "sign_out"}}
           </li>
         {{/if}}
       </ul>


### PR DESCRIPTION
## Description

This PR fixes an accessibility issue with the user dropdown menu on mobile. We were incorrectly setting a `menuitem` role to the links in the dropdown, which is not valid for WCAG since they don't have a container element with a `menu` role. The issue was reported by a customer and it is also reported by a11y checker tools.:

![Screenshot 2025-02-13 at 14 41 41](https://github.com/user-attachments/assets/43d5c7c3-de5b-4d6b-8ea3-8c275452e83b)

This PR just removes the unneeded role, the mobile menu seems already compatible with the suggested APG pattern for navigation menus: https://www.w3.org/WAI/ARIA/apg/patterns/disclosure/examples/disclosure-navigation/

## Screenshots

The change doesn't seem to affect the styling of the menu items in any way.

Before:
![Screenshot 2025-02-13 at 14 42 22](https://github.com/user-attachments/assets/046c980b-bd16-49d8-8c0f-a359821065dd)

After:
![Screenshot 2025-02-13 at 14 42 45](https://github.com/user-attachments/assets/9b8102c3-7113-47f5-a2a9-f9d02d533739)

## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->