### PR TITLE
fix: include shared baseLocale translations in ApprovalRequest loader

### DIFF
--- a/src/modules/approval-requests/renderApprovalRequest.tsx
+++ b/src/modules/approval-requests/renderApprovalRequest.tsx
@@ -21,6 +21,7 @@ export async function renderApprovalRequest(
   initI18next(baseLocale);
   await loadTranslations(baseLocale, [
     () => import(`./translations/locales/${baseLocale}.json`),
+    () => import(`../shared/translations/locales/${baseLocale}.json`),
   ]);
 
   render(

--- a/src/modules/approval-requests/renderApprovalRequestList.tsx
+++ b/src/modules/approval-requests/renderApprovalRequestList.tsx
@@ -20,6 +20,7 @@ export async function renderApprovalRequestList(
   initI18next(baseLocale);
   await loadTranslations(baseLocale, [
     () => import(`./translations/locales/${baseLocale}.json`),
+    () => import(`../shared/translations/locales/${baseLocale}.json`),
   ]);
 
   render(


### PR DESCRIPTION
## Description

This PR updates renderApprovalRequest and renderApprovalRequestList functions to ensure that translations from the shared locales are also loaded. 

## References

- https://zendesk.atlassian.net/browse/PDSC-109

## Screenshots

<img width="1258" height="799" alt="Screenshot 2025-09-15 at 17 08 11" src="https://github.com/user-attachments/assets/0029a660-5817-48f5-b140-5eb7a7b114dd" />

## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->