### PR TITLE
feat: adds support for multiple dynamic filters

### DIFF
--- a/src/modules/ticket-fields/fields/LookupField.test.tsx
+++ b/src/modules/ticket-fields/fields/LookupField.test.tsx
@@ -3,7 +3,7 @@ import type { TicketFieldObject } from "../data-types/TicketFieldObject";
 import { buildAdvancedDynamicFilterParams } from "./LookupField";
 
 describe("buildAdvancedDynamicFilterParams", () => {
-  it('returns correct dynamic filter value and matching field value for operator "matches"', () => {
+  it('returns correct dynamic filter array for operator "matches"', () => {
     const filter: LookupRelationshipFieldFilter = {
       all: [
         {
@@ -40,16 +40,12 @@ describe("buildAdvancedDynamicFilterParams", () => {
       },
     ];
 
-    const [dynamicValue, fieldValue] = buildAdvancedDynamicFilterParams(
-      filter,
-      fields
-    );
+    const result = buildAdvancedDynamicFilterParams(filter, fields);
 
-    expect(dynamicValue).toBe("ticket_fields_12345");
-    expect(fieldValue).toBe("fooValue");
+    expect(result).toEqual([{ key: "ticket_fields_12345", value: "fooValue" }]);
   });
 
-  it('returns correct dynamic filter value and matching field value for operator "not_matches" in any', () => {
+  it('returns correct dynamic filter array for operator "not_matches" in any', () => {
     const filter: LookupRelationshipFieldFilter = {
       all: [{ field: "someField", operator: "is", value: "foo" }],
       any: [
@@ -85,16 +81,12 @@ describe("buildAdvancedDynamicFilterParams", () => {
       },
     ];
 
-    const [dynamicValue, fieldValue] = buildAdvancedDynamicFilterParams(
-      filter,
-      fields
-    );
+    const result = buildAdvancedDynamicFilterParams(filter, fields);
 
-    expect(dynamicValue).toBe("ticket_fields_67890");
-    expect(fieldValue).toBe("barValue");
+    expect(result).toEqual([{ key: "ticket_fields_67890", value: "barValue" }]);
   });
 
-  it("returns [undefined, undefined] when no matching operator found", () => {
+  it("returns an empty array when no matching operator found", () => {
     const filter: LookupRelationshipFieldFilter = {
       all: [{ field: "someField", operator: "is", value: "foo" }],
       any: [{ field: "anotherField", operator: "is", value: "foo" }],
@@ -124,13 +116,9 @@ describe("buildAdvancedDynamicFilterParams", () => {
       },
     ];
 
-    const [dynamicValue, fieldValue] = buildAdvancedDynamicFilterParams(
-      filter,
-      fields
-    );
+    const result = buildAdvancedDynamicFilterParams(filter, fields);
 
-    expect(dynamicValue).toBeUndefined();
-    expect(fieldValue).toBeUndefined();
+    expect(result).toEqual([]);
   });
 
   it("returns [undefined, undefined] when filter is undefined", () => {
@@ -148,12 +136,57 @@ describe("buildAdvancedDynamicFilterParams", () => {
       },
     ];
 
-    const [dynamicValue, fieldValue] = buildAdvancedDynamicFilterParams(
-      undefined,
-      fields
-    );
+    const result = buildAdvancedDynamicFilterParams(undefined, fields);
 
-    expect(dynamicValue).toBeUndefined();
-    expect(fieldValue).toBeUndefined();
+    expect(result).toEqual([]);
+  });
+
+  it("returns multiple filters if more than one matches", () => {
+    const filter: LookupRelationshipFieldFilter = {
+      all: [
+        {
+          field: "someField",
+          operator: "matches",
+          value: "ticket_fields_12345",
+        },
+        {
+          field: "otherField",
+          operator: "matches",
+          value: "ticket_fields_67890",
+        },
+      ],
+      any: [],
+    };
+    const fields: TicketFieldObject[] = [
+      {
+        id: 12345,
+        name: "Test Field 1",
+        value: "fooValue",
+        error: null,
+        label: "Test Field 1",
+        required: false,
+        description: "",
+        type: "text",
+        options: [],
+      },
+      {
+        id: 67890,
+        name: "Test Field 2",
+        value: "barValue",
+        error: null,
+        label: "Test Field 2",
+        required: false,
+        description: "",
+        type: "text",
+        options: [],
+      },
+    ];
+
+    const result = buildAdvancedDynamicFilterParams(filter, fields);
+
+    expect(result).toEqual([
+      { key: "ticket_fields_12345", value: "fooValue" },
+      { key: "ticket_fields_67890", value: "barValue" },
+    ]);
   });
 });


### PR DESCRIPTION
## Description
Previously we were only supporting a single custom dynamic filter. This work appends dynamic query params for each defined filter.

<!-- a summary of the changes introduced by this PR and the motivation behind them -->

## Screenshots
Before:
![Screenshot 2025-06-30 at 11 29 53 AM](https://github.com/user-attachments/assets/b93eb07f-051d-4c7c-98aa-d5603fe6d37d)

After:
![Screenshot 2025-06-30 at 11 29 01 AM](https://github.com/user-attachments/assets/c40d4a3a-05f6-424c-a240-24616af35720)

<!-- (optional) when applicable, please include some screenshots or gifs that illustrate the changes -->

## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->