### PR TITLE
chore(TAA-407): adjust RTL styles

### DIFF
--- a/assets/approval-requests-bundle.js
+++ b/assets/approval-requests-bundle.js
@@ -76,15 +76,22 @@ const SearchField = styled(Field) `
 const DropdownFilterField = styled(Field) `
   flex: 1;
 `;
-const ApprovalRequestStatusInputMap = {
-    any: "Any",
-    active: "Decision pending",
-    approved: "Approved",
-    rejected: "Denied",
-    withdrawn: "Withdrawn",
-};
 function ApprovalRequestListFilters({ approvalRequestStatus, setApprovalRequestStatus, setSearchTerm, }) {
     const { t } = useTranslation();
+    const getStatusLabel = reactExports.useCallback((status) => {
+        switch (status) {
+            case "any":
+                return t("approval-requests.list.status-dropdown.any", "Any");
+            case "active":
+                return t("approval-requests.status.decision-pending", "Decision pending");
+            case "approved":
+                return t("approval-requests.status.approved", "Approved");
+            case "rejected":
+                return t("approval-requests.status.denied", "Denied");
+            case "withdrawn":
+                return t("approval-requests.status.withdrawn", "Withdrawn");
+        }
+    }, [t]);
     const handleChange = reactExports.useCallback((changes) => {
         if (!changes.selectionValue) {
             return;
@@ -96,7 +103,7 @@ function ApprovalRequestListFilters({ approvalRequestStatus, setApprovalRequestS
     const handleSearch = reactExports.useCallback((event) => {
         debouncedSetSearchTerm(event.target.value);
     }, [debouncedSetSearchTerm]);
-    return (jsxRuntimeExports.jsxs(FiltersContainer, { children: [jsxRuntimeExports.jsxs(SearchField, { children: [jsxRuntimeExports.jsx(Label, { hidden: true, children: t("approval-requests.list.search-placeholder", "Search approval requests") }), jsxRuntimeExports.jsx(MediaInput, { start: jsxRuntimeExports.jsx(SvgSearchStroke, {}), placeholder: t("approval-requests.list.search-placeholder", "Search approval requests"), onChange: handleSearch })] }), jsxRuntimeExports.jsxs(DropdownFilterField, { children: [jsxRuntimeExports.jsx(Label, { children: t("approval-requests.list.status-dropdown.label_v2", "Status") }), jsxRuntimeExports.jsxs(Combobox, { isEditable: false, onChange: handleChange, selectionValue: approvalRequestStatus, inputValue: ApprovalRequestStatusInputMap[approvalRequestStatus], children: [jsxRuntimeExports.jsx(Option, { value: "any", label: t("approval-requests.list.status-dropdown.any", "Any") }), jsxRuntimeExports.jsx(Option, { value: APPROVAL_REQUEST_STATES.ACTIVE, label: t("approval-requests.status.decision-pending", "Decision pending") }), jsxRuntimeExports.jsx(Option, { value: APPROVAL_REQUEST_STATES.APPROVED, label: t("approval-requests.status.approved", "Approved") }), jsxRuntimeExports.jsx(Option, { value: APPROVAL_REQUEST_STATES.REJECTED, label: t("approval-requests.status.denied", "Denied") }), jsxRuntimeExports.jsx(Option, { value: APPROVAL_REQUEST_STATES.WITHDRAWN, label: t("approval-requests.status.withdrawn", "Withdrawn") })] })] })] }));
+    return (jsxRuntimeExports.jsxs(FiltersContainer, { children: [jsxRuntimeExports.jsxs(SearchField, { children: [jsxRuntimeExports.jsx(Label, { hidden: true, children: t("approval-requests.list.search-placeholder", "Search approval requests") }), jsxRuntimeExports.jsx(MediaInput, { start: jsxRuntimeExports.jsx(SvgSearchStroke, {}), placeholder: t("approval-requests.list.search-placeholder", "Search approval requests"), onChange: handleSearch })] }), jsxRuntimeExports.jsxs(DropdownFilterField, { children: [jsxRuntimeExports.jsx(Label, { children: t("approval-requests.list.status-dropdown.label_v2", "Status") }), jsxRuntimeExports.jsxs(Combobox, { isEditable: false, onChange: handleChange, selectionValue: approvalRequestStatus, inputValue: getStatusLabel(approvalRequestStatus), children: [jsxRuntimeExports.jsx(Option, { value: "any", label: t("approval-requests.list.status-dropdown.any", "Any") }), jsxRuntimeExports.jsx(Option, { value: APPROVAL_REQUEST_STATES.ACTIVE, label: t("approval-requests.status.decision-pending", "Decision pending") }), jsxRuntimeExports.jsx(Option, { value: APPROVAL_REQUEST_STATES.APPROVED, label: t("approval-requests.status.approved", "Approved") }), jsxRuntimeExports.jsx(Option, { value: APPROVAL_REQUEST_STATES.REJECTED, label: t("approval-requests.status.denied", "Denied") }), jsxRuntimeExports.jsx(Option, { value: APPROVAL_REQUEST_STATES.WITHDRAWN, label: t("approval-requests.status.withdrawn", "Withdrawn") })] })] })] }));
 }
 var ApprovalRequestListFilters$1 = reactExports.memo(ApprovalRequestListFilters);
 
@@ -407,7 +414,7 @@ const FieldLabel = styled(MD) `
   color: ${(props) => getColorV8("grey", 600, props.theme)};
 `;
 const MultiselectTag = styled(Tag) `
-  margin-right: ${(props) => props.theme.space.xxs}; /* 4px */
+  margin-inline-end: ${(props) => props.theme.space.xxs}; /* 4px */
 `;
 const CustomFieldsGrid = styled.div `
   display: grid;
@@ -475,7 +482,7 @@ const ButtonContainer = styled.div `
   display: flex;
   flex-direction: row;
   gap: ${(props) => props.theme.space.md}; /* 20px */
-  margin-left: ${(props) => props.hasAvatar ? "55px" : "0"}; // avatar width + margin + border
+  margin-inline-start: ${(props) => props.hasAvatar ? "55px" : "0"}; // avatar width + margin + border
 
   @media (max-width: ${(props) => props.theme.breakpoints.md}) {
     flex-direction: ${(props) => props.isSubmitButton ? "row-reverse" : "column"};
@@ -667,16 +674,16 @@ const LeftColumn = styled.div `
 
   @media (max-width: ${(props) => props.theme.breakpoints.md}) {
     flex: 1;
-    margin-right: 0;
+    margin-inline-end: 0;
     margin-bottom: ${(props) => props.theme.space.lg};
   }
 `;
 const RightColumn = styled.div `
   flex: 1;
-  margin-left: ${(props) => props.theme.space.base * 6}px; /* 24px */
+  margin-inline-start: ${(props) => props.theme.space.base * 6}px; /* 24px */
 
   @media (max-width: ${(props) => props.theme.breakpoints.md}) {
-    margin-left: 0;
+    margin-inline-start: 0;
   }
 `;
 function ApprovalRequestPage({ approvalWorkflowInstanceId, approvalRequestId, baseLocale, helpCenterPath, organizations, userId, }) {

--- a/src/modules/approval-requests/ApprovalRequestPage.tsx
+++ b/src/modules/approval-requests/ApprovalRequestPage.tsx
@@ -44,17 +44,17 @@ const LeftColumn = styled.div`
 
   @media (max-width: ${(props) => props.theme.breakpoints.md}) {
     flex: 1;
-    margin-right: 0;
+    margin-inline-end: 0;
     margin-bottom: ${(props) => props.theme.space.lg};
   }
 `;
 
 const RightColumn = styled.div`
   flex: 1;
-  margin-left: ${(props) => props.theme.space.base * 6}px; /* 24px */
+  margin-inline-start: ${(props) => props.theme.space.base * 6}px; /* 24px */
 
   @media (max-width: ${(props) => props.theme.breakpoints.md}) {
-    margin-left: 0;
+    margin-inline-start: 0;
   }
 `;
 

--- a/src/modules/approval-requests/components/approval-request-list/ApprovalRequestListFilters.tsx
+++ b/src/modules/approval-requests/components/approval-request-list/ApprovalRequestListFilters.tsx
@@ -40,14 +40,6 @@ const DropdownFilterField = styled(Field)`
   flex: 1;
 `;
 
-const ApprovalRequestStatusInputMap = {
-  any: "Any",
-  active: "Decision pending",
-  approved: "Approved",
-  rejected: "Denied",
-  withdrawn: "Withdrawn",
-};
-
 interface ApprovalRequestListFiltersProps {
   approvalRequestStatus: ApprovalRequestDropdownStatus;
   setApprovalRequestStatus: Dispatch<
@@ -62,6 +54,27 @@ function ApprovalRequestListFilters({
   setSearchTerm,
 }: ApprovalRequestListFiltersProps) {
   const { t } = useTranslation();
+
+  const getStatusLabel = useCallback(
+    (status: ApprovalRequestDropdownStatus) => {
+      switch (status) {
+        case "any":
+          return t("approval-requests.list.status-dropdown.any", "Any");
+        case "active":
+          return t(
+            "approval-requests.status.decision-pending",
+            "Decision pending"
+          );
+        case "approved":
+          return t("approval-requests.status.approved", "Approved");
+        case "rejected":
+          return t("approval-requests.status.denied", "Denied");
+        case "withdrawn":
+          return t("approval-requests.status.withdrawn", "Withdrawn");
+      }
+    },
+    [t]
+  );
 
   const handleChange = useCallback<NonNullable<IComboboxProps["onChange"]>>(
     (changes) => {
@@ -115,7 +128,7 @@ function ApprovalRequestListFilters({
           isEditable={false}
           onChange={handleChange}
           selectionValue={approvalRequestStatus}
-          inputValue={ApprovalRequestStatusInputMap[approvalRequestStatus]}
+          inputValue={getStatusLabel(approvalRequestStatus)}
         >
           <Option
             value="any"

--- a/src/modules/approval-requests/components/approval-request/ApprovalTicketDetails.tsx
+++ b/src/modules/approval-requests/components/approval-request/ApprovalTicketDetails.tsx
@@ -23,7 +23,7 @@ const FieldLabel = styled(MD)`
 `;
 
 const MultiselectTag = styled(Tag)`
-  margin-right: ${(props) => props.theme.space.xxs}; /* 4px */
+  margin-inline-end: ${(props) => props.theme.space.xxs}; /* 4px */
 `;
 
 const CustomFieldsGrid = styled.div`

--- a/src/modules/approval-requests/components/approval-request/ApproverActions.tsx
+++ b/src/modules/approval-requests/components/approval-request/ApproverActions.tsx
@@ -22,7 +22,7 @@ const ButtonContainer = styled.div<{
   display: flex;
   flex-direction: row;
   gap: ${(props) => props.theme.space.md}; /* 20px */
-  margin-left: ${(props) =>
+  margin-inline-start: ${(props) =>
     props.hasAvatar ? "55px" : "0"}; // avatar width + margin + border
 
   @media (max-width: ${(props) => props.theme.breakpoints.md}) {


### PR DESCRIPTION
## Description
These changes should have been included in https://github.com/zendesk/copenhagen_theme/pull/592 but were mistakenly not committed.
<!-- a summary of the changes introduced by this PR and the motivation behind them -->
This updates the styles and the label for the filters dropdown so that it shows the translated text.

## Screenshots
Before:
<img width="1226" alt="Screenshot 2025-03-03 at 10 52 20 AM" src="https://github.com/user-attachments/assets/462b387d-f9f8-41da-af77-c626a3c03d98" />

After:
<img width="1168" alt="Screenshot 2025-03-03 at 10 58 32 AM" src="https://github.com/user-attachments/assets/d5b44410-a90a-4821-9a81-0ba856eb92a1" />

<img width="1219" alt="Screenshot 2025-03-03 at 10 50 42 AM" src="https://github.com/user-attachments/assets/1708ec20-1590-476d-9507-20287aeed472" />

<!-- (optional) when applicable, please include some screenshots or gifs that illustrate the changes -->

## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [X] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->