### PR TITLE
feat: render service item description with html in service item page

### DIFF
--- a/assets/service-catalog-bundle.js
+++ b/assets/service-catalog-bundle.js
@@ -115,7 +115,7 @@ import{s as e,E as n,j as t,a7 as s,a8 as r,a9 as a,aa as o,ab as i,u as l,ac as
   &:hover {
     text-decoration: none;
   }
-`,he=({title:e,description:n})=>{const[s,r]=v.useState(!1),{t:a}=l(),o=n.length>270;return t.jsxs(le,{children:[t.jsx(ce,{tag:"h1",children:e}),t.jsx(ue,{expanded:s||!o,children:n}),o&&t.jsxs(de,{isLink:!0,onClick:()=>{r(!s)},children:[s?a("service-catalog.item.read-less","Read less"):a("service-catalog.item.read-more","Read more"),t.jsx(d.EndIcon,{children:s?t.jsx(E,{}):t.jsx(P,{})})]})]})},je=e.form`
+`,he=({title:e,description:n})=>{const[s,r]=v.useState(!1),{t:a}=l(),o=n.length>270;return t.jsxs(le,{children:[t.jsx(ce,{tag:"h1",children:e}),n&&t.jsx(ue,{expanded:s||!o,dangerouslySetInnerHTML:{__html:n}}),o&&t.jsxs(de,{isLink:!0,onClick:()=>{r(!s)},children:[s?a("service-catalog.item.read-less","Read less"):a("service-catalog.item.read-more","Read more"),t.jsx(d.EndIcon,{children:s?t.jsx(E,{}):t.jsx(P,{})})]})]})},je=e.form`
   display: flex;
   flex-direction: row;
   justify-content: space-between;

--- a/src/modules/service-catalog/components/service-catalog-item/CollapsibleDescription.tsx
+++ b/src/modules/service-catalog/components/service-catalog-item/CollapsibleDescription.tsx
@@ -67,9 +67,12 @@ export const CollapsibleDescription = ({
   return (
     <DescriptionWrapper>
       <ItemTitle tag="h1">{title}</ItemTitle>
-      <CollapsibleText expanded={isExpanded || !showToggleButton}>
-        {description}
-      </CollapsibleText>
+      {description && (
+        <CollapsibleText
+          expanded={isExpanded || !showToggleButton}
+          dangerouslySetInnerHTML={{ __html: description }}
+        ></CollapsibleText>
+      )}
       {showToggleButton && (
         <ToggleButton isLink onClick={toggleDescription}>
           {isExpanded


### PR DESCRIPTION
## Description

Render service item description with html in service item page.
Jira: [https://zendesk.atlassian.net/browse/GG-4240](https://zendesk.atlassian.net/browse/GG-4240)

## Screenshots


## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->