### PR TITLE
chore: added new translation string for the scoped search setting

### DIFF
--- a/translations.yml
+++ b/translations.yml
@@ -192,6 +192,12 @@ parts:
       title: "Label for the scoped knowledge base search setting"
       screenshot: "https://drive.google.com/open?id=1uZaNe12E-A_snTd_7AjcqirB4ROLF4bB"
       value: "Scoped search in Knowledge Base"
+      obsolete: "2025-06-12"
+  - translation:
+      key: "txt.help_center_copenhagen_theme.scoped_knowledge_base_search_label_v2"
+      title: "Label for the scoped knowledge base search setting"
+      screenshot: "https://drive.google.com/file/d/13n_GJuyQJJ7uHAmLD8fobxnmfs3Y9G04/view?usp=drive_link"
+      value: "Scoped search in help center"
   - translation:
       key: "txt.help_center_copenhagen_theme.scoped_knowledge_base_search_description"
       title: "Description for the scoped knowledge base search search setting"


### PR DESCRIPTION
## Description

This PR adds a new string to rename the "scoped search" setting from "Scoped search in Knowledge Base" to ""Scoped search in Help Center"

## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->