### PR TITLE
chore: add service catalog count strings for translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,13 +178,14 @@ function MyComponent() {
 Providing the default English value in the code makes it possible to use it as a fallback value when strings are not yet translated and to extract the strings from the source code to the translations YAML file.
 
 #### Plurals 
-When using [plurals](https://www.i18next.com/translation-function/plurals), you need to provide default values for at least the `one` and `other` forms. You can also pass a default value for the `zero` form, if you want it to be different from the `other` form. This can be done by passing the default values in the [options](https://www.i18next.com/translation-function/essentials#overview-options) of the `t` function.
+When using [plurals](https://www.i18next.com/translation-function/plurals), you need to provide default values for the `zero`, `one`, `two`, `few`, `many` and `other` forms, as some languages have specific forms for all of these. These forms should be provided in the translations YAML file, such as [this one](./src/modules/shared/translations/en-us.yml). This can be done manually or by running the extract script after adding the string in the code (check [String extraction](#string-extraction) for more details).
+
+To use the plural forms in the code, you need to provide at least a default value for `one` and a generic value for the other plural forms. It is also possible to pass a default value for `zero`, if you want it to be different from the generic value. This can be done by passing the default values in the [options](https://www.i18next.com/translation-function/essentials#overview-options) of the `t` function.
 
 ```ts
-t("my-key", {
+t("my-key", "{{count}} items", {
   "defaultValue.zero": "No items",
   "defaultValue.one": "{{count}} item",
-  "defaultValue.other": "{{count}} items",
   count: ...
 })
 ```

--- a/src/modules/service-catalog/translations/en-us.yml
+++ b/src/modules/service-catalog/translations/en-us.yml
@@ -87,4 +87,33 @@ parts:
       title: "Error notification when there is problem with loading the list of services"
       screenshot: "https://drive.google.com/file/d/1vIeLVSOOV9-vUj-Kh9-ZwyFSC9jN6AFs/view?usp=drive_link"
       value: "Give it a moment and try it again"
-      
+  - translation:
+      key: "service-catalog.service-count.zero"
+      title: "Label indicating number of services currently being listed, when there are 0 requests."
+      screenshot: "https://drive.google.com/file/d/1uP3fyDR1vE2Z8lHXiNXaZD7LeTEgLCSw/view?usp=drive_link"
+      value: "{{count}} services"
+  - translation:
+      key: "service-catalog.service-count.one"
+      title: "Label indicating number of services currently being listed, when there is 1 request."
+      screenshot: "https://drive.google.com/file/d/1uP3fyDR1vE2Z8lHXiNXaZD7LeTEgLCSw/view?usp=drive_link"
+      value: "{{count}} service"
+  - translation:
+      key: "service-catalog.service-count.two"
+      title: "Label indicating number of services currently being listed, when there are 2 requests."
+      screenshot: "https://drive.google.com/file/d/1uP3fyDR1vE2Z8lHXiNXaZD7LeTEgLCSw/view?usp=drive_link"
+      value: "{{count}} services"
+  - translation:
+      key: "service-catalog.service-count.few"
+      title: "Label indicating number of services currently being listed, when the few plural form applies."
+      screenshot: "https://drive.google.com/file/d/1uP3fyDR1vE2Z8lHXiNXaZD7LeTEgLCSw/view?usp=drive_link"
+      value: "{{count}} services"
+  - translation:
+      key: "service-catalog.service-count.many"
+      title: "Label indicating number of services currently being listed, when the many plural form applies."
+      screenshot: "https://drive.google.com/file/d/1uP3fyDR1vE2Z8lHXiNXaZD7LeTEgLCSw/view?usp=drive_link"
+      value: "{{count}} services"
+  - translation:
+      key: "service-catalog.service-count.other"
+      title: "Label indicating number of services currently being listed, the default plural form."
+      screenshot: "https://drive.google.com/file/d/1uP3fyDR1vE2Z8lHXiNXaZD7LeTEgLCSw/view?usp=drive_link"
+      value: "{{count}} services"


### PR DESCRIPTION
## Description

We add new strings for the Services count in our beta branch. However, given that our translation tool only picks up new strings from master, we did not get the required translation variants.

This PR adds the strings to master in order to get the translations. It also updates the README to include all the necessary plural forms. 

## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->