### PR TITLE
style: make sure code snippet is always aligned ltr

### DIFF
--- a/style.css
+++ b/style.css
@@ -1776,6 +1776,7 @@ ul {
   padding: 10px 15px;
   overflow: auto;
   white-space: pre;
+  direction: ltr;
 }
 .article-body blockquote {
   border-left: 1px solid #ddd;
@@ -2245,6 +2246,7 @@ ul {
   padding: 10px 15px;
   overflow: auto;
   white-space: pre;
+  direction: ltr;
 }
 .comment-body blockquote {
   border-left: 1px solid #ddd;
@@ -2812,6 +2814,7 @@ ul {
   padding: 10px 15px;
   overflow: auto;
   white-space: pre;
+  direction: ltr;
 }
 .post-body blockquote {
   border-left: 1px solid #ddd;
@@ -4822,6 +4825,7 @@ zd-summary-block {
   padding: 10px 15px;
   overflow: auto;
   white-space: pre;
+  direction: ltr;
 }
 .service-catalog-description blockquote {
   border-left: 1px solid #ddd;

--- a/styles/_mixins.scss
+++ b/styles/_mixins.scss
@@ -164,6 +164,7 @@
     padding: 10px 15px;
     overflow: auto;
     white-space: pre;
+    direction: ltr;
   }
 
   blockquote {


### PR DESCRIPTION
## Description

<!-- a summary of the changes introduced by this PR and the motivation behind them -->
Make sure code snippets are always aligned `ltr` even if we are in a `rtl` language like Arabic.

Jira: https://zendesk.atlassian.net/browse/OH-4030
## Screenshots

(incorrect)
<img width="1387" height="817" alt="incorrect_alignment" src="https://github.com/user-attachments/assets/b760a6cd-639d-4b24-ad8b-f4010cee70a4" />

(correct)
<img width="1326" height="760" alt="correct_alignment" src="https://github.com/user-attachments/assets/d1fcb305-74d6-422d-945d-bf52a7c51370" />


## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->