### PR TITLE
chore: restore missing translation strings for the new-request-form module

### DIFF
--- a/src/modules/new-request-form/translations/en-us.yml
+++ b/src/modules/new-request-form/translations/en-us.yml
@@ -187,3 +187,13 @@ parts:
       title: "Placeholder shown in combobox, {{label}} will be replaced by field label"
       screenshot: "https://drive.google.com/file/d/1nlnj_I-L7bkIs9Hn93Btrl8bh_HJfL6h/view?usp=drive_link"
       value: "Search {{label}}"
+  - translation:
+      key: "new-request-form.attachments.upload-failed-title"
+      title: "Title of the notification shown when the upload of an attachment failed"
+      screenshot: "https://drive.google.com/file/d/1HaYFIjlr89IWfu-HweJbTRjC23u3bLP-/view?usp=sharing"
+      value: "{{fileName}} upload failed"
+  - translation:
+      key: "new-request-form.attachments.error-separator"
+      title: "Separator between errors for the same file - please localize according to your language's punctuation rules"
+      screenshot: "https://drive.google.com/file/d/1z8VM5w7BLz9E5iJlAzX1mVuvv9Jz0XGL/view?usp=sharing"
+      value: "; "


### PR DESCRIPTION
## Description

For some reason, we are missing a couple of translation strings that are present on master on the beta branch. Probably, I did something wrong when I previously merged these changes from master.

Note for localization: these strings are already approved and present on the [master branch](https://github.com/zendesk/copenhagen_theme/blob/27b9a13281960ec5b7d9cd21cca7ee78bdfecec7/src/modules/new-request-form/translations/en-us.yml#L190). I am just bringing them here as well to avoid us deleting them when we merge this branch on master

## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->