### PR TITLE
fix(service-catalog): fix description alignment in RTL languages

### DIFF
--- a/src/modules/service-catalog/components/service-catalog-item/CollapsibleDescription.tsx
+++ b/src/modules/service-catalog/components/service-catalog-item/CollapsibleDescription.tsx
@@ -24,7 +24,6 @@ const ItemTitle = styled(XXXL)`
 
 const CollapsibleText = styled.div<{ expanded: boolean }>`
   font-size: ${(props) => props.theme.fontSizes.md};
-  text-align: left;
   display: -webkit-box;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: ${(props) => (props.expanded ? "none" : 3)};


### PR DESCRIPTION
## Description

We were setting `text-align: left` in the `CollapsibleDescription` component, which was causing the description text to be left-aligned even in RTL languages.

The rule is not needed, and we can rely on the default alignment which is right-aligned in RTL languages.

## Screenshots

Before
<img width="1087" alt="Screenshot 2025-03-28 at 16 04 41" src="https://github.com/user-attachments/assets/eb8d5ea9-d32a-4721-a372-947f24e1eed4" />

After
<img width="1087" alt="Screenshot 2025-03-28 at 16 05 20" src="https://github.com/user-attachments/assets/91209976-24be-40fa-a75b-1a884308cac9" />



## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->