### PR TITLE
[PDSC-75] - Validation on SC request does not refresh

### DIFF
--- a/src/modules/service-catalog/components/service-catalog-item/ServiceCatalogItem.tsx
+++ b/src/modules/service-catalog/components/service-catalog-item/ServiceCatalogItem.tsx
@@ -113,9 +113,7 @@ export function ServiceCatalogItem({
           const errorField = invalidFieldErrors.find(
             (errorField) => errorField.field_key === field.id
           );
-          return errorField
-            ? { ...field, error: errorField.description }
-            : field;
+          return { ...field, error: errorField?.description || null };
         });
         setRequestFields(updatedFields);
       } else {


### PR DESCRIPTION
## Description

Fixed error display in SC Item form — on submit, only current field errors are shown, and errors for corrected fields are cleared.

## Screenshots

Before: 

https://github.com/user-attachments/assets/f390dc67-058e-4660-8498-d9b348fbf7d9

After:


https://github.com/user-attachments/assets/40c7dec4-fb7e-4af6-9c36-c633f52dba86


## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->