### PR TITLE
fix: fixed upload of some type of attachments

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "eslint-plugin-check-file": "^2.6.2",
     "i18next": "^23.10.1",
     "lodash.debounce": "^4.0.8",
-    "mime": "^4.0.4",
     "node-fetch": "2.6.9",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/src/modules/new-request-form/fields/attachments/Attachments.tsx
+++ b/src/modules/new-request-form/fields/attachments/Attachments.tsx
@@ -19,7 +19,6 @@ import type { AttachmentField } from "../../data-types";
 import { FileListItem } from "./FileListItem";
 import type { AttachedFile } from "./useAttachedFiles";
 import { useAttachedFiles } from "./useAttachedFiles";
-import mime from "mime";
 
 interface AttachmentProps {
   field: AttachmentField;
@@ -100,17 +99,12 @@ export function Attachments({ field }: AttachmentProps): JSX.Element {
         xhr.open("POST", url);
 
         // If the browser returns a type for the file, use it as the Content-Type header,
-        // otherwise try to determine the mime type from the file extension using the mime
-        // library. If we can't determine the mime type, we'll fall back to a generic
-        // application/octet-stream.
+        // otherwise we fall back to application/octet-stream and let the backend
+        // determine the file type.
         if (file.type) {
           xhr.setRequestHeader("Content-Type", file.type);
         } else {
-          const mimeType = mime.getType(file.name);
-          xhr.setRequestHeader(
-            "Content-Type",
-            mimeType || "application/octet-stream"
-          );
+          xhr.setRequestHeader("Content-Type", "application/octet-stream");
         }
         xhr.setRequestHeader("X-CSRF-Token", csrfToken);
         xhr.responseType = "json";

--- a/yarn.lock
+++ b/yarn.lock
@@ -9891,11 +9891,6 @@ mime@^3.0.0:
   resolved "https://registry.yarnpkg.com/mime/-/mime-3.0.0.tgz#b374550dca3a0c18443b0c950a6a58f1931cf7a7"
   integrity sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==
 
-mime@^4.0.4:
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/mime/-/mime-4.0.4.tgz#9f851b0fc3c289d063b20a7a8055b3014b25664b"
-  integrity sha512-v8yqInVjhXyqP6+Kw4fV3ZzeMRqEW6FotRsKXjRS5VMTNIuXsdRoAvklpoRgSqXm6o9VNH4/C0mgedko9DdLsQ==
-
 mimic-fn@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"


### PR DESCRIPTION
## Description

We were determining the mime type for attachments in the theme using the `mime` library, and passing this info to the Upload Attachments API in the `Content-Type` header.

This was implemented in #520 to support some specific files, as suggested by the team that owns the endpoint, but it still causes some issues with some files (namely `.log` files not encoded as UTF-8).

The team advises passing `application/octet-stream` as type if the browser doesn't detect the type automatically. This solves the upload issue for all the problematic files we know so far, and we can stop bundling a library just to determine the mime type of the uploaded files.

## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->