### PR TITLE
fix: hide deactivated Fields on the ServiceCatalog Item page

### DIFF
--- a/src/modules/service-catalog/hooks/useItemFormFields.tsx
+++ b/src/modules/service-catalog/hooks/useItemFormFields.tsx
@@ -97,6 +97,7 @@ const fetchTicketFields = async (
         ticketField &&
         ticketField.type !== "subject" &&
         ticketField.type !== "description" &&
+        ticketField.active !== false &&
         ticketField.editable_in_portal
       ) {
         if (


### PR DESCRIPTION
## Description

Deactivated CustomField is visible on Employee SC Item page

## Screenshots

before Field deactivation:

<img width="1226" height="525" alt="image" src="https://github.com/user-attachments/assets/62abd80f-409b-446e-9c5b-ddf9e73c3458" />

Field deactivation:
<img width="1065" height="435" alt="image" src="https://github.com/user-attachments/assets/505adeb3-0ccf-4261-aa87-68b08d20b62b" />

After Field deactivation:
<img width="1229" height="423" alt="image" src="https://github.com/user-attachments/assets/58fd74ef-1a0a-49a3-b27d-87b4c8655add" />


## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->