### PR TITLE
chore: add services search strings for translation

### DIFF
--- a/src/modules/service-catalog/translations/en-us.yml
+++ b/src/modules/service-catalog/translations/en-us.yml
@@ -117,3 +117,18 @@ parts:
       title: "Label indicating number of services currently being listed, the default plural form."
       screenshot: "https://drive.google.com/file/d/1uP3fyDR1vE2Z8lHXiNXaZD7LeTEgLCSw/view?usp=drive_link"
       value: "{{count}} services"
+  - translation:
+      key: "service-catalog.search-services"
+      title: "Search for services in the Service List"
+      screenshot: "https://drive.google.com/file/d/1JHDB_jxDaL0ozmpUTYIhYMaCm4-4SN27/view?usp=drive_link"
+      value: "Search for services"
+  - translation:
+      key: "service-catalog.clear-search"
+      title: "Clear search button"
+      screenshot: "https://drive.google.com/file/d/11u8u7DOlPvAMZcFlsj_aPU1mPOSzjBxY/view?usp=drive_link"
+      value: "Clear search"
+  - translation:
+      key: "service-catalog.empty-state.search-description"
+      title: "Empty state with search description"
+      screenshot: "https://drive.google.com/file/d/10DiQB3DDf9x13owivlJs9QMNWVXCKdOd/view?usp=drive_link"
+      value: "Enter your keywords in the search field."


### PR DESCRIPTION
## Description

We have added new strings related to the Services search feature in our beta branch. However, given that our translation tool only picks up new strings from master, we did not get the required translation variants.

This PR adds the strings to master so we are able to get the translations, which will then be added to the beta branch in a future PR. 

## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->