### PR TITLE
GG-4255: fix: Use colours from team settings in the services page

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,8 @@
     "wait-on": "8.0.3"
   },
   "resolutions": {
-    "@types/react": "^17.x"
+    "@types/react": "^17.x",
+    "nwsapi": "^2.2.20"
   },
   "commitlint": {
     "extends": [

--- a/src/modules/service-catalog/components/service-catalog-list/ServiceCatalogListItem.spec.tsx
+++ b/src/modules/service-catalog/components/service-catalog-list/ServiceCatalogListItem.spec.tsx
@@ -90,8 +90,6 @@ describe("ServiceCatalogListItem", () => {
       const itemTitle = screen.getByTestId("service-catalog-list-item");
       const defaultBorderColor = "#d8dcde";
 
-      await user.unhover(itemTitle);
-
       expect(itemTitle).toHaveStyle(`border-color: ${defaultBorderColor}`);
 
       await user.hover(itemTitle);

--- a/src/modules/service-catalog/components/service-catalog-list/ServiceCatalogListItem.spec.tsx
+++ b/src/modules/service-catalog/components/service-catalog-list/ServiceCatalogListItem.spec.tsx
@@ -1,0 +1,102 @@
+import { render, screen } from "@testing-library/react";
+import { ThemeProvider } from "styled-components";
+import { DEFAULT_THEME } from "@zendeskgarden/react-theming";
+import ServiceCatalogListItem from "./ServiceCatalogListItem";
+import type { ServiceCatalogItem } from "../../data-types/ServiceCatalogItem";
+import { userEvent } from "@testing-library/user-event";
+
+jest.mock("@zendeskgarden/svg-icons/src/16/shapes-fill.svg", () => {
+  return function MockShapesIcon() {
+    return <div data-testid="atl-nacional" />;
+  };
+});
+
+const theme = {
+  ...DEFAULT_THEME,
+  colors: {
+    ...DEFAULT_THEME.colors,
+    foreground: "#ff0000",
+    primaryHue: "#0000ff",
+  },
+};
+
+const renderWithTheme = (component: React.ReactElement) => {
+  return render(<ThemeProvider theme={theme}>{component}</ThemeProvider>);
+};
+
+describe("ServiceCatalogListItem", () => {
+  const mockServiceItem: ServiceCatalogItem = {
+    id: 1989,
+    name: "Atl Nacional keyboard",
+    description: "This is a keyboard from Atl Nacional",
+    form_id: 456,
+  };
+
+  const mockHelpCenterPath = "/hc/en-us";
+
+  beforeEach(() => jest.clearAllMocks());
+
+  describe("Rendering", () => {
+    it("should render the service item with correct content", () => {
+      renderWithTheme(
+        <ServiceCatalogListItem
+          serviceItem={mockServiceItem}
+          helpCenterPath={mockHelpCenterPath}
+        />
+      );
+
+      expect(screen.getByText(mockServiceItem.name)).toBeInTheDocument();
+      expect(screen.getByText(mockServiceItem.description)).toBeInTheDocument();
+      expect(screen.getByTestId("atl-nacional")).toBeInTheDocument();
+    });
+
+    it("should render as a link with correct href", () => {
+      renderWithTheme(
+        <ServiceCatalogListItem
+          serviceItem={mockServiceItem}
+          helpCenterPath={mockHelpCenterPath}
+        />
+      );
+
+      const linkElement = screen.getByRole("link");
+
+      expect(linkElement).toHaveAttribute(
+        "href",
+        `${mockHelpCenterPath}/services/${mockServiceItem.id}`
+      );
+    });
+
+    it("should use the theme foreground color as text color", () => {
+      renderWithTheme(
+        <ServiceCatalogListItem
+          serviceItem={mockServiceItem}
+          helpCenterPath={mockHelpCenterPath}
+        />
+      );
+
+      const itemTitle = screen.getByTestId("service-catalog-list-item");
+      expect(itemTitle).toHaveStyle(`color: ${theme.colors.foreground}`);
+    });
+
+    it("should use primaryHue as card border color on hover", async () => {
+      renderWithTheme(
+        <ServiceCatalogListItem
+          serviceItem={mockServiceItem}
+          helpCenterPath={mockHelpCenterPath}
+        />
+      );
+
+      const user = userEvent.setup();
+      const itemTitle = screen.getByTestId("service-catalog-list-item");
+      const defaultBorderColor = "#d8dcde";
+
+      await user.unhover(itemTitle);
+
+      expect(itemTitle).toHaveStyle(`border-color: ${defaultBorderColor}`);
+
+      await user.hover(itemTitle);
+
+      expect(itemTitle).toHaveStyle(`border-color: ${theme.colors.primaryHue}`);
+    });
+  });
+});

--- a/src/modules/service-catalog/components/service-catalog-list/ServiceCatalogListItem.spec.tsx
+++ b/src/modules/service-catalog/components/service-catalog-list/ServiceCatalogListItem.spec.tsx
@@ -74,8 +74,10 @@ describe("ServiceCatalogListItem", () => {
         />
       );
 
-      const itemTitle = screen.getByTestId("service-catalog-list-item");
-      expect(itemTitle).toHaveStyle(`color: ${theme.colors.foreground}`);
+      const itemContainer = screen.getByTestId(
+        "service-catalog-list-item-container"
+      );
+      expect(itemContainer).toHaveStyle(`color: ${theme.colors.foreground}`);
     });
 
     it("should use primaryHue as card border color on hover", async () => {
@@ -87,14 +89,19 @@ describe("ServiceCatalogListItem", () => {
       );
 
       const user = userEvent.setup();
-      const itemTitle = screen.getByTestId("service-catalog-list-item");
-      const defaultBorderColor = "#d8dcde";
+      const itemContainer = screen.getByTestId(
+        "service-catalog-list-item-container"
+      );
+      const defaultBorderColor = DEFAULT_THEME.palette.grey?.[300];
 
-      expect(itemTitle).toHaveStyle(`border-color: ${defaultBorderColor}`);
+      expect(defaultBorderColor).toBeTruthy();
+      expect(itemContainer).toHaveStyle(`border-color: ${defaultBorderColor}`);
 
-      await user.hover(itemTitle);
+      await user.hover(itemContainer);
 
-      expect(itemTitle).toHaveStyle(`border-color: ${theme.colors.primaryHue}`);
+      expect(itemContainer).toHaveStyle(
+        `border-color: ${theme.colors.primaryHue}`
+      );
     });
   });
 });

--- a/src/modules/service-catalog/components/service-catalog-list/ServiceCatalogListItem.tsx
+++ b/src/modules/service-catalog/components/service-catalog-list/ServiceCatalogListItem.tsx
@@ -69,7 +69,7 @@ const ServiceCatalogListItem = ({
 }) => {
   return (
     <ItemContainer
-      data-testid="service-catalog-list-item"
+      data-testid="service-catalog-list-item-container"
       href={`${helpCenterPath}/services/${serviceItem.id}`}
     >
       <IconContainer>

--- a/src/modules/service-catalog/components/service-catalog-list/ServiceCatalogListItem.tsx
+++ b/src/modules/service-catalog/components/service-catalog-list/ServiceCatalogListItem.tsx
@@ -11,17 +11,15 @@ const ItemContainer = styled.a`
   padding: ${(props) => props.theme.space.md};
   border: ${(props) => props.theme.borders.sm}
     ${(props) => getColorV8("grey", 300, props.theme)};
-  color: ${(props) => getColorV8("grey", 800, props.theme)};
+  color: ${(props) => props.theme.colors.foreground};
 
   &:hover {
-    text-decoration: none;
-    border: ${(props) => props.theme.borders.sm};
-    border-color: ${(props) => getColorV8("blue", 600, props.theme)};
+    border-color: ${(props) => props.theme.colors.primaryHue};
   }
 
+  &:hover,
   &:visited {
     text-decoration: none;
-    color: ${(props) => getColorV8("grey", 800, props.theme)};
   }
 `;
 
@@ -49,6 +47,7 @@ const TextContainer = styled.div`
   flex-direction: column;
   align-items: flex-start;
   gap: ${(props) => props.theme.space.xxs};
+  color: ${(props) => props.theme.colors.foreground};
 `;
 
 const IconContainer = styled.div`
@@ -69,7 +68,10 @@ const ServiceCatalogListItem = ({
   helpCenterPath: string;
 }) => {
   return (
-    <ItemContainer href={`${helpCenterPath}/services/${serviceItem.id}`}>
+    <ItemContainer
+      data-testid="service-catalog-list-item"
+      href={`${helpCenterPath}/services/${serviceItem.id}`}
+    >
       <IconContainer>
         <ShapesIcon />
       </IconContainer>

--- a/yarn.lock
+++ b/yarn.lock
@@ -10836,10 +10836,10 @@ nth-check@^2.0.1:
   dependencies:
     boolbase "^1.0.0"
 
-nwsapi@^2.2.2:
-  version "2.2.7"
-  resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.2.7.tgz#738e0707d3128cb750dddcfe90e4610482df0f30"
-  integrity sha512-ub5E4+FBPKwAZx0UwIQOjYWGHTEq5sPqHQNRN8Z9e4A7u3Tj1weLJsL59yH9vmvqEtBHaOmT6cYQKIZOxp35FQ==
+nwsapi@2.2.20, nwsapi@^2.2.2:
+  version "2.2.20"
+  resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.2.20.tgz#22e53253c61e7b0e7e93cef42c891154bcca11ef"
+  integrity sha512-/ieB+mDe4MrrKMT8z+mQL8klXydZWGR5Dowt4RAGKbJ3kIGEx3X4ljUo+6V73IXtUPWgfOlU5B9MlGxFO5T+cA==
 
 object-assign@^4, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10836,7 +10836,7 @@ nth-check@^2.0.1:
   dependencies:
     boolbase "^1.0.0"
 
-nwsapi@2.2.20, nwsapi@^2.2.2:
+nwsapi@^2.2.2, nwsapi@^2.2.20:
   version "2.2.20"
   resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.2.20.tgz#22e53253c61e7b0e7e93cef42c891154bcca11ef"
   integrity sha512-/ieB+mDe4MrrKMT8z+mQL8klXydZWGR5Dowt4RAGKbJ3kIGEx3X4ljUo+6V73IXtUPWgfOlU5B9MlGxFO5T+cA==


### PR DESCRIPTION
## Description

Use the colours from the team settings in the services list item cards. The main changes are:

- We will use the brand colour (`primaryHue`) as the border colour on hover and maintain the same.
- Use the text color (`foreground `) as the text colour for the cards.
- Updates `nwsapi` to fix a problem preventing the tests for on hover user events to work when implemented using [userEvent](https://github.com/testing-library/user-event). You can check [this issue](https://github.com/testing-library/jest-dom/issues/594).

## Video


https://github.com/user-attachments/assets/344bdbda-259f-4332-ac7d-f8bf87f01718



## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->

[GG-4255]: https://zendesk.atlassian.net/browse/GG-4255?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ