### PR TITLE
chore: added missing tranlsation string for multi-level dropdown back option

### DIFF
--- a/src/modules/ticket-fields/translations/en-us.yml
+++ b/src/modules/ticket-fields/translations/en-us.yml
@@ -36,3 +36,8 @@ parts:
       title: "Additional label shown above the credit card field, informing the user that only the last 4 digits are required."
       screenshot: "https://drive.google.com/file/d/13Pz2p5q7FHX9FKT6MUR6Sg5vWy55X0kP/view?usp=drive_link"
       value: "(Last 4 digits)"
+  - translation:
+      key: "cph-theme-ticket-fields.dropdown.back-option-label"
+      title: "Label for the back option in a multi-level dropdown, used to return to the previous menu."
+      screenshot: "https://drive.google.com/file/d/1u_eLJAGP8bGvQE7cteCQyCNJT13_9dOu/view?usp=drive_link"
+      value: "Back"


### PR DESCRIPTION
## Description

This PR adds a translation string that was missing, and it will be used in #655 when translations are ready

## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->