### PR TITLE
Fix lookup relationship fields (lurf) in service catalog forms

### DIFF
--- a/src/modules/service-catalog/components/service-catalog-item/ItemRequestForm.tsx
+++ b/src/modules/service-catalog/components/service-catalog-item/ItemRequestForm.tsx
@@ -126,6 +126,7 @@ export function ItemRequestForm({
               brandId={brandId}
               defaultOrganizationId={defaultOrganizationId}
               handleChange={handleChange}
+              organizationField={null}
             />
           ))}
         </FieldsContainer>

--- a/src/modules/ticket-fields/TicketField.tsx
+++ b/src/modules/ticket-fields/TicketField.tsx
@@ -16,7 +16,7 @@ interface TicketFieldProps {
   userRole: string;
   userId: number;
   defaultOrganizationId: string | null;
-  organizationField?: Field | null;
+  organizationField: Field | null;
   brandId: number;
   dueDateField?: Field;
   handleDueDateChange?: (value: string) => void;


### PR DESCRIPTION
## Description

1. `organizationField` was not passed to the `TicketField` component as it was marked as an "optional"
2. The problem was that inside the `TicketField` component we checked if `organizationField !== null` when building up the API endpoint and since `organizationField` was `undefined` it resulted in broken API calls:

<img width="1697" alt="image" src="https://github.com/user-attachments/assets/497c9b66-430d-4d88-8442-f1315a295af4" />

This PR addresses this issue and just passed `organizationField={null}` since the "organization field" is a standard field and can't be added to a Service Catalog Item form.

## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->