### PR TITLE
feat: display thumbnails in the services item list

### DIFF
--- a/src/modules/service-catalog/components/item-thumbnail/ItemThumbnail.tsx
+++ b/src/modules/service-catalog/components/item-thumbnail/ItemThumbnail.tsx
@@ -3,7 +3,7 @@ import styled from "styled-components";
 import { getColorV8 } from "@zendeskgarden/react-theming";
 import { Avatar } from "@zendeskgarden/react-avatars";
 
-const StyledAvatar = styled(Avatar)<{ size: string }>`
+const StyledAvatar = styled(Avatar)<{ size: "medium" | "large" }>`
   background-color: ${(props) => getColorV8("grey", 100, props.theme)};
   width: ${(props) => (props.size === "large" ? 72 : 40)}px !important;
   height: ${(props) => (props.size === "large" ? 72 : 40)}px !important;
@@ -20,12 +20,10 @@ type ItemThumbnailProps = {
   url?: string | null;
 };
 
-const ItemThumbnail = ({ size, url }: ItemThumbnailProps) => {
+export const ItemThumbnail = ({ size, url }: ItemThumbnailProps) => {
   return (
     <StyledAvatar size={size} isSystem>
       {url ? <img src={url} alt="" /> : <ShapesIcon aria-hidden="true" />}
     </StyledAvatar>
   );
 };
-
-export default ItemThumbnail;

--- a/src/modules/service-catalog/components/service-catalog-item/CollapsibleDescription.tsx
+++ b/src/modules/service-catalog/components/service-catalog-item/CollapsibleDescription.tsx
@@ -6,8 +6,7 @@ import ChevronDown from "@zendeskgarden/svg-icons/src/16/chevron-down-fill.svg";
 import { useTranslation } from "react-i18next";
 import { getColorV8 } from "@zendeskgarden/react-theming";
 import { XXXL } from "@zendeskgarden/react-typography";
-import { Avatar } from "@zendeskgarden/react-avatars";
-import ShapesIcon from "@zendeskgarden/svg-icons/src/16/shapes-fill.svg";
+import ItemThumbnail from "../service-catalog-list/ItemThumbnail";
 
 const DescriptionWrapper = styled.div`
   border-bottom: ${(props) => props.theme.borders.sm}
@@ -54,18 +53,6 @@ const HeaderContainer = styled.div`
   gap: ${(props) => props.theme.space.md};
 `;
 
-const StyledAvatar = styled(Avatar)`
-  width: 72px !important;
-  height: 72px !important;
-  background-color: ${(props) => getColorV8("grey", 100, props.theme)};
-
-  && > svg {
-    width: 28px;
-    height: 28px;
-    color: ${(props) => getColorV8("grey", 600, props.theme)};
-  }
-`;
-
 interface CollapsibleDescriptionProps {
   title: string;
   description: string;
@@ -91,13 +78,7 @@ export const CollapsibleDescription = ({
   return (
     <DescriptionWrapper>
       <HeaderContainer>
-        <StyledAvatar isSystem>
-          {thumbnailUrl ? (
-            <img src={thumbnailUrl} alt="" />
-          ) : (
-            <ShapesIcon aria-hidden="true" />
-          )}
-        </StyledAvatar>
+        <ItemThumbnail size="large" url={thumbnailUrl} />
         <ItemTitle tag="h1">{title}</ItemTitle>
       </HeaderContainer>
       {description && (

--- a/src/modules/service-catalog/components/service-catalog-item/CollapsibleDescription.tsx
+++ b/src/modules/service-catalog/components/service-catalog-item/CollapsibleDescription.tsx
@@ -6,7 +6,7 @@ import ChevronDown from "@zendeskgarden/svg-icons/src/16/chevron-down-fill.svg";
 import { useTranslation } from "react-i18next";
 import { getColorV8 } from "@zendeskgarden/react-theming";
 import { XXXL } from "@zendeskgarden/react-typography";
-import ItemThumbnail from "../service-catalog-list/ItemThumbnail";
+import { ItemThumbnail } from "../item-thumbnail/ItemThumbnail";
 
 const DescriptionWrapper = styled.div`
   border-bottom: ${(props) => props.theme.borders.sm}

--- a/src/modules/service-catalog/components/service-catalog-item/CollapsibleDescription.tsx
+++ b/src/modules/service-catalog/components/service-catalog-item/CollapsibleDescription.tsx
@@ -6,6 +6,8 @@ import ChevronDown from "@zendeskgarden/svg-icons/src/16/chevron-down-fill.svg";
 import { useTranslation } from "react-i18next";
 import { getColorV8 } from "@zendeskgarden/react-theming";
 import { XXXL } from "@zendeskgarden/react-typography";
+import { Avatar } from "@zendeskgarden/react-avatars";
+import ShapesIcon from "@zendeskgarden/svg-icons/src/16/shapes-fill.svg";
 
 const DescriptionWrapper = styled.div`
   border-bottom: ${(props) => props.theme.borders.sm}
@@ -20,6 +22,7 @@ const DescriptionWrapper = styled.div`
 
 const ItemTitle = styled(XXXL)`
   font-weight: ${(props) => props.theme.fontWeights.semibold};
+  margin-bottom: 0;
 `;
 
 const CollapsibleText = styled.div<{ expanded: boolean }>`
@@ -44,9 +47,29 @@ const ToggleButton = styled(Button)`
   }
 `;
 
+const HeaderContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: ${(props) => props.theme.space.md};
+`;
+
+const StyledAvatar = styled(Avatar)`
+  width: 72px !important;
+  height: 72px !important;
+  background-color: ${(props) => getColorV8("grey", 100, props.theme)};
+`;
+
+const StyledShapesIcon = styled(ShapesIcon)`s
+  width: 28px !important;
+  height: 28px !important;
+  color: ${(props) => getColorV8("grey", 600, props.theme)} !important;
+`;
+
 interface CollapsibleDescriptionProps {
   title: string;
   description: string;
+  thumbnailUrl: string;
 }
 
 const DESCRIPTION_LENGTH_THRESHOLD = 270;
@@ -54,6 +77,7 @@ const DESCRIPTION_LENGTH_THRESHOLD = 270;
 export const CollapsibleDescription = ({
   title,
   description,
+  thumbnailUrl,
 }: CollapsibleDescriptionProps) => {
   const [isExpanded, setIsExpanded] = useState<boolean>(false);
   const { t } = useTranslation();
@@ -66,7 +90,16 @@ export const CollapsibleDescription = ({
 
   return (
     <DescriptionWrapper>
-      <ItemTitle tag="h1">{title}</ItemTitle>
+      <HeaderContainer>
+        <StyledAvatar isSystem>
+          {thumbnailUrl ? (
+            <img src={thumbnailUrl} alt="" />
+          ) : (
+            <StyledShapesIcon aria-hidden="true" />
+          )}
+        </StyledAvatar>
+        <ItemTitle tag="h1">{title}</ItemTitle>
+      </HeaderContainer>
       {description && (
         <CollapsibleText
           className="service-catalog-description"

--- a/src/modules/service-catalog/components/service-catalog-item/CollapsibleDescription.tsx
+++ b/src/modules/service-catalog/components/service-catalog-item/CollapsibleDescription.tsx
@@ -58,12 +58,12 @@ const StyledAvatar = styled(Avatar)`
   width: 72px !important;
   height: 72px !important;
   background-color: ${(props) => getColorV8("grey", 100, props.theme)};
-`;
 
-const StyledShapesIcon = styled(ShapesIcon)`s
-  width: 28px !important;
-  height: 28px !important;
-  color: ${(props) => getColorV8("grey", 600, props.theme)} !important;
+  && > svg {
+    width: 28px;
+    height: 28px;
+    color: ${(props) => getColorV8("grey", 600, props.theme)};
+  }
 `;
 
 interface CollapsibleDescriptionProps {
@@ -95,7 +95,7 @@ export const CollapsibleDescription = ({
           {thumbnailUrl ? (
             <img src={thumbnailUrl} alt="" />
           ) : (
-            <StyledShapesIcon aria-hidden="true" />
+            <ShapesIcon aria-hidden="true" />
           )}
         </StyledAvatar>
         <ItemTitle tag="h1">{title}</ItemTitle>

--- a/src/modules/service-catalog/components/service-catalog-item/ItemRequestForm.tsx
+++ b/src/modules/service-catalog/components/service-catalog-item/ItemRequestForm.tsx
@@ -113,6 +113,7 @@ export function ItemRequestForm({
         <CollapsibleDescription
           title={serviceCatalogItem.name}
           description={serviceCatalogItem.description}
+          thumbnailUrl={serviceCatalogItem.thumbnail_url}
         />
         <FieldsContainer>
           {requestFields.map((field) => (

--- a/src/modules/service-catalog/components/service-catalog-list/ItemThumbnail.tsx
+++ b/src/modules/service-catalog/components/service-catalog-list/ItemThumbnail.tsx
@@ -1,0 +1,31 @@
+import ShapesIcon from "@zendeskgarden/svg-icons/src/16/shapes-fill.svg";
+import styled from "styled-components";
+import { getColorV8 } from "@zendeskgarden/react-theming";
+import { Avatar } from "@zendeskgarden/react-avatars";
+
+const StyledAvatar = styled(Avatar)<{ size: string }>`
+  background-color: ${(props) => getColorV8("grey", 100, props.theme)};
+  width: ${(props) => (props.size === "large" ? 72 : 40)}px !important;
+  height: ${(props) => (props.size === "large" ? 72 : 40)}px !important;
+
+  && > svg {
+    width: ${(props) => (props.size === "large" ? 28 : 16)}px;
+    height: ${(props) => (props.size === "large" ? 28 : 16)}px;
+    color: ${(props) => getColorV8("grey", 600, props.theme)};
+  }
+`;
+
+type ItemThumbnailProps = {
+  size: "medium" | "large";
+  url?: string | null;
+};
+
+const ItemThumbnail = ({ size, url }: ItemThumbnailProps) => {
+  return (
+    <StyledAvatar size={size} isSystem>
+      {url ? <img src={url} alt="" /> : <ShapesIcon aria-hidden="true" />}
+    </StyledAvatar>
+  );
+};
+
+export default ItemThumbnail;

--- a/src/modules/service-catalog/components/service-catalog-list/ServiceCatalogListItem.spec.tsx
+++ b/src/modules/service-catalog/components/service-catalog-list/ServiceCatalogListItem.spec.tsx
@@ -30,6 +30,7 @@ describe("ServiceCatalogListItem", () => {
     name: "Atl Nacional keyboard",
     description: "This is a keyboard from Atl Nacional",
     form_id: 456,
+    thumbnail_url: "",
   };
 
   const mockHelpCenterPath = "/hc/en-us";

--- a/src/modules/service-catalog/components/service-catalog-list/ServiceCatalogListItem.tsx
+++ b/src/modules/service-catalog/components/service-catalog-list/ServiceCatalogListItem.tsx
@@ -1,7 +1,7 @@
 import type { ServiceCatalogItem } from "../../data-types/ServiceCatalogItem";
 import styled from "styled-components";
 import { getColorV8 } from "@zendeskgarden/react-theming";
-import ItemThumbnail from "./ItemThumbnail";
+import { ItemThumbnail } from "../item-thumbnail/ItemThumbnail";
 
 const ItemContainer = styled.a`
   display: flex;

--- a/src/modules/service-catalog/components/service-catalog-list/ServiceCatalogListItem.tsx
+++ b/src/modules/service-catalog/components/service-catalog-list/ServiceCatalogListItem.tsx
@@ -54,12 +54,12 @@ const TextContainer = styled.div`
 const StyledAvatar = styled(Avatar)`
   background-color: ${(props) => getColorV8("grey", 100, props.theme)};
   margin-bottom: ${(props) => props.theme.space.sm};
-`;
 
-const StyledShapesIcon = styled(ShapesIcon)`
-  height: 16px !important;
-  width: 16px !important;
-  color: ${(props) => getColorV8("grey", 600, props.theme)} !important;
+  && > svg {
+    width: 16px;
+    height: 16px;
+    color: ${(props) => getColorV8("grey", 600, props.theme)};
+  }
 `;
 
 const ServiceCatalogListItem = ({
@@ -78,7 +78,7 @@ const ServiceCatalogListItem = ({
         {serviceItem.thumbnail_url ? (
           <img src={serviceItem.thumbnail_url} alt="" />
         ) : (
-          <StyledShapesIcon aria-hidden="true" />
+          <ShapesIcon aria-hidden="true" />
         )}
       </StyledAvatar>
       <TextContainer>

--- a/src/modules/service-catalog/components/service-catalog-list/ServiceCatalogListItem.tsx
+++ b/src/modules/service-catalog/components/service-catalog-list/ServiceCatalogListItem.tsx
@@ -51,20 +51,9 @@ const TextContainer = styled.div`
   color: ${(props) => props.theme.colors.foreground};
 `;
 
-const IconContainer = styled.div`
-  color: ${(props) => getColorV8("grey", 600, props.theme)};
-  background-color: ${(props) => getColorV8("grey", 100, props.theme)};
-  margin-bottom: ${(props) => props.theme.space.sm};
-  width: ${(props) => props.theme.space.xl};
-  height: ${(props) => props.theme.space.xl};
-  border-radius: ${({ theme }) => theme.borderRadii.md};
-  display: flex;
-  justify-content: center;
-  align-items: center;
-`;
-
 const StyledAvatar = styled(Avatar)`
   background-color: ${(props) => getColorV8("grey", 100, props.theme)};
+  margin-bottom: ${(props) => props.theme.space.sm};
 `;
 
 const StyledShapesIcon = styled(ShapesIcon)`
@@ -85,15 +74,13 @@ const ServiceCatalogListItem = ({
       data-testid="service-catalog-list-item-container"
       href={`${helpCenterPath}/services/${serviceItem.id}`}
     >
-      <IconContainer>
-        <StyledAvatar size="extraextrasmall" isSystem>
-          {serviceItem.thumbnail_url ? (
-            <img src={serviceItem.thumbnail_url} alt="" />
-          ) : (
-            <StyledShapesIcon aria-hidden="true" />
-          )}
-        </StyledAvatar>
-      </IconContainer>
+      <StyledAvatar size="medium" isSystem>
+        {serviceItem.thumbnail_url ? (
+          <img src={serviceItem.thumbnail_url} alt="" />
+        ) : (
+          <StyledShapesIcon aria-hidden="true" />
+        )}
+      </StyledAvatar>
       <TextContainer>
         <ItemTitle>{serviceItem.name}</ItemTitle>
         <ItemDescription>{serviceItem.description}</ItemDescription>

--- a/src/modules/service-catalog/components/service-catalog-list/ServiceCatalogListItem.tsx
+++ b/src/modules/service-catalog/components/service-catalog-list/ServiceCatalogListItem.tsx
@@ -2,6 +2,7 @@ import type { ServiceCatalogItem } from "../../data-types/ServiceCatalogItem";
 import ShapesIcon from "@zendeskgarden/svg-icons/src/16/shapes-fill.svg";
 import styled from "styled-components";
 import { getColorV8 } from "@zendeskgarden/react-theming";
+import { Avatar } from "@zendeskgarden/react-avatars";
 
 const ItemContainer = styled.a`
   display: flex;
@@ -56,8 +57,20 @@ const IconContainer = styled.div`
   margin-bottom: ${(props) => props.theme.space.sm};
   width: ${(props) => props.theme.space.xl};
   height: ${(props) => props.theme.space.xl};
-  text-align: center;
-  align-content: center;
+  border-radius: ${({ theme }) => theme.borderRadii.md};
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+const StyledAvatar = styled(Avatar)`
+  background-color: ${(props) => getColorV8("grey", 100, props.theme)};
+`;
+
+const StyledShapesIcon = styled(ShapesIcon)`
+  height: 16px !important;
+  width: 16px !important;
+  color: ${(props) => getColorV8("grey", 600, props.theme)} !important;
 `;
 
 const ServiceCatalogListItem = ({
@@ -73,7 +86,13 @@ const ServiceCatalogListItem = ({
       href={`${helpCenterPath}/services/${serviceItem.id}`}
     >
       <IconContainer>
-        <ShapesIcon />
+        <StyledAvatar size="extraextrasmall" isSystem>
+          {serviceItem.thumbnail_url ? (
+            <img src={serviceItem.thumbnail_url} alt="" />
+          ) : (
+            <StyledShapesIcon aria-hidden="true" />
+          )}
+        </StyledAvatar>
       </IconContainer>
       <TextContainer>
         <ItemTitle>{serviceItem.name}</ItemTitle>

--- a/src/modules/service-catalog/components/service-catalog-list/ServiceCatalogListItem.tsx
+++ b/src/modules/service-catalog/components/service-catalog-list/ServiceCatalogListItem.tsx
@@ -1,8 +1,7 @@
 import type { ServiceCatalogItem } from "../../data-types/ServiceCatalogItem";
-import ShapesIcon from "@zendeskgarden/svg-icons/src/16/shapes-fill.svg";
 import styled from "styled-components";
 import { getColorV8 } from "@zendeskgarden/react-theming";
-import { Avatar } from "@zendeskgarden/react-avatars";
+import ItemThumbnail from "./ItemThumbnail";
 
 const ItemContainer = styled.a`
   display: flex;
@@ -49,17 +48,7 @@ const TextContainer = styled.div`
   align-items: flex-start;
   gap: ${(props) => props.theme.space.xxs};
   color: ${(props) => props.theme.colors.foreground};
-`;
-
-const StyledAvatar = styled(Avatar)`
-  background-color: ${(props) => getColorV8("grey", 100, props.theme)};
-  margin-bottom: ${(props) => props.theme.space.sm};
-
-  && > svg {
-    width: 16px;
-    height: 16px;
-    color: ${(props) => getColorV8("grey", 600, props.theme)};
-  }
+  margin-top: ${(props) => props.theme.space.sm};
 `;
 
 const ServiceCatalogListItem = ({
@@ -74,13 +63,7 @@ const ServiceCatalogListItem = ({
       data-testid="service-catalog-list-item-container"
       href={`${helpCenterPath}/services/${serviceItem.id}`}
     >
-      <StyledAvatar size="medium" isSystem>
-        {serviceItem.thumbnail_url ? (
-          <img src={serviceItem.thumbnail_url} alt="" />
-        ) : (
-          <ShapesIcon aria-hidden="true" />
-        )}
-      </StyledAvatar>
+      <ItemThumbnail size="medium" url={serviceItem.thumbnail_url} />
       <TextContainer>
         <ItemTitle>{serviceItem.name}</ItemTitle>
         <ItemDescription>{serviceItem.description}</ItemDescription>

--- a/src/modules/service-catalog/data-types/ServiceCatalogItem.ts
+++ b/src/modules/service-catalog/data-types/ServiceCatalogItem.ts
@@ -3,4 +3,5 @@ export interface ServiceCatalogItem {
   name: string;
   description: string;
   form_id: number;
+  thumbnail_url: string;
 }

--- a/src/modules/service-catalog/hooks/useItemFormFields.spec.ts
+++ b/src/modules/service-catalog/hooks/useItemFormFields.spec.ts
@@ -8,6 +8,7 @@ describe("useItemFormFields", () => {
     name: "Test Item",
     description: "Test Description",
     form_id: 1,
+    thumbnail_url: "",
   };
 
   const textField = {


### PR DESCRIPTION
## Description

Display thunbnails in the Service list page - https://zendesk.atlassian.net/browse/GG-4327
Display thunbnails in the Service page - https://zendesk.atlassian.net/browse/GG-4328

I joined both tickets as they are very similar, using same components and BL. 

## Screenshots

### Design

Index:
<img width="667" alt="image" src="https://github.com/user-attachments/assets/e499f95e-657b-44ed-a62c-6ee0bab4c3f0" />

Show:
<img width="667" alt="image" src="https://github.com/user-attachments/assets/65ce829b-f5c9-4297-80af-c5f79e81202c" />

### Before

Index:
<img width="667" alt="image" src="https://github.com/user-attachments/assets/9c7a4c1a-27ba-4a92-9348-c0fa557466fe" />

Show:
<img width="667" alt="image" src="https://github.com/user-attachments/assets/29673dd4-397d-4537-8cb5-53cc6b033da1" />

### After

Index:
<img width="667" alt="image" src="https://github.com/user-attachments/assets/589f2336-b2fb-4f4c-8665-84cd2eb35ae1" />

Show with thumbnail:
<img width="667" alt="image" src="https://github.com/user-attachments/assets/c1212b1c-c15c-4264-997a-7fcf9fbd3468" />

Show with fallback icon:
<img width="667" alt="image" src="https://github.com/user-attachments/assets/81f7e097-35b1-441e-bf1a-550bdf62f5c8" />

## Checklist

- [x] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->