### PR TITLE
fix: added styles for service catalog description

### DIFF
--- a/src/modules/service-catalog/components/service-catalog-item/CollapsibleDescription.tsx
+++ b/src/modules/service-catalog/components/service-catalog-item/CollapsibleDescription.tsx
@@ -69,6 +69,7 @@ export const CollapsibleDescription = ({
       <ItemTitle tag="h1">{title}</ItemTitle>
       {description && (
         <CollapsibleText
+          className="service-catalog-description"
           expanded={isExpanded || !showToggleButton}
           dangerouslySetInnerHTML={{ __html: description }}
         ></CollapsibleText>

--- a/styles/_service_catalog.scss
+++ b/styles/_service_catalog.scss
@@ -1,0 +1,3 @@
+.service-catalog-description {
+  @include content-body;
+}

--- a/styles/index.scss
+++ b/styles/index.scss
@@ -44,3 +44,4 @@
 @import "wysiwyg";
 @import "upload_dropzone";
 @import "summary";
+@import "service_catalog";


### PR DESCRIPTION
## Description

This PR defines a `service-catalog-description` CSS class in the SASS files, which contains some styles needed to properly show content created by the WYSIWYG editor in Knowledge Admin. The class is then added to the `CollapsibleText` component.

The class uses the `content-body` mixin, also used for the article body and in the community pages. The build process will generate the needed classes in the main `styles.css` file.

## Screenshots

Example of some fixed styles:

Before - list bullet points and blockquote are not styled correctly

<img width="1296" alt="Screenshot 2025-05-20 at 16 32 15" src="https://github.com/user-attachments/assets/6f563989-f5f5-4e60-9665-46ccf3cf8d12" />

After
<img width="1296" alt="Screenshot 2025-05-20 at 16 35 40" src="https://github.com/user-attachments/assets/6c72f745-ac9c-4bbf-b0ae-9fe7f7b19d1c" />




## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->