### PR TITLE
fix: apply word-break to prevent overflow

### DIFF
--- a/src/modules/service-catalog/components/service-catalog-item/CollapsibleDescription.tsx
+++ b/src/modules/service-catalog/components/service-catalog-item/CollapsibleDescription.tsx
@@ -13,7 +13,6 @@ const DescriptionWrapper = styled.div`
     ${(props) => getColorV8("grey", 300, props.theme)};
   padding-bottom: ${(props) => props.theme.space.lg};
   margin-inline-end: ${(props) => props.theme.space.xl};
-  word-break: break-all;
 
   @media (max-width: ${(props) => props.theme.breakpoints.md}) {
     margin-inline-end: 0;
@@ -23,6 +22,8 @@ const DescriptionWrapper = styled.div`
 const ItemTitle = styled(XXXL)`
   font-weight: ${(props) => props.theme.fontWeights.semibold};
   margin-bottom: 0;
+  overflow-wrap: break-word;
+  max-width: 100%;
 `;
 
 const CollapsibleText = styled.div<{ isCollapsed: boolean }>`
@@ -33,6 +34,7 @@ const CollapsibleText = styled.div<{ isCollapsed: boolean }>`
   overflow: hidden;
   margin-top: ${(props) => props.theme.space.md};
   padding-inline-end: ${(props) => props.theme.space.xl};
+  overflow-wrap: break-word;
 
   @media (max-width: ${(props) => props.theme.breakpoints.md}) {
     padding-inline-end: 0;

--- a/src/modules/service-catalog/components/service-catalog-item/ItemRequestForm.tsx
+++ b/src/modules/service-catalog/components/service-catalog-item/ItemRequestForm.tsx
@@ -72,6 +72,7 @@ const LeftColumn = styled.div`
   flex-direction: column;
   gap: ${(props) => props.theme.space.lg};
   margin-inline-end: ${(props) => props.theme.space.xl};
+  min-width: 0;
 
   @media (max-width: ${(props) => props.theme.breakpoints.md}) {
     margin-inline-end: 0;


### PR DESCRIPTION
## Description

On the Employee SC Item page, the title was not truncated, which caused layout issues when long words were used

## References

https://zendesk.atlassian.net/browse/GG-4479

## Changes

The issue was caused by long unbroken words not fitting within the container, which led to layout problems. To resolve this the `word-break: break-all` property was applied to allow words to break and wrap properly across lines.

## Screenshots

### Before 
<img width="1467" height="817" alt="Screenshot 2025-07-28 at 17 39 22" src="https://github.com/user-attachments/assets/7c4b961f-fe79-4676-80f5-d549f70d9b06" />

### After
<img width="1507" height="811" alt="Screenshot 2025-07-28 at 17 39 37" src="https://github.com/user-attachments/assets/4ab0e7aa-838d-41f7-81d7-f952e22bff1c" />

## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->