### PR TITLE
chore: mark unused strings for service-catalog as obsolete

### DIFF
--- a/src/modules/service-catalog/translations/en-us.yml
+++ b/src/modules/service-catalog/translations/en-us.yml
@@ -35,6 +35,7 @@ parts:
       title: "Empty state support article link"
       screenshot: "https://drive.google.com/file/d/1D_3VXzWSuj9f34PsFPa0b4uELz8-T9ll/view?usp=drive_link"
       value: "Learn about the service catalog"    
+      obsolete: "2025-04-22"
   - translation:
       key: "service-catalog.empty-state.go-to-homepage"
       title: "Empty state go to homepage link"
@@ -75,6 +76,7 @@ parts:
       title: "[A11Y] Hidden label for screen readers for close buttons (e.g. in modals and notifications)"
       screenshot: ""
       value: "Close"
+      obsolete: "2025-04-22"
   - translation:
       key: "service-catalog.service-list-error-title"
       title: "Error notification title when there is problem with loading the list of services"


### PR DESCRIPTION
## Description

This PR brings the changes about obsolete strings added in #567 on master.

## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->