### PR TITLE
fix: updated scoped search in help center setting label

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -271,7 +271,7 @@
           "identifier": "scoped_kb_search",
           "type": "checkbox",
           "description": "scoped_knowledge_base_search_description",
-          "label": "scoped_knowledge_base_search_label",
+          "label": "scoped_knowledge_base_search_label_v2",
           "value": true
         },
         {

--- a/translations/ar.json
+++ b/translations/ar.json
@@ -62,6 +62,7 @@
   "scoped_community_search_label": "البحث في إطار مجال في المجتمع",
   "scoped_knowledge_base_search_description": "تقتصر نتائج البحث على الفئة الحالية للمستخدم",
   "scoped_knowledge_base_search_label": "البحث في إطار مجال في قاعدة المعرفة",
+  "scoped_knowledge_base_search_label_v2": "بحث محدد النطاق في مركز المساعدة",
   "search_group_label": "إعدادات البحث",
   "section_page_group_label": "عناصر صفحة الجزء",
   "show_brand_name_description": "عرض اسم مركز المساعدة إلى جانب الشعار",

--- a/translations/bg.json
+++ b/translations/bg.json
@@ -62,6 +62,7 @@
   "scoped_community_search_label": "Филтрирано търсене в общността",
   "scoped_knowledge_base_search_description": "Резултатите от търсенето са ограничени до категорията, в която е потребителят",
   "scoped_knowledge_base_search_label": "Филтрирано търсене в базата знания",
+  "scoped_knowledge_base_search_label_v2": "Търсен обхват в помощния център",
   "search_group_label": "Настройки за търсене",
   "section_page_group_label": "Елементи на страницата на раздел",
   "show_brand_name_description": "Показване на името на помощния център до логото",

--- a/translations/cs.json
+++ b/translations/cs.json
@@ -62,6 +62,7 @@
   "scoped_community_search_label": "Cílené hledání v komunitě",
   "scoped_knowledge_base_search_description": "Omezí výsledky hledání na kategorii, ve které uživatel právě je.",
   "scoped_knowledge_base_search_label": "Cílené hledání ve znalostní bázi",
+  "scoped_knowledge_base_search_label_v2": "Cílené vyhledávání v centru nápovědy",
   "search_group_label": "Nastavení hledání",
   "section_page_group_label": "Elementy stránky oddílu",
   "show_brand_name_description": "Zobrazí název Centra nápovědy vedle loga.",

--- a/translations/da.json
+++ b/translations/da.json
@@ -62,6 +62,7 @@
   "scoped_community_search_label": "Filtreret søgning i community",
   "scoped_knowledge_base_search_description": "Søgeresultater er begrænset til den kategori, som brugeren befinder sig i",
   "scoped_knowledge_base_search_label": "Filtreret søgning i vidensbase",
+  "scoped_knowledge_base_search_label_v2": "Filtreret søgning i hjælpecenter",
   "search_group_label": "Søgeindstillinger",
   "section_page_group_label": "Sektionssideelementer",
   "show_brand_name_description": "Vis navnet på hjælpecenteret ved siden af logoet",

--- a/translations/de.json
+++ b/translations/de.json
@@ -62,6 +62,7 @@
   "scoped_community_search_label": "Begrenzte Suche in Community",
   "scoped_knowledge_base_search_description": "Suchergebnisse sind auf die jeweilige Kategorie begrenzt",
   "scoped_knowledge_base_search_label": "Begrenzte Suche in Wissensdatenbank",
+  "scoped_knowledge_base_search_label_v2": "Begrenzte Suche im Help Center",
   "search_group_label": "Sucheinstellungen",
   "section_page_group_label": "Elemente auf Abschnittsseiten",
   "show_brand_name_description": "Namen des Help Centers neben dem Logo anzeigen",

--- a/translations/el.json
+++ b/translations/el.json
@@ -62,6 +62,7 @@
   "scoped_community_search_label": "Εστιασμένη αναζήτηση στην Κοινότητα",
   "scoped_knowledge_base_search_description": "Τα αποτελέσματα αναζήτησης περιορίζονται στην κατηγορία στην οποία βρίσκεται ο χρήστης",
   "scoped_knowledge_base_search_label": "Εστιασμένη αναζήτηση στη Γνωσιακή βάση",
+  "scoped_knowledge_base_search_label_v2": "Εστιασμένη αναζήτηση στο κέντρο βοήθειας",
   "search_group_label": "Ρυθμίσεις αναζήτησης",
   "section_page_group_label": "Στοιχεία σελίδας ενοτήτων",
   "show_brand_name_description": "Εμφάνιση του ονόματος κέντρου βοήθειας δίπλα στο λογότυπο",

--- a/translations/en-ca.json
+++ b/translations/en-ca.json
@@ -62,6 +62,7 @@
   "scoped_community_search_label": "Scoped search in Community",
   "scoped_knowledge_base_search_description": "Search results are confined to the category the user is in",
   "scoped_knowledge_base_search_label": "Scoped search in Knowledge Base",
+  "scoped_knowledge_base_search_label_v2": "Scoped search in help centre",
   "search_group_label": "Search settings",
   "section_page_group_label": "Section page elements",
   "show_brand_name_description": "Display the Help Centre name next to the logo",

--- a/translations/en-gb.json
+++ b/translations/en-gb.json
@@ -62,6 +62,7 @@
   "scoped_community_search_label": "Scoped search in Community",
   "scoped_knowledge_base_search_description": "Search results are confined to the category the user is in",
   "scoped_knowledge_base_search_label": "Scoped search in Knowledge Base",
+  "scoped_knowledge_base_search_label_v2": "Scoped search in help centre",
   "search_group_label": "Search settings",
   "section_page_group_label": "Section page elements",
   "show_brand_name_description": "Display the Help Centre name next to the logo",

--- a/translations/en-us.json
+++ b/translations/en-us.json
@@ -62,6 +62,7 @@
   "scoped_community_search_label": "Scoped search in Community",
   "scoped_knowledge_base_search_description": "Search results are confined to the category the user is in",
   "scoped_knowledge_base_search_label": "Scoped search in Knowledge Base",
+  "scoped_knowledge_base_search_label_v2": "Scoped search in help center",
   "search_group_label": "Search settings",
   "section_page_group_label": "Section page elements",
   "show_brand_name_description": "Display the Help Center name next to the logo",

--- a/translations/es-419.json
+++ b/translations/es-419.json
@@ -62,6 +62,7 @@
   "scoped_community_search_label": "Búsqueda filtrada en la comunidad",
   "scoped_knowledge_base_search_description": "Los resultados de la búsqueda se limitan a la categoría en la que se encuentra el usuario",
   "scoped_knowledge_base_search_label": "Búsqueda filtrada en la base de conocimientos",
+  "scoped_knowledge_base_search_label_v2": "Búsqueda limitada en el centro de ayuda",
   "search_group_label": "Configuración de la búsqueda",
   "section_page_group_label": "Elementos de página de la sección",
   "show_brand_name_description": "Muestre el nombre del Centro de ayuda junto al logotipo",

--- a/translations/es-es.json
+++ b/translations/es-es.json
@@ -62,6 +62,7 @@
   "scoped_community_search_label": "Búsqueda filtrada en la comunidad",
   "scoped_knowledge_base_search_description": "Los resultados de la búsqueda se limitan a la categoría en la que se encuentra el usuario",
   "scoped_knowledge_base_search_label": "Búsqueda filtrada en la base de conocimientos",
+  "scoped_knowledge_base_search_label_v2": "Búsqueda limitada en el centro de ayuda",
   "search_group_label": "Configuración de la búsqueda",
   "section_page_group_label": "Elementos de página de la sección",
   "show_brand_name_description": "Muestre el nombre del Centro de ayuda junto al logotipo",

--- a/translations/es.json
+++ b/translations/es.json
@@ -62,6 +62,7 @@
   "scoped_community_search_label": "Búsqueda filtrada en la comunidad",
   "scoped_knowledge_base_search_description": "Los resultados de la búsqueda se limitan a la categoría en la que se encuentra el usuario",
   "scoped_knowledge_base_search_label": "Búsqueda filtrada en la base de conocimientos",
+  "scoped_knowledge_base_search_label_v2": "Búsqueda limitada en el centro de ayuda",
   "search_group_label": "Configuración de la búsqueda",
   "section_page_group_label": "Elementos de página de la sección",
   "show_brand_name_description": "Muestre el nombre del Centro de ayuda junto al logotipo",

--- a/translations/fi.json
+++ b/translations/fi.json
@@ -62,6 +62,7 @@
   "scoped_community_search_label": "Suodatettu haku yhteisössä",
   "scoped_knowledge_base_search_description": "Hakutulokset rajoitetaan kategoriaan, jossa käyttäjä on",
   "scoped_knowledge_base_search_label": "Suodatettu haku ratkaisutietokannasta",
+  "scoped_knowledge_base_search_label_v2": "Suodatettu haku tukiportaalissa",
   "search_group_label": "Hakutulokset",
   "section_page_group_label": "Osio-sivun elementit",
   "show_brand_name_description": "Näytä Tukiportaalin nimi logon vieressä",

--- a/translations/fr-ca.json
+++ b/translations/fr-ca.json
@@ -62,6 +62,7 @@
   "scoped_community_search_label": "Recherche limitée dans la communauté",
   "scoped_knowledge_base_search_description": "Les résultats de la recherche sont limités à la catégorie dans laquelle se trouve l’utilisateur",
   "scoped_knowledge_base_search_label": "Recherche limitée dans la base de connaissances",
+  "scoped_knowledge_base_search_label_v2": "Recherche ciblée dans le centre d’aide",
   "search_group_label": "Paramètres de recherche",
   "section_page_group_label": "Éléments de la page de section",
   "show_brand_name_description": "Affichez le nom du Centre d’aide en regard du logo",

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -62,6 +62,7 @@
   "scoped_community_search_label": "Recherche limitée dans la communauté",
   "scoped_knowledge_base_search_description": "Les résultats de la recherche sont limités à la catégorie dans laquelle se trouve l’utilisateur",
   "scoped_knowledge_base_search_label": "Recherche limitée dans la base de connaissances",
+  "scoped_knowledge_base_search_label_v2": "Recherche ciblée dans le centre d’aide",
   "search_group_label": "Paramètres de recherche",
   "section_page_group_label": "Éléments de la page de section",
   "show_brand_name_description": "Affichez le nom du Centre d’aide en regard du logo",

--- a/translations/he.json
+++ b/translations/he.json
@@ -62,6 +62,7 @@
   "scoped_community_search_label": "חיפוש מתוחם בקהילה",
   "scoped_knowledge_base_search_description": "תוצאות החיפוש מוגבלות לקטגוריה שהמשתמש נמצא בה",
   "scoped_knowledge_base_search_label": "חיפוש מתוחם במאגר הידע",
+  "scoped_knowledge_base_search_label_v2": "חיפוש מתוחם במרכז התמיכה",
   "search_group_label": "הגדרות חיפוש",
   "section_page_group_label": "רכיבי דף קטגוריית משנה",
   "show_brand_name_description": "הצג את שם מרכז התמיכה ליד הלוגו",

--- a/translations/hi.json
+++ b/translations/hi.json
@@ -62,6 +62,7 @@
   "scoped_community_search_label": "समुदाय में सीमित खोज",
   "scoped_knowledge_base_search_description": "खोज परिणाम उस श्रेणी तक ही सीमित हैं, जिसमें उपयोगकर्ता है",
   "scoped_knowledge_base_search_label": "जानकारी के आधार में सीमित खोज",
+  "scoped_knowledge_base_search_label_v2": "सहायता केंद्र में सीमित खोज",
   "search_group_label": "खोज सेटिंग",
   "section_page_group_label": "अनुभाग पृष्ठ तत्व",
   "show_brand_name_description": "लोगो के आगे सहायता केंद्र का नाम दिखाएं",

--- a/translations/hu.json
+++ b/translations/hu.json
@@ -62,6 +62,7 @@
   "scoped_community_search_label": "Célzott keresés a közösségben",
   "scoped_knowledge_base_search_description": "A keresési eredmények azokra a kategóriákra korlátozódnak, amelyekben a felhasználó megtalálható",
   "scoped_knowledge_base_search_label": "Célzott keresés a Tudásbázisban",
+  "scoped_knowledge_base_search_label_v2": "Célzott keresés a súgóközpontban",
   "search_group_label": "Keresési beállítások",
   "section_page_group_label": "Szakaszoldal elemei",
   "show_brand_name_description": "A Súgóközpont nevének megjelenítése az embléma mellett",

--- a/translations/id.json
+++ b/translations/id.json
@@ -62,6 +62,7 @@
   "scoped_community_search_label": "Pencarian dalam cakupan di Komunitas",
   "scoped_knowledge_base_search_description": "Hasil pencarian dibatasi untuk kategori yang dimasuki pengguna",
   "scoped_knowledge_base_search_label": "Pencarian dalam cakupan di Basis Pengetahuan",
+  "scoped_knowledge_base_search_label_v2": "Pencarian yang tercakup di pusat bantuan",
   "search_group_label": "Pengaturan pencarian",
   "section_page_group_label": "Elemen halaman bagian",
   "show_brand_name_description": "Tampilkan nama Pusat Bantuan di samping logo",

--- a/translations/it.json
+++ b/translations/it.json
@@ -62,6 +62,7 @@
   "scoped_community_search_label": "Ricerca limitata nella Community",
   "scoped_knowledge_base_search_description": "Risultati di ricerca limitati alla categoria visualizzata dall’utente",
   "scoped_knowledge_base_search_label": "Ricerca limitata nella Knowledge base",
+  "scoped_knowledge_base_search_label_v2": "Ricerca con ambito nel centro assistenza",
   "search_group_label": "Impostazioni di ricerca",
   "section_page_group_label": "Elementi pagina sezione",
   "show_brand_name_description": "Visualizza il nome del Centro assistenza accanto al logo",

--- a/translations/ja.json
+++ b/translations/ja.json
@@ -62,6 +62,7 @@
   "scoped_community_search_label": "コミュニティの範囲限定検索",
   "scoped_knowledge_base_search_description": "検索結果はユーザーが閲覧中のカテゴリに限定されます",
   "scoped_knowledge_base_search_label": "ナレッジベースの範囲限定検索",
+  "scoped_knowledge_base_search_label_v2": "ヘルプセンター内の範囲限定検索",
   "search_group_label": "検索設定",
   "section_page_group_label": "セクションページの要素",
   "show_brand_name_description": "ロゴの横にヘルプセンターの名前を表示します",

--- a/translations/ko.json
+++ b/translations/ko.json
@@ -62,6 +62,7 @@
   "scoped_community_search_label": "커뮤니티에서만 검색",
   "scoped_knowledge_base_search_description": "검색 결과의 범위를 사용자가 속한 카테고리로 제한",
   "scoped_knowledge_base_search_label": "지식창고에서만 검색",
+  "scoped_knowledge_base_search_label_v2": "헬프 센터의 범위 지정 검색",
   "search_group_label": "검색 설정",
   "section_page_group_label": "섹션 페이지 요소",
   "show_brand_name_description": "로고 옆에 헬프 센터 이름 표시",

--- a/translations/nl.json
+++ b/translations/nl.json
@@ -62,6 +62,7 @@
   "scoped_community_search_label": "Gefilterde zoekopdracht in community",
   "scoped_knowledge_base_search_description": "Zoekresultaten zijn beperkt tot de categorie waarbinnen de gebruiker zich bevindt",
   "scoped_knowledge_base_search_label": "Gefilterde zoekopdracht in kennisbank",
+  "scoped_knowledge_base_search_label_v2": "Zoeken met bereiken in helpcenter",
   "search_group_label": "Zoekinstellingen",
   "section_page_group_label": "Elementen op sectiepagina",
   "show_brand_name_description": "Geef de naam van het Helpcentrum weer naast het logo",

--- a/translations/no.json
+++ b/translations/no.json
@@ -62,6 +62,7 @@
   "scoped_community_search_label": "Begrenset søk i Nettsamfunn",
   "scoped_knowledge_base_search_description": "Søkeresultater er begrenset til kategorien brukeren er i",
   "scoped_knowledge_base_search_label": "Begrenset søk i Kunnskapsbase",
+  "scoped_knowledge_base_search_label_v2": "Begrenset søk i kundesenter",
   "search_group_label": "Søk-innstillinger",
   "section_page_group_label": "Seksjonssideelementer",
   "show_brand_name_description": "Vis kundesenternavnet ved siden av logoen",

--- a/translations/pl.json
+++ b/translations/pl.json
@@ -62,6 +62,7 @@
   "scoped_community_search_label": "Filtrowane wyszukiwanie w społeczności",
   "scoped_knowledge_base_search_description": "Wyniki wyszukiwania są zawężone do kategorii, w której znajduje się użytkownik",
   "scoped_knowledge_base_search_label": "Filtrowane wyszukiwanie w bazie wiedzy",
+  "scoped_knowledge_base_search_label_v2": "Filtrowane wyszukiwanie w centrum pomocy",
   "search_group_label": "Ustawienia wyszukiwania",
   "section_page_group_label": "Elementy strony sekcji",
   "show_brand_name_description": "Wyświetl nazwę Centrum pomocy obok logo",

--- a/translations/pt-br.json
+++ b/translations/pt-br.json
@@ -62,6 +62,7 @@
   "scoped_community_search_label": "Pesquisa dentro do escopo na Comunidade",
   "scoped_knowledge_base_search_description": "Os resultados da pesquisa estão restritos à categoria que o usuário está visitando",
   "scoped_knowledge_base_search_label": "Pesquisa dentro do escopo na base de conhecimento",
+  "scoped_knowledge_base_search_label_v2": "Pesquisa com escopo na central de ajuda",
   "search_group_label": "Configurações de pesquisa",
   "section_page_group_label": "Elementos da página da seção",
   "show_brand_name_description": "Exibir o nome da Central de Ajuda ao lado do logotipo",

--- a/translations/pt.json
+++ b/translations/pt.json
@@ -62,6 +62,7 @@
   "scoped_community_search_label": "Pesquisa dentro do escopo na Comunidade",
   "scoped_knowledge_base_search_description": "Os resultados da pesquisa estão restritos à categoria que o usuário está visitando",
   "scoped_knowledge_base_search_label": "Pesquisa dentro do escopo na base de conhecimento",
+  "scoped_knowledge_base_search_label_v2": "Pesquisa com escopo na central de ajuda",
   "search_group_label": "Configurações de pesquisa",
   "section_page_group_label": "Elementos da página da seção",
   "show_brand_name_description": "Exibir o nome da Central de Ajuda ao lado do logotipo",

--- a/translations/ro.json
+++ b/translations/ro.json
@@ -62,6 +62,7 @@
   "scoped_community_search_label": "Căutare filtrată în Comunitate",
   "scoped_knowledge_base_search_description": "Rezultatele căutării sunt limitate la categoria în care se află utilizatorul",
   "scoped_knowledge_base_search_label": "Căutare filtrată în Baza de cunoștințe",
+  "scoped_knowledge_base_search_label_v2": "Căutare cu scop în centrul de asistență",
   "search_group_label": "Setări căutare",
   "section_page_group_label": "Elemente pagină de secțiune",
   "show_brand_name_description": "Afișați numele Centrului de asistență lângă siglă",

--- a/translations/ru.json
+++ b/translations/ru.json
@@ -62,6 +62,7 @@
   "scoped_community_search_label": "Ограниченный поиск в сообществе",
   "scoped_knowledge_base_search_description": "Результаты поиска ограничены категорией, в которой находится пользователь",
   "scoped_knowledge_base_search_label": "Ограниченный поиск в базе знаний",
+  "scoped_knowledge_base_search_label_v2": "Ограниченный поиск в справочном центре",
   "search_group_label": "Настройки поиска",
   "section_page_group_label": "Элементы страницы раздела",
   "show_brand_name_description": "Показывать около логотипа название Справочного центра",

--- a/translations/sk.json
+++ b/translations/sk.json
@@ -62,6 +62,7 @@
   "scoped_community_search_label": "Obmedzený rozsah vyhľadávania v komunite",
   "scoped_knowledge_base_search_description": "Výsledky vyhľadávania sú obmedzené na kategóriu, v ktorej sa nachádza používateľ",
   "scoped_knowledge_base_search_label": "Obmedzený rozsah vyhľadávania vo vedomostnej databáze",
+  "scoped_knowledge_base_search_label_v2": "Obmedzený rozsah vyhľadávania v centre pomoci",
   "search_group_label": "Nastavenia vyhľadávania",
   "section_page_group_label": "Prvky stránky sekcií",
   "show_brand_name_description": "Zobrazenie názvu Centra pomoci vedľa loga",

--- a/translations/sv.json
+++ b/translations/sv.json
@@ -62,6 +62,7 @@
   "scoped_community_search_label": "Begränsad sökning i communityn",
   "scoped_knowledge_base_search_description": "Sökresultaten begränsas till den kategori användaren befinner sig i",
   "scoped_knowledge_base_search_label": "Begränsad sökning i kunskapsbasen",
+  "scoped_knowledge_base_search_label_v2": "Begränsad sökning i helpcenter",
   "search_group_label": "Sökinställningar",
   "section_page_group_label": "Element på avsnittssidan",
   "show_brand_name_description": "Visa Helpcenter-namnet bredvid logotypen",

--- a/translations/th.json
+++ b/translations/th.json
@@ -62,6 +62,7 @@
   "scoped_community_search_label": "ขอบเขตการค้นหาในชุมชน",
   "scoped_knowledge_base_search_description": "ผลการค้นหาจะจำกัดเฉพาะหมวดหมู่ที่ผู้ใช้สนใจ",
   "scoped_knowledge_base_search_label": "ขอบเขตการค้นหาในฐานความรู้",
+  "scoped_knowledge_base_search_label_v2": "การค้นหาตามขอบเขตในศูนย์ความช่วยเหลือ",
   "search_group_label": "การตั้งค่าการค้นหา",
   "section_page_group_label": "องค์ประกอบของหน้าหมวด",
   "show_brand_name_description": "แสดงชื่อศูนย์ความช่วยเหลือถัดจากโลโก้",

--- a/translations/tr.json
+++ b/translations/tr.json
@@ -62,6 +62,7 @@
   "scoped_community_search_label": "Toplulukta kapsamı belirli arama",
   "scoped_knowledge_base_search_description": "Arama sonuçları, kullanıcının içinde bulunduğu kategoriyle sınırlıdır",
   "scoped_knowledge_base_search_label": "Bilgi Bankasında kapsamı belirli arama",
+  "scoped_knowledge_base_search_label_v2": "Yardım merkezinde kapsamlı arama",
   "search_group_label": "Arama ayarları",
   "section_page_group_label": "Bölüm sayfası öğeleri",
   "show_brand_name_description": "Yardım Merkezi adını logonun yanında görüntüleyin",

--- a/translations/uk.json
+++ b/translations/uk.json
@@ -62,6 +62,7 @@
   "scoped_community_search_label": "Масштабований пошук у спільноті",
   "scoped_knowledge_base_search_description": "Результати пошуку обмежені категорією, до якої належить користувач",
   "scoped_knowledge_base_search_label": "Масштабний пошук у Базі знань",
+  "scoped_knowledge_base_search_label_v2": "Обмежений пошук у довідковому центрі",
   "search_group_label": "Налаштування пошуку",
   "section_page_group_label": "Елементи сторінки розділу",
   "show_brand_name_description": "Відображення назви Довідкового центру поруч із логотипом",

--- a/translations/vi.json
+++ b/translations/vi.json
@@ -62,6 +62,7 @@
   "scoped_community_search_label": "Tìm kiếm theo phạm vi trong Cộng đồng",
   "scoped_knowledge_base_search_description": "Kết quả tìm kiếm được giới hạn trong nhóm hiện tại của người dùng",
   "scoped_knowledge_base_search_label": "Tìm kiếm theo phạm vi trong Thư viện thông tin",
+  "scoped_knowledge_base_search_label_v2": "Tìm kiếm theo phạm vi trong trung tâm trợ giúp",
   "search_group_label": "Cài đặt tìm kiếm",
   "section_page_group_label": "Các phần tử của trang mục",
   "show_brand_name_description": "Hiển thị tên Trung tâm trợ giúp bên cạnh biểu tượng",

--- a/translations/zh-cn.json
+++ b/translations/zh-cn.json
@@ -62,6 +62,7 @@
   "scoped_community_search_label": "社区中有范围限制的搜索",
   "scoped_knowledge_base_search_description": "搜索结果限制在用户所在的类别内",
   "scoped_knowledge_base_search_label": "知识库中有范围限制的搜索",
+  "scoped_knowledge_base_search_label_v2": "帮助中心范围内搜索",
   "search_group_label": "搜索设置",
   "section_page_group_label": "组别页面元素",
   "show_brand_name_description": "在徽标旁显示帮助中心名称",

--- a/translations/zh-tw.json
+++ b/translations/zh-tw.json
@@ -62,6 +62,7 @@
   "scoped_community_search_label": "社區內的限定範圍搜尋",
   "scoped_knowledge_base_search_description": "搜尋結果限於使用者所在類別",
   "scoped_knowledge_base_search_label": "知識庫內的限定範圍搜尋",
+  "scoped_knowledge_base_search_label_v2": "客服中心的限定範圍搜尋",
   "search_group_label": "搜尋設定值",
   "section_page_group_label": "段落頁面元素",
   "show_brand_name_description": "在標誌的旁邊顯示客服中心名稱",


### PR DESCRIPTION
## Description

This PR updates the label used for the `scoped_kb_search` setting from "scoped search in Knowledge Base" to "scoped search in help center" for all the supported languages

## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->