### PR TITLE
GG-4444: feat: Replace service request subject and description

### DIFF
--- a/src/modules/service-catalog/components/service-catalog-item/submitServiceItemRequest.tsx
+++ b/src/modules/service-catalog/components/service-catalog-item/submitServiceItemRequest.tsx
@@ -30,7 +30,7 @@ export async function submitServiceItemRequest(
         request: {
           subject: `${serviceCatalogItem.name}`,
           comment: {
-            html_body: `<a href="/hc/en-us/services/${serviceCatalogItem.id}" target="_blank" rel="noopener noreferrer">${serviceCatalogItem.name}</a>`,
+            html_body: `<a href="/hc/en-us/services/${serviceCatalogItem.id}" style="text-decoration: underline" target="_blank" rel="noopener noreferrer">${serviceCatalogItem.name}</a>`,
           },
           ticket_form_id: serviceCatalogItem.form_id,
           custom_fields: [


### PR DESCRIPTION
## Description

Replace service request submission subject and description strings:

- Subject is service's name.
- Description is a link pointing to the requested service's page in Help Center that opens in a new tab. 

## Screenshots

Result: 
<img width="1431" alt="image" src="https://github.com/user-attachments/assets/e271f98c-7664-4c3e-8bad-86be68b4ebc2" />


## Checklist

- [x] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [x] :arrow_left: changes are compatible with RTL direction
- [x] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [x] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [x] :iphone: changes are responsive and tested in mobile
- [x] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->