### PR TITLE
TAA-393: Updated to display hyphen incase of empty comment

### DIFF
--- a/src/modules/approval-requests/components/approval-request/ApprovalRequestDetails.tsx
+++ b/src/modules/approval-requests/components/approval-request/ApprovalRequestDetails.tsx
@@ -128,7 +128,7 @@ function ApprovalRequestDetails({
             <MD>
               {approvalRequest.status === APPROVAL_REQUEST_STATES.WITHDRAWN
                 ? approvalRequest.withdrawn_reason
-                : approvalRequest.decisions[0]?.decision_notes}
+                : approvalRequest.decisions[0]?.decision_notes ?? '-'}
             </MD>
           </Col>
         </DetailRow>

--- a/src/modules/approval-requests/components/approval-request/ApprovalRequestDetails.tsx
+++ b/src/modules/approval-requests/components/approval-request/ApprovalRequestDetails.tsx
@@ -128,7 +128,7 @@ function ApprovalRequestDetails({
             <MD>
               {approvalRequest.status === APPROVAL_REQUEST_STATES.WITHDRAWN
                 ? approvalRequest.withdrawn_reason
-                : approvalRequest.decisions[0]?.decision_notes ?? '-'}
+                : approvalRequest.decisions[0]?.decision_notes ?? "-"}
             </MD>
           </Col>
         </DetailRow>


### PR DESCRIPTION
## Description

<!-- a summary of the changes introduced by this PR and the motivation behind them -->
This PR fixes the issue where the comment field would display nothing if the comment was null or undefined. Now, it will display a hyphen (-) in such cases.
JIRA: [TAA-393](https://zendesk.atlassian.net/browse/TAA-393)

## Screenshots

<!-- (optional) when applicable, please include some screenshots or gifs that illustrate the changes -->

Before:
![Screenshot 2025-02-24 at 12 03 31 PM](https://github.com/user-attachments/assets/d2270138-7d08-4880-a00e-a0bb258e5088)

After:
<img width="1255" alt="Screenshot 2025-02-24 at 4 43 45 PM" src="https://github.com/user-attachments/assets/3c009cce-d9dc-4fe2-86f9-5ebdf1f0ee68" />


## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->

[TAA-393]: https://zendesk.atlassian.net/browse/TAA-393?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ