### PR TITLE
feat(TAA-360): add the Previous Decision display on a withdrawn Approval Request

### DIFF
--- a/assets/approval-requests-bundle.js
+++ b/assets/approval-requests-bundle.js
@@ -96,7 +96,7 @@ function ApprovalRequestListFilters({ approvalRequestStatus, setApprovalRequestS
     const handleSearch = reactExports.useCallback((event) => {
         debouncedSetSearchTerm(event.target.value);
     }, [debouncedSetSearchTerm]);
-    return (jsxRuntimeExports.jsxs(FiltersContainer, { children: [jsxRuntimeExports.jsxs(SearchField, { children: [jsxRuntimeExports.jsx(Label, { hidden: true, children: t("approval-requests.list.search-placeholder", "Search approval requests") }), jsxRuntimeExports.jsx(MediaInput, { start: jsxRuntimeExports.jsx(SvgSearchStroke, {}), placeholder: t("approval-requests.list.search-placeholder", "Search approval requests"), onChange: handleSearch })] }), jsxRuntimeExports.jsxs(DropdownFilterField, { children: [jsxRuntimeExports.jsx(Label, { children: t("approval-requests.list.status-dropdown.label", "Status:") }), jsxRuntimeExports.jsxs(Combobox, { isEditable: false, onChange: handleChange, selectionValue: approvalRequestStatus, inputValue: ApprovalRequestStatusInputMap[approvalRequestStatus], children: [jsxRuntimeExports.jsx(Option, { value: "any", label: t("approval-requests.list.status-dropdown.any", "Any") }), jsxRuntimeExports.jsx(Option, { value: APPROVAL_REQUEST_STATES.ACTIVE, label: t("approval-requests.status.decision-pending", "Decision pending") }), jsxRuntimeExports.jsx(Option, { value: APPROVAL_REQUEST_STATES.APPROVED, label: t("approval-requests.status.approved", "Approved") }), jsxRuntimeExports.jsx(Option, { value: APPROVAL_REQUEST_STATES.REJECTED, label: t("approval-requests.status.denied", "Denied") }), jsxRuntimeExports.jsx(Option, { value: APPROVAL_REQUEST_STATES.WITHDRAWN, label: t("approval-requests.status.withdrawn", "Withdrawn") })] })] })] }));
+    return (jsxRuntimeExports.jsxs(FiltersContainer, { children: [jsxRuntimeExports.jsxs(SearchField, { children: [jsxRuntimeExports.jsx(Label, { hidden: true, children: t("approval-requests.list.search-placeholder", "Search approval requests") }), jsxRuntimeExports.jsx(MediaInput, { start: jsxRuntimeExports.jsx(SvgSearchStroke, {}), placeholder: t("approval-requests.list.search-placeholder", "Search approval requests"), onChange: handleSearch })] }), jsxRuntimeExports.jsxs(DropdownFilterField, { children: [jsxRuntimeExports.jsx(Label, { children: t("approval-requests.list.status-dropdown.label", "Status") }), jsxRuntimeExports.jsxs(Combobox, { isEditable: false, onChange: handleChange, selectionValue: approvalRequestStatus, inputValue: ApprovalRequestStatusInputMap[approvalRequestStatus], children: [jsxRuntimeExports.jsx(Option, { value: "any", label: t("approval-requests.list.status-dropdown.any", "Any") }), jsxRuntimeExports.jsx(Option, { value: APPROVAL_REQUEST_STATES.ACTIVE, label: t("approval-requests.status.decision-pending", "Decision pending") }), jsxRuntimeExports.jsx(Option, { value: APPROVAL_REQUEST_STATES.APPROVED, label: t("approval-requests.status.approved", "Approved") }), jsxRuntimeExports.jsx(Option, { value: APPROVAL_REQUEST_STATES.REJECTED, label: t("approval-requests.status.denied", "Denied") }), jsxRuntimeExports.jsx(Option, { value: APPROVAL_REQUEST_STATES.WITHDRAWN, label: t("approval-requests.status.withdrawn", "Withdrawn") })] })] })] }));
 }
 var ApprovalRequestListFilters$1 = reactExports.memo(ApprovalRequestListFilters);
 
@@ -172,7 +172,7 @@ function ApprovalRequestListTable({ approvalRequests, helpCenterPath, baseLocale
 }
 var ApprovalRequestListTable$1 = reactExports.memo(ApprovalRequestListTable);
 
-const Container$2 = styled.div `
+const Container$3 = styled.div `
   display: flex;
   flex-direction: column;
   gap: ${(props) => props.theme.space.lg};
@@ -214,13 +214,43 @@ function ApprovalRequestListPage({ baseLocale, helpCenterPath, }) {
     if (isLoading) {
         return (jsxRuntimeExports.jsx(LoadingContainer$1, { children: jsxRuntimeExports.jsx(Spinner, { size: "64" }) }));
     }
-    return (jsxRuntimeExports.jsxs(Container$2, { children: [jsxRuntimeExports.jsx(XXL, { isBold: true, children: t("approval-requests.list.header", "Approval requests") }), jsxRuntimeExports.jsx(ApprovalRequestListFilters$1, { approvalRequestStatus: approvalRequestStatus, setApprovalRequestStatus: setApprovalRequestStatus, setSearchTerm: setSearchTerm }), approvalRequests.length === 0 ? (jsxRuntimeExports.jsx(NoApprovalRequestsText, { children: t("approval-requests.list.no-requests", "No approval requests found.") })) : (jsxRuntimeExports.jsx(ApprovalRequestListTable$1, { approvalRequests: sortedAndFilteredApprovalRequests, baseLocale: baseLocale, helpCenterPath: helpCenterPath, sortDirection: sortDirection, onSortChange: setSortDirection }))] }));
+    return (jsxRuntimeExports.jsxs(Container$3, { children: [jsxRuntimeExports.jsx(XXL, { isBold: true, children: t("approval-requests.list.header", "Approval requests") }), jsxRuntimeExports.jsx(ApprovalRequestListFilters$1, { approvalRequestStatus: approvalRequestStatus, setApprovalRequestStatus: setApprovalRequestStatus, setSearchTerm: setSearchTerm }), approvalRequests.length === 0 ? (jsxRuntimeExports.jsx(NoApprovalRequestsText, { children: t("approval-requests.list.no-requests", "No approval requests found.") })) : (jsxRuntimeExports.jsx(ApprovalRequestListTable$1, { approvalRequests: sortedAndFilteredApprovalRequests, baseLocale: baseLocale, helpCenterPath: helpCenterPath, sortDirection: sortDirection, onSortChange: setSortDirection }))] }));
 }
 var ApprovalRequestListPage$1 = reactExports.memo(ApprovalRequestListPage);
 
 async function renderApprovalRequestList(container, settings, props, helpCenterPath) {
     reactDomExports.render(jsxRuntimeExports.jsx(ThemeProviders, { theme: createTheme(settings), children: jsxRuntimeExports.jsx(ErrorBoundary, { helpCenterPath: helpCenterPath, children: jsxRuntimeExports.jsx(ApprovalRequestListPage$1, { ...props, helpCenterPath: helpCenterPath }) }) }), container);
 }
+
+const Container$2 = styled.div `
+  border-top: ${(props) => `1px solid ${getColorV8("grey", 300, props.theme)}`};
+  display: flex;
+  flex-direction: column;
+  padding-top: ${(props) => props.theme.space.base * 4}px; /* 16px */
+`;
+const PreviousDecisionTitle = styled(MD) `
+  margin-bottom: ${(props) => props.theme.space.xxs}; /* 4px */
+`;
+const FieldLabel$2 = styled(MD) `
+  color: ${(props) => getColorV8("grey", 600, props.theme)};
+`;
+function getPreviousDecisionFallbackLabel(status) {
+    switch (status) {
+        case APPROVAL_REQUEST_STATES.APPROVED:
+            return "Approved";
+        case APPROVAL_REQUEST_STATES.REJECTED:
+            return "Rejected";
+        default:
+            return status;
+    }
+}
+function ApprovalRequestPreviousDecision({ decision, baseLocale, }) {
+    const { t } = useTranslation();
+    return (jsxRuntimeExports.jsxs(Container$2, { children: [jsxRuntimeExports.jsx(PreviousDecisionTitle, { children: t("approval-requests.request.approval-request-details.previous-decision", "Previous decision") }), jsxRuntimeExports.jsxs(FieldLabel$2, { children: [t(`approval-requests.request.approval-request-details.${decision.status.toLowerCase()}`, getPreviousDecisionFallbackLabel(decision.status)), " ", formatApprovalRequestDate(decision.decided_at ?? "", baseLocale)] }), decision.decision_notes && (
+            // eslint-disable-next-line @shopify/jsx-no-hardcoded-content
+            jsxRuntimeExports.jsx(FieldLabel$2, { children: `"${decision.decision_notes}"` }))] }));
+}
+var ApprovalRequestPreviousDecision$1 = reactExports.memo(ApprovalRequestPreviousDecision);
 
 const Container$1 = styled(Grid) `
   padding: ${(props) => props.theme.space.base * 6}px; /* 24px */
@@ -234,7 +264,7 @@ const FieldLabel$1 = styled(MD) `
   color: ${(props) => getColorV8("grey", 600, props.theme)};
 `;
 const DetailRow = styled(Row$1) `
-  margin-bottom: ${(props) => props.theme.space.sm}; /* 8px */
+  margin-bottom: ${(props) => props.theme.space.sm}; /* 12px */
 
   &:last-child {
     margin-bottom: 0;
@@ -242,11 +272,18 @@ const DetailRow = styled(Row$1) `
 `;
 function ApprovalRequestDetails({ approvalRequest, baseLocale, }) {
     const { t } = useTranslation();
-    return (jsxRuntimeExports.jsxs(Container$1, { children: [jsxRuntimeExports.jsx(ApprovalRequestHeader, { isBold: true, children: t("approval-requests.request.approval-request-details.header", "Approval request details") }), jsxRuntimeExports.jsxs(DetailRow, { children: [jsxRuntimeExports.jsx(Col, { size: 4, children: jsxRuntimeExports.jsx(FieldLabel$1, { children: t("approval-requests.request.approval-request-details.sent-by", "Sent by") }) }), jsxRuntimeExports.jsx(Col, { size: 8, children: jsxRuntimeExports.jsx(MD, { children: approvalRequest.created_by_user.name }) })] }), jsxRuntimeExports.jsxs(DetailRow, { children: [jsxRuntimeExports.jsx(Col, { size: 4, children: jsxRuntimeExports.jsx(FieldLabel$1, { children: t("approval-requests.request.approval-request-details.sent-on", "Sent on") }) }), jsxRuntimeExports.jsx(Col, { size: 8, children: jsxRuntimeExports.jsx(MD, { children: formatApprovalRequestDate(approvalRequest.created_at, baseLocale) }) })] }), jsxRuntimeExports.jsxs(DetailRow, { children: [jsxRuntimeExports.jsx(Col, { size: 4, children: jsxRuntimeExports.jsx(FieldLabel$1, { children: t("approval-requests.request.approval-request-details.approver", "Approver") }) }), jsxRuntimeExports.jsx(Col, { size: 8, children: jsxRuntimeExports.jsx(MD, { children: approvalRequest.assignee_user.name }) })] }), jsxRuntimeExports.jsxs(DetailRow, { children: [jsxRuntimeExports.jsx(Col, { size: 4, children: jsxRuntimeExports.jsx(FieldLabel$1, { children: t("approval-requests.request.approval-request-details.status", "Status") }) }), jsxRuntimeExports.jsx(Col, { size: 8, children: jsxRuntimeExports.jsx(MD, { children: jsxRuntimeExports.jsx(ApprovalStatusTag$1, { status: approvalRequest.status }) }) })] }), approvalRequest.decision_notes.length > 0 && (jsxRuntimeExports.jsxs(DetailRow, { children: [jsxRuntimeExports.jsx(Col, { size: 4, children: jsxRuntimeExports.jsx(FieldLabel$1, { children: t("approval-requests.request.approval-request-details.comment", "Comment") }) }), jsxRuntimeExports.jsx(Col, { size: 8, children: jsxRuntimeExports.jsx(MD, { children: approvalRequest.decision_notes[0] }) })] })), approvalRequest.decided_at && (jsxRuntimeExports.jsxs(DetailRow, { children: [jsxRuntimeExports.jsx(Col, { size: 4, children: jsxRuntimeExports.jsx(FieldLabel$1, { children: t(approvalRequest.status === APPROVAL_REQUEST_STATES.WITHDRAWN
+    const shouldShowApprovalRequestComment = approvalRequest.status === APPROVAL_REQUEST_STATES.WITHDRAWN
+        ? Boolean(approvalRequest.withdrawn_reason)
+        : approvalRequest.decisions.length > 0;
+    const shouldShowPreviousDecision = approvalRequest.status === APPROVAL_REQUEST_STATES.WITHDRAWN &&
+        approvalRequest.decisions.length > 0;
+    return (jsxRuntimeExports.jsxs(Container$1, { children: [jsxRuntimeExports.jsx(ApprovalRequestHeader, { isBold: true, children: t("approval-requests.request.approval-request-details.header", "Approval request details") }), jsxRuntimeExports.jsxs(DetailRow, { children: [jsxRuntimeExports.jsx(Col, { size: 4, children: jsxRuntimeExports.jsx(FieldLabel$1, { children: t("approval-requests.request.approval-request-details.sent-by", "Sent by") }) }), jsxRuntimeExports.jsx(Col, { size: 8, children: jsxRuntimeExports.jsx(MD, { children: approvalRequest.created_by_user.name }) })] }), jsxRuntimeExports.jsxs(DetailRow, { children: [jsxRuntimeExports.jsx(Col, { size: 4, children: jsxRuntimeExports.jsx(FieldLabel$1, { children: t("approval-requests.request.approval-request-details.sent-on", "Sent on") }) }), jsxRuntimeExports.jsx(Col, { size: 8, children: jsxRuntimeExports.jsx(MD, { children: formatApprovalRequestDate(approvalRequest.created_at, baseLocale) }) })] }), jsxRuntimeExports.jsxs(DetailRow, { children: [jsxRuntimeExports.jsx(Col, { size: 4, children: jsxRuntimeExports.jsx(FieldLabel$1, { children: t("approval-requests.request.approval-request-details.approver", "Approver") }) }), jsxRuntimeExports.jsx(Col, { size: 8, children: jsxRuntimeExports.jsx(MD, { children: approvalRequest.assignee_user.name }) })] }), jsxRuntimeExports.jsxs(DetailRow, { children: [jsxRuntimeExports.jsx(Col, { size: 4, children: jsxRuntimeExports.jsx(FieldLabel$1, { children: t("approval-requests.request.approval-request-details.status", "Status") }) }), jsxRuntimeExports.jsx(Col, { size: 8, children: jsxRuntimeExports.jsx(MD, { children: jsxRuntimeExports.jsx(ApprovalStatusTag$1, { status: approvalRequest.status }) }) })] }), shouldShowApprovalRequestComment && (jsxRuntimeExports.jsxs(DetailRow, { children: [jsxRuntimeExports.jsx(Col, { size: 4, children: jsxRuntimeExports.jsx(FieldLabel$1, { children: t("approval-requests.request.approval-request-details.comment", "Comment") }) }), jsxRuntimeExports.jsx(Col, { size: 8, children: jsxRuntimeExports.jsx(MD, { children: approvalRequest.status === APPROVAL_REQUEST_STATES.WITHDRAWN
+                                ? approvalRequest.withdrawn_reason
+                                : approvalRequest.decisions[0]?.decision_notes }) })] })), approvalRequest.decided_at && (jsxRuntimeExports.jsxs(DetailRow, { children: [jsxRuntimeExports.jsx(Col, { size: 4, children: jsxRuntimeExports.jsx(FieldLabel$1, { children: t(approvalRequest.status === APPROVAL_REQUEST_STATES.WITHDRAWN
                                 ? "approval-requests.request.approval-request-details.withdrawn-on"
                                 : "approval-requests.request.approval-request-details.decided", approvalRequest.status === APPROVAL_REQUEST_STATES.WITHDRAWN
                                 ? "Withdrawn on"
-                                : "Decided") }) }), jsxRuntimeExports.jsx(Col, { size: 8, children: jsxRuntimeExports.jsx(MD, { children: formatApprovalRequestDate(approvalRequest.decided_at, baseLocale) }) })] }))] }));
+                                : "Decided") }) }), jsxRuntimeExports.jsx(Col, { size: 8, children: jsxRuntimeExports.jsx(MD, { children: formatApprovalRequestDate(approvalRequest.decided_at, baseLocale) }) })] })), shouldShowPreviousDecision && approvalRequest.decisions[0] && (jsxRuntimeExports.jsx(ApprovalRequestPreviousDecision$1, { decision: approvalRequest.decisions[0], baseLocale: baseLocale }))] }));
 }
 var ApprovalRequestDetails$1 = reactExports.memo(ApprovalRequestDetails);
 

--- a/src/modules/approval-requests/ApprovalRequestPage.test.tsx
+++ b/src/modules/approval-requests/ApprovalRequestPage.test.tsx
@@ -4,6 +4,7 @@ import { ThemeProvider } from "@zendeskgarden/react-theming";
 import ApprovalRequestPage from "./ApprovalRequestPage";
 import { useApprovalRequest } from "./hooks/useApprovalRequest";
 import { ToastProvider } from "@zendeskgarden/react-notifications";
+import type { ApprovalRequest } from "./types";
 
 jest.mock("./hooks/useApprovalRequest");
 const mockUseApprovalRequest = useApprovalRequest as jest.Mock;
@@ -16,7 +17,7 @@ const renderWithTheme = (ui: ReactElement) => {
   );
 };
 
-const mockApprovalRequest = {
+const mockApprovalRequest: ApprovalRequest = {
   id: "123",
   subject: "Test Request",
   message: "Please approve this request",
@@ -33,7 +34,8 @@ const mockApprovalRequest = {
     photo: { content_url: null },
   },
   decided_at: null,
-  decision_notes: [],
+  decisions: [],
+  withdrawn_reason: null,
   ticket_details: {
     id: "T123",
     priority: "normal",

--- a/src/modules/approval-requests/components/approval-request-list/ApprovalRequestListFilters.test.tsx
+++ b/src/modules/approval-requests/components/approval-request-list/ApprovalRequestListFilters.test.tsx
@@ -32,9 +32,9 @@ describe("ApprovalRequestListFilters", () => {
       />
     );
 
-    expect(screen.getByLabelText("Status:")).toBeInTheDocument();
+    expect(screen.getByLabelText("Status")).toBeInTheDocument();
     const combobox = screen.getByRole("combobox", {
-      name: /status:/i,
+      name: /status/i,
     });
 
     await user.click(combobox);
@@ -64,7 +64,7 @@ describe("ApprovalRequestListFilters", () => {
     );
 
     const combobox = screen.getByRole("combobox", {
-      name: /status:/i,
+      name: /status/i,
     });
 
     await user.click(combobox);

--- a/src/modules/approval-requests/components/approval-request-list/ApprovalRequestListFilters.tsx
+++ b/src/modules/approval-requests/components/approval-request-list/ApprovalRequestListFilters.tsx
@@ -109,7 +109,7 @@ function ApprovalRequestListFilters({
       </SearchField>
       <DropdownFilterField>
         <Label>
-          {t("approval-requests.list.status-dropdown.label", "Status:")}
+          {t("approval-requests.list.status-dropdown.label", "Status")}
         </Label>
         <Combobox
           isEditable={false}

--- a/src/modules/approval-requests/components/approval-request/ApprovalRequestDetails.test.tsx
+++ b/src/modules/approval-requests/components/approval-request/ApprovalRequestDetails.test.tsx
@@ -29,7 +29,17 @@ const mockApprovalRequest: ApprovalRequest = {
     },
   },
   decided_at: null,
-  decision_notes: [],
+  decisions: {
+    decided_at: null,
+    decided_by_user: {
+      id: 456,
+      name: "Jane Approver",
+      photo: {
+        content_url: null,
+      },
+    },
+    decision_notes: null,
+  },
   ticket_details: {
     id: "789",
     priority: "normal",
@@ -66,7 +76,17 @@ describe("ApprovalRequestDetails", () => {
       ...mockApprovalRequest,
       status: "approved",
       decided_at: "2024-02-21T15:45:00Z",
-      decision_notes: ["This looks good to me"],
+      decisions: {
+        decision_notes: "This looks good to me",
+        decided_at: "2024-02-21T15:45:00Z",
+        decided_by_user: {
+          id: 456,
+          name: "Jane Approver",
+          photo: {
+            content_url: null,
+          },
+        },
+      },
     };
 
     renderWithTheme(

--- a/src/modules/approval-requests/components/approval-request/ApprovalRequestDetails.test.tsx
+++ b/src/modules/approval-requests/components/approval-request/ApprovalRequestDetails.test.tsx
@@ -29,17 +29,8 @@ const mockApprovalRequest: ApprovalRequest = {
     },
   },
   decided_at: null,
-  decisions: {
-    decided_at: null,
-    decided_by_user: {
-      id: 456,
-      name: "Jane Approver",
-      photo: {
-        content_url: null,
-      },
-    },
-    decision_notes: null,
-  },
+  decisions: [],
+  withdrawn_reason: null,
   ticket_details: {
     id: "789",
     priority: "normal",
@@ -76,17 +67,20 @@ describe("ApprovalRequestDetails", () => {
       ...mockApprovalRequest,
       status: "approved",
       decided_at: "2024-02-21T15:45:00Z",
-      decisions: {
-        decision_notes: "This looks good to me",
-        decided_at: "2024-02-21T15:45:00Z",
-        decided_by_user: {
-          id: 456,
-          name: "Jane Approver",
-          photo: {
-            content_url: null,
+      decisions: [
+        {
+          decision_notes: "This looks good to me",
+          decided_at: "2024-02-21T15:45:00Z",
+          decided_by_user: {
+            id: 456,
+            name: "Jane Approver",
+            photo: {
+              content_url: null,
+            },
           },
+          status: "approved",
         },
-      },
+      ],
     };
 
     renderWithTheme(
@@ -100,5 +94,89 @@ describe("ApprovalRequestDetails", () => {
     expect(screen.getByText(/this looks good to me/i)).toBeInTheDocument();
     expect(screen.getByText("Decided")).toBeInTheDocument();
     expect(screen.getByText(/this looks good to me/i)).toBeInTheDocument();
+  });
+
+  it("renders a withdrawn approval request with the withdrawal reason", () => {
+    const withdrawnRequest: ApprovalRequest = {
+      ...mockApprovalRequest,
+      status: "withdrawn",
+      withdrawn_reason: "No longer needed",
+      decided_at: "2024-02-21T15:45:00Z",
+    };
+
+    renderWithTheme(
+      <ApprovalRequestDetails
+        approvalRequest={withdrawnRequest}
+        baseLocale="en-US"
+      />
+    );
+
+    expect(screen.getByText("Withdrawn on")).toBeInTheDocument();
+    expect(screen.getByText("No longer needed")).toBeInTheDocument();
+  });
+
+  it("shows the previous decision when an approval request is withdrawn with prior approval", () => {
+    const withdrawnWithPriorApproval: ApprovalRequest = {
+      ...mockApprovalRequest,
+      status: "withdrawn",
+      withdrawn_reason: "Changed my mind",
+      decided_at: "2024-02-21T15:45:00Z",
+      decisions: [
+        {
+          decision_notes: "Originally stamped",
+          decided_at: "2024-02-20T10:30:00Z",
+          decided_by_user: {
+            id: 456,
+            name: "Jane Approver",
+            photo: {
+              content_url: null,
+            },
+          },
+          status: "approved",
+        },
+      ],
+    };
+
+    renderWithTheme(
+      <ApprovalRequestDetails
+        approvalRequest={withdrawnWithPriorApproval}
+        baseLocale="en-US"
+      />
+    );
+
+    expect(screen.getByText("Previous decision")).toBeInTheDocument();
+    expect(screen.getByText(/approved/i)).toBeInTheDocument();
+    expect(screen.getByText(/"Originally stamped"/)).toBeInTheDocument();
+  });
+
+  it("does not show the previous decision for non-withdrawn requests", () => {
+    const approvedRequest: ApprovalRequest = {
+      ...mockApprovalRequest,
+      status: "approved",
+      decided_at: "2024-02-21T15:45:00Z",
+      decisions: [
+        {
+          decision_notes: "Looks good",
+          decided_at: "2024-02-21T15:45:00Z",
+          decided_by_user: {
+            id: 456,
+            name: "Jane Approver",
+            photo: {
+              content_url: null,
+            },
+          },
+          status: "approved",
+        },
+      ],
+    };
+
+    renderWithTheme(
+      <ApprovalRequestDetails
+        approvalRequest={approvedRequest}
+        baseLocale="en-US"
+      />
+    );
+
+    expect(screen.queryByText("Previous decision")).not.toBeInTheDocument();
   });
 });

--- a/src/modules/approval-requests/components/approval-request/ApprovalRequestDetails.tsx
+++ b/src/modules/approval-requests/components/approval-request/ApprovalRequestDetails.tsx
@@ -8,6 +8,7 @@ import type { ApprovalRequest } from "../../types";
 import ApprovalStatusTag from "./ApprovalStatusTag";
 import { formatApprovalRequestDate } from "../../utils";
 import { APPROVAL_REQUEST_STATES } from "../../constants";
+import ApprovalRequestPreviousDecision from "./ApprovalRequestPreviousDecision";
 
 const Container = styled(Grid)`
   padding: ${(props) => props.theme.space.base * 6}px; /* 24px */
@@ -24,7 +25,7 @@ const FieldLabel = styled(MD)`
 `;
 
 const DetailRow = styled(Row)`
-  margin-bottom: ${(props) => props.theme.space.sm}; /* 8px */
+  margin-bottom: ${(props) => props.theme.space.sm}; /* 12px */
 
   &:last-child {
     margin-bottom: 0;
@@ -42,6 +43,13 @@ function ApprovalRequestDetails({
 }: ApprovalRequestDetailsProps) {
   const { t } = useTranslation();
 
+  const shouldShowApprovalRequestComment =
+    approvalRequest.status === APPROVAL_REQUEST_STATES.WITHDRAWN
+      ? Boolean(approvalRequest.withdrawn_reason)
+      : approvalRequest.decisions.length > 0;
+  const shouldShowPreviousDecision =
+    approvalRequest.status === APPROVAL_REQUEST_STATES.WITHDRAWN &&
+    approvalRequest.decisions.length > 0;
   return (
     <Container>
       <ApprovalRequestHeader isBold>
@@ -106,24 +114,25 @@ function ApprovalRequestDetails({
           </MD>
         </Col>
       </DetailRow>
-      {approvalRequest.decisions &&
-        Array.isArray(approvalRequest.decisions) &&
-        approvalRequest.decisions.length > 0 && (
-          <DetailRow>
-            <Col size={4}>
-              <FieldLabel>
-                {t(
-                  "approval-requests.request.approval-request-details.comment",
-                  "Comment"
-                )}
-              </FieldLabel>
-            </Col>
-            <Col size={8}>
-              <MD>{approvalRequest.decisions[0].decision_notes}</MD>
-            </Col>
-          </DetailRow>
-        )}
-
+      {shouldShowApprovalRequestComment && (
+        <DetailRow>
+          <Col size={4}>
+            <FieldLabel>
+              {t(
+                "approval-requests.request.approval-request-details.comment",
+                "Comment"
+              )}
+            </FieldLabel>
+          </Col>
+          <Col size={8}>
+            <MD>
+              {approvalRequest.status === APPROVAL_REQUEST_STATES.WITHDRAWN
+                ? approvalRequest.withdrawn_reason
+                : approvalRequest.decisions[0]?.decision_notes}
+            </MD>
+          </Col>
+        </DetailRow>
+      )}
       {approvalRequest.decided_at && (
         <DetailRow>
           <Col size={4}>
@@ -147,6 +156,12 @@ function ApprovalRequestDetails({
             </MD>
           </Col>
         </DetailRow>
+      )}
+      {shouldShowPreviousDecision && approvalRequest.decisions[0] && (
+        <ApprovalRequestPreviousDecision
+          decision={approvalRequest.decisions[0]}
+          baseLocale={baseLocale}
+        />
       )}
     </Container>
   );

--- a/src/modules/approval-requests/components/approval-request/ApprovalRequestDetails.tsx
+++ b/src/modules/approval-requests/components/approval-request/ApprovalRequestDetails.tsx
@@ -106,21 +106,24 @@ function ApprovalRequestDetails({
           </MD>
         </Col>
       </DetailRow>
-      {approvalRequest.decision_notes.length > 0 && (
-        <DetailRow>
-          <Col size={4}>
-            <FieldLabel>
-              {t(
-                "approval-requests.request.approval-request-details.comment",
-                "Comment"
-              )}
-            </FieldLabel>
-          </Col>
-          <Col size={8}>
-            <MD>{approvalRequest.decision_notes[0]}</MD>
-          </Col>
-        </DetailRow>
-      )}
+      {approvalRequest.decisions &&
+        Array.isArray(approvalRequest.decisions) &&
+        approvalRequest.decisions.length > 0 && (
+          <DetailRow>
+            <Col size={4}>
+              <FieldLabel>
+                {t(
+                  "approval-requests.request.approval-request-details.comment",
+                  "Comment"
+                )}
+              </FieldLabel>
+            </Col>
+            <Col size={8}>
+              <MD>{approvalRequest.decisions[0].decision_notes}</MD>
+            </Col>
+          </DetailRow>
+        )}
+
       {approvalRequest.decided_at && (
         <DetailRow>
           <Col size={4}>

--- a/src/modules/approval-requests/components/approval-request/ApprovalRequestPreviousDecision.test.tsx
+++ b/src/modules/approval-requests/components/approval-request/ApprovalRequestPreviousDecision.test.tsx
@@ -1,0 +1,54 @@
+import { screen, render } from "@testing-library/react";
+import type { ReactElement } from "react";
+import { ThemeProvider } from "@zendeskgarden/react-theming";
+import ApprovalRequestPreviousDecision from "./ApprovalRequestPreviousDecision";
+import type { ApprovalDecision } from "../../types";
+
+const renderWithTheme = (ui: ReactElement) => {
+  return render(<ThemeProvider>{ui}</ThemeProvider>);
+};
+
+const mockDecision: ApprovalDecision = {
+  decision_notes: "Looks good to me",
+  decided_at: "2024-02-21T15:45:00Z",
+  decided_by_user: {
+    id: 456,
+    name: "Jane Approver",
+    photo: {
+      content_url: null,
+    },
+  },
+  status: "approved",
+};
+
+describe("ApprovalRequestPreviousDecision", () => {
+  it("renders the previous decision header, status, and notes", () => {
+    renderWithTheme(
+      <ApprovalRequestPreviousDecision
+        decision={mockDecision}
+        baseLocale="en-US"
+      />
+    );
+
+    expect(screen.getByText("Previous decision")).toBeInTheDocument();
+    expect(screen.getByText(/approved/i)).toBeInTheDocument();
+    expect(screen.getByText(/"Looks good to me"/)).toBeInTheDocument();
+  });
+
+  it("renders the decision without decision notes if they do not exist", () => {
+    const decisionWithoutNotes: ApprovalDecision = {
+      ...mockDecision,
+      decision_notes: null,
+    };
+
+    renderWithTheme(
+      <ApprovalRequestPreviousDecision
+        decision={decisionWithoutNotes}
+        baseLocale="en-US"
+      />
+    );
+
+    expect(screen.getByText(/approved/i)).toBeInTheDocument();
+    expect(screen.queryByText(/"/)).not.toBeInTheDocument();
+  });
+});

--- a/src/modules/approval-requests/components/approval-request/ApprovalRequestPreviousDecision.tsx
+++ b/src/modules/approval-requests/components/approval-request/ApprovalRequestPreviousDecision.tsx
@@ -1,0 +1,70 @@
+import { memo } from "react";
+import styled from "styled-components";
+import { useTranslation } from "react-i18next";
+import { MD } from "@zendeskgarden/react-typography";
+import { getColorV8 } from "@zendeskgarden/react-theming";
+import { APPROVAL_REQUEST_STATES } from "../../constants";
+import { formatApprovalRequestDate } from "../../utils";
+import type { ApprovalDecision } from "../../types";
+
+const Container = styled.div`
+  border-top: ${(props) => `1px solid ${getColorV8("grey", 300, props.theme)}`};
+  display: flex;
+  flex-direction: column;
+  padding-top: ${(props) => props.theme.space.base * 4}px; /* 16px */
+`;
+
+const PreviousDecisionTitle = styled(MD)`
+  margin-bottom: ${(props) => props.theme.space.xxs}; /* 4px */
+`;
+
+const FieldLabel = styled(MD)`
+  color: ${(props) => getColorV8("grey", 600, props.theme)};
+`;
+
+function getPreviousDecisionFallbackLabel(status: string) {
+  switch (status) {
+    case APPROVAL_REQUEST_STATES.APPROVED:
+      return "Approved";
+    case APPROVAL_REQUEST_STATES.REJECTED:
+      return "Rejected";
+    default:
+      return status;
+  }
+}
+
+interface ApprovalRequestPreviousDecisionProps {
+  decision: ApprovalDecision;
+  baseLocale: string;
+}
+
+function ApprovalRequestPreviousDecision({
+  decision,
+  baseLocale,
+}: ApprovalRequestPreviousDecisionProps) {
+  const { t } = useTranslation();
+
+  return (
+    <Container>
+      <PreviousDecisionTitle>
+        {t(
+          "approval-requests.request.approval-request-details.previous-decision",
+          "Previous decision"
+        )}
+      </PreviousDecisionTitle>
+      <FieldLabel>
+        {t(
+          `approval-requests.request.approval-request-details.${decision.status.toLowerCase()}`,
+          getPreviousDecisionFallbackLabel(decision.status)
+        )}{" "}
+        {formatApprovalRequestDate(decision.decided_at ?? "", baseLocale)}
+      </FieldLabel>
+      {decision.decision_notes && (
+        // eslint-disable-next-line @shopify/jsx-no-hardcoded-content
+        <FieldLabel>{`"${decision.decision_notes}"`}</FieldLabel>
+      )}
+    </Container>
+  );
+}
+
+export default memo(ApprovalRequestPreviousDecision);

--- a/src/modules/approval-requests/translations/en-us.yml
+++ b/src/modules/approval-requests/translations/en-us.yml
@@ -82,6 +82,11 @@ parts:
       screenshot: "https://drive.google.com/file/d/1hkgy-71WFkLQnZ0PmEHFaWhfnuguiUmv/view?usp=drive_link"
       value: "Withdrawn on"
   - translation:
+      key: "approval-requests.request.approval-request-details.previous-decision"
+      title: "The Previous Decision label on an approval request - Subject: 'approval request'"
+      screenshot: "https://drive.google.com/file/d/1R55CIlKhowOKZ9J22ChB81qiMz2NifYO/view?usp=drive_link"
+      value: "Previous decision"
+  - translation:
       key: "approval-requests.request.approver-actions.approve-request"
       title: "Label for the approve request button to begin approving an approval request"
       screenshot: "https://drive.google.com/file/d/1uWDMNa7cfF2EdD5HpDxcTVHTa6M07v81/view?usp=drive_link"
@@ -149,8 +154,8 @@ parts:
   - translation:
       key: "approval-requests.list.status-dropdown.label"
       title: "Label for the status dropdown on the approval requests list page"
-      screenshot: "https://drive.google.com/file/d/18_4fS0yROAMC1yVdDYLfYvjKWeUdWCDH/view?usp=drive_link"
-      value: "Status:"
+      screenshot: "https://drive.google.com/file/d/1T7BGzFgCWC74RIoUBBZ8tZzAvcksIw1r/view?usp=drive_link"
+      value: "Status"
   - translation:
       key: "approval-requests.list.status-dropdown.any"
       title: "Label for any dropdown option within the status dropdown on the approval requests list page - Subject: 'status'"

--- a/src/modules/approval-requests/types.ts
+++ b/src/modules/approval-requests/types.ts
@@ -6,6 +6,18 @@ interface ApprovalRequestUser {
   };
 }
 
+interface ApprovalDecisions {
+  decided_at: string | null;
+  decided_by_user: {
+    id: number;
+    name: string;
+    photo: {
+      content_url: string | null;
+    };
+  };
+  decision_notes: string | null;
+}
+
 export type ApprovalRequestStatus =
   | "active"
   | "approved"
@@ -23,7 +35,7 @@ export interface ApprovalRequest {
   created_at: string;
   created_by_user: ApprovalRequestUser;
   decided_at: string | null;
-  decision_notes: string[];
+  decisions: ApprovalDecisions;
   assignee_user: ApprovalRequestUser;
   ticket_details: ApprovalRequestTicket;
 }

--- a/src/modules/approval-requests/types.ts
+++ b/src/modules/approval-requests/types.ts
@@ -6,7 +6,7 @@ interface ApprovalRequestUser {
   };
 }
 
-interface ApprovalDecisions {
+export interface ApprovalDecision {
   decided_at: string | null;
   decided_by_user: {
     id: number;
@@ -16,6 +16,7 @@ interface ApprovalDecisions {
     };
   };
   decision_notes: string | null;
+  status: ApprovalRequestStatus;
 }
 
 export type ApprovalRequestStatus =
@@ -35,9 +36,10 @@ export interface ApprovalRequest {
   created_at: string;
   created_by_user: ApprovalRequestUser;
   decided_at: string | null;
-  decisions: ApprovalDecisions;
+  decisions: ApprovalDecision[];
   assignee_user: ApprovalRequestUser;
   ticket_details: ApprovalRequestTicket;
+  withdrawn_reason: string | null;
 }
 
 export interface ApprovalRequestTicket {


### PR DESCRIPTION
## Description
This PR adds the Previous Decision display on a withdrawn Approval Request. It also updates the types to accommodate for the API changes to surface the withdrawn_reason and the decisions.
<!-- a summary of the changes introduced by this PR and the motivation behind them -->

## Screenshots
<img width="1237" alt="Screenshot 2025-02-21 at 1 42 29 PM" src="https://github.com/user-attachments/assets/993fc07e-c66f-46df-bd3b-9438143f862f" />

<!-- (optional) when applicable, please include some screenshots or gifs that illustrate the changes -->

## Checklist

- [X] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [X] :arrow_left: changes are compatible with RTL direction
- [X] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [X] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [X] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->