### PR TITLE
TAA-385: updated UI to accomodate api change for decision

### DIFF
--- a/src/modules/approval-requests/components/approval-request/ApprovalRequestDetails.test.tsx
+++ b/src/modules/approval-requests/components/approval-request/ApprovalRequestDetails.test.tsx
@@ -29,7 +29,17 @@ const mockApprovalRequest: ApprovalRequest = {
     },
   },
   decided_at: null,
-  decision_notes: [],
+  decisions: {
+    decided_at: null,
+    decided_by_user: {
+      id: 456,
+      name: "Jane Approver",
+      photo: {
+        content_url: null,
+      },
+    },
+    decision_notes: null,
+  },
   ticket_details: {
     id: "789",
     priority: "normal",
@@ -66,7 +76,17 @@ describe("ApprovalRequestDetails", () => {
       ...mockApprovalRequest,
       status: "approved",
       decided_at: "2024-02-21T15:45:00Z",
-      decision_notes: ["This looks good to me"],
+      decisions: {
+        decision_notes: "This looks good to me",
+        decided_at: "2024-02-21T15:45:00Z",
+        decided_by_user: {
+          id: 456,
+          name: "Jane Approver",
+          photo: {
+            content_url: null,
+          },
+        },
+      },
     };
 
     renderWithTheme(

--- a/src/modules/approval-requests/components/approval-request/ApprovalRequestDetails.tsx
+++ b/src/modules/approval-requests/components/approval-request/ApprovalRequestDetails.tsx
@@ -106,21 +106,24 @@ function ApprovalRequestDetails({
           </MD>
         </Col>
       </DetailRow>
-      {approvalRequest.decision_notes.length > 0 && (
-        <DetailRow>
-          <Col size={4}>
-            <FieldLabel>
-              {t(
-                "approval-requests.request.approval-request-details.comment",
-                "Comment"
-              )}
-            </FieldLabel>
-          </Col>
-          <Col size={8}>
-            <MD>{approvalRequest.decision_notes[0]}</MD>
-          </Col>
-        </DetailRow>
-      )}
+      {approvalRequest.decisions &&
+        Array.isArray(approvalRequest.decisions) &&
+        approvalRequest.decisions.length > 0 && (
+          <DetailRow>
+            <Col size={4}>
+              <FieldLabel>
+                {t(
+                  "approval-requests.request.approval-request-details.comment",
+                  "Comment"
+                )}
+              </FieldLabel>
+            </Col>
+            <Col size={8}>
+              <MD>{approvalRequest.decisions[0].decision_notes}</MD>
+            </Col>
+          </DetailRow>
+        )}
+
       {approvalRequest.decided_at && (
         <DetailRow>
           <Col size={4}>

--- a/src/modules/approval-requests/types.ts
+++ b/src/modules/approval-requests/types.ts
@@ -6,6 +6,18 @@ interface ApprovalRequestUser {
   };
 }
 
+interface ApprovalDecisions {
+  decided_at: string | null;
+  decided_by_user: {
+    id: number;
+    name: string;
+    photo: {
+      content_url: string | null;
+    };
+  };
+  decision_notes: string | null;
+}
+
 export type ApprovalRequestStatus =
   | "active"
   | "approved"
@@ -23,7 +35,7 @@ export interface ApprovalRequest {
   created_at: string;
   created_by_user: ApprovalRequestUser;
   decided_at: string | null;
-  decision_notes: string[];
+  decisions: ApprovalDecisions;
   assignee_user: ApprovalRequestUser;
   ticket_details: ApprovalRequestTicket;
 }


### PR DESCRIPTION
## Description

<!-- a summary of the changes introduced by this PR and the motivation behind them -->
Fixed to update the UI according to updated api response.
JIRA: [TAA-385](https://zendesk.atlassian.net/browse/TAA-385)

## Screenshots

<!-- (optional) when applicable, please include some screenshots or gifs that illustrate the changes -->
Before:
<img width="1728" alt="Screenshot 2025-02-21 at 7 27 59 PM" src="https://github.com/user-attachments/assets/5d744ddf-4d1a-42e5-b590-a53d0c75f0e4" />
After:
<img width="1728" alt="Screenshot 2025-02-21 at 7 29 48 PM" src="https://github.com/user-attachments/assets/cfbfb33a-926b-48d6-a56f-1925a4573cb6" />


## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->


[TAA-385]: https://zendesk.atlassian.net/browse/TAA-385?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ