### PR TITLE
chore: add 2 new translations for the approval-requests module

### DIFF
--- a/src/modules/approval-requests/translations/en-us.yml
+++ b/src/modules/approval-requests/translations/en-us.yml
@@ -82,6 +82,11 @@ parts:
       screenshot: "https://drive.google.com/file/d/1hkgy-71WFkLQnZ0PmEHFaWhfnuguiUmv/view?usp=drive_link"
       value: "Withdrawn on"
   - translation:
+      key: "approval-requests.request.approval-request-details.previous-decision"
+      title: "Label in approval request details component"
+      screenshot: "https://drive.google.com/file/d/1R55CIlKhowOKZ9J22ChB81qiMz2NifYO/view?usp=drive_link"
+      value: "Previous decision"
+  - translation:
       key: "approval-requests.request.approver-actions.approve-request"
       title: "Label for the approve request button to begin approving an approval request"
       screenshot: "https://drive.google.com/file/d/1uWDMNa7cfF2EdD5HpDxcTVHTa6M07v81/view?usp=drive_link"
@@ -151,6 +156,12 @@ parts:
       title: "Label for the status dropdown on the approval requests list page"
       screenshot: "https://drive.google.com/file/d/18_4fS0yROAMC1yVdDYLfYvjKWeUdWCDH/view?usp=drive_link"
       value: "Status:"
+      obsolete: "2025-05-24"
+  - translation:
+      key: "approval-requests.list.status-dropdown.label_v2"
+      title: "Label for the status dropdown on the approval requests list page"
+      screenshot: "https://drive.google.com/file/d/1T7BGzFgCWC74RIoUBBZ8tZzAvcksIw1r/view?usp=drive_link"
+      value: "Status"
   - translation:
       key: "approval-requests.list.status-dropdown.any"
       title: "Label for any dropdown option within the status dropdown on the approval requests list page - Subject: 'status'"


### PR DESCRIPTION
## Description
Updating the translation for `Status` to not include a colon and adding a translation for `Previous decision`
<!-- a summary of the changes introduced by this PR and the motivation behind them -->

## Screenshots
<img width="1213" alt="approval-requests request approval-request-details previous-decision" src="https://github.com/user-attachments/assets/74370e18-57d7-4a10-b3fa-cf1237692121" />
<img width="1226" alt="approval-requests list status-dropdown label_v2" src="https://github.com/user-attachments/assets/b20de6e7-ab2d-44ba-8bb5-85e8daca71d0" />

<!-- (optional) when applicable, please include some screenshots or gifs that illustrate the changes -->

## Checklist

- [X] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->