### PR TITLE
[KIAW-1463] Change aria-label for subfilters menu button 

### DIFF
--- a/templates/search_results.hbs
+++ b/templates/search_results.hbs
@@ -78,7 +78,7 @@
           {{#is current_filter.identifier 'community'}}
             <h3 class="collapsible-sidebar-title sidenav-title">{{t 'filter_by_topic'}}</h3>
           {{/is}}
-          <button type="button" class="collapsible-sidebar-toggle" aria-expanded="false" aria-label="{{t 'search_result_subfilter_menu'}}">
+          <button type="button" class="collapsible-sidebar-toggle" aria-expanded="false" aria-label="{{#is current_filter.identifier 'knowledge_base'}}{{t 'search_result_articles_menu'}}{{else}}{{#is current_filter.identifier 'community'}}{{t 'search_result_posts_menu'}}{{else}}{{t 'search_result_subfilter_menu'}}{{/is}}{{/is}}">
             <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" focusable="false" viewBox="0 0 12 12" aria-hidden="true" class="collapsible-sidebar-toggle-icon chevron-icon">
               <path fill="none" stroke="currentColor" stroke-linecap="round" d="M3 4.5l2.6 2.6c.2.2.5.2.7 0L9 4.5"/>
             </svg>


### PR DESCRIPTION
## Description

<!-- a summary of the changes introduced by this PR and the motivation behind them -->
Accessibility change: change aria-label for subfilter menu to be aligned with the visible text label for posts and articles subfilters. 

https://zendesk.atlassian.net/browse/KIAW-1463
## Screenshots

<!-- (optional) when applicable, please include some screenshots or gifs that illustrate the changes -->
<img width="551" height="37" alt="Screenshot 2025-09-23 at 14 15 58" src="https://github.com/user-attachments/assets/48fffd94-fb80-4c13-b89c-a8b51ac93b75" />
<img width="544" height="37" alt="Screenshot 2025-09-23 at 14 16 58" src="https://github.com/user-attachments/assets/10a72800-acd1-43e6-9d3a-5232fe20f840" />


## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->