### PR TITLE
Use translation for page title

### DIFF
--- a/templates/service_list_page.hbs
+++ b/templates/service_list_page.hbs
@@ -4,8 +4,7 @@
     {{breadcrumbs}}
   </div>
 
-  {{!-- <h1>{{t 'Services'}}</h1> //this translation is missing in HC --}}
-  <h1>Services</h1>
+  <h1>{{t 'services'}}</h1>
 
   <div id="main-content">
      <div id="service-catalog"></div>


### PR DESCRIPTION
## Description

This one translation string was missing and we had hardcoded page title. Now we can use translation passed from HC in handlebars. 

[Jira issue GG-4127](https://zendesk.atlassian.net/browse/GG-4127)

## Screenshots

<!-- (optional) when applicable, please include some screenshots or gifs that illustrate the changes -->

## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->