### PR TITLE
fix: add missing values for services count string

### DIFF
--- a/src/modules/service-catalog/ServiceCatalogList.tsx
+++ b/src/modules/service-catalog/ServiceCatalogList.tsx
@@ -105,10 +105,9 @@ export function ServiceCatalogList({
         onChange={handleInputChange}
       />
       <span>
-        {t("service-catalog.service-count", {
+        {t("service-catalog.service-count", "{{count}} services", {
           "defaultValue.one": "{{count}} service",
-          "defaultValue.other": "{{count}} services",
-          count: count,
+          count,
         })}
       </span>
       {isLoading ? (


### PR DESCRIPTION
## Description

Some languages make use of the `few` and `many` plural forms, such as arabic. When we added the Services count, we only provided values for `one` and `other` which led to errors when displaying the counter in the page.

This PR adds a default value for all the other forms, in order to display the counter correctly. The translations for the counter will be added in another PR.

## Screenshots

### Before 

![Screenshot 2025-03-31 at 17 49 39](https://github.com/user-attachments/assets/6dbb1127-0237-402e-8eee-f4ecc954a111)

### After

![Screenshot 2025-03-31 at 17 49 29](https://github.com/user-attachments/assets/f3d8043d-0c40-4657-9ed0-6a5a0d7c9899)

## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->