### PR TITLE
fix: update organizationField equality check so that it is consistent with master branch

### DIFF
--- a/src/modules/ticket-fields/TicketField.tsx
+++ b/src/modules/ticket-fields/TicketField.tsx
@@ -129,7 +129,7 @@ export const TicketField = ({
           field={field}
           userId={userId}
           organizationId={
-            organizationField !== undefined
+            organizationField !== null
               ? (organizationField?.value as string)
               : defaultOrganizationId
           }


### PR DESCRIPTION
…onsistent with master branch

## Description
JIRA: https://zendesk.atlassian.net/browse/CD-3071

This was an issue noticed by Ashwin, our product manager, but only on the beta theme. Lookup fields were not working on the `beta` branch of `copenhagen_theme` but were fine on the `master` branch.

The issue was that the equality check changed from this line in the `master` branch: https://github.com/zendesk/copenhagen_theme/blob/c9a30bd6bc4ae5ea4d1023b1d9ba2c88c12d62a1/src/modules/new-request-form/NewRequestForm.tsx#L326

The update was checking if organizationField was !== to undefined, evaluating to true since it was actually `null` and thus `organizationField?.value` was `undefined` leading to a `400 Bad Request` from the `/autocomplete` endpoint.
<!-- a summary of the changes introduced by this PR and the motivation behind them -->

## Screenshots
Before:
![before](https://github.com/user-attachments/assets/6e0ba679-b07c-4544-b141-d0798fe07f61)

After:
![after](https://github.com/user-attachments/assets/e5b590d3-5d75-48cc-b63c-16666309951d)

<!-- (optional) when applicable, please include some screenshots or gifs that illustrate the changes -->

## Checklist

- [X] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [X] :arrow_left: changes are compatible with RTL direction
- [X] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [X] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [X] :iphone: changes are responsive and tested in mobile
- [X] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->