### PR TITLE
Fix translations on windows

### DIFF
--- a/bin/update-modules-translations.mjs
+++ b/bin/update-modules-translations.mjs
@@ -8,6 +8,7 @@ import { resolve } from "node:path";
 import { glob } from "glob";
 import { load } from "js-yaml";
 import { parseArgs } from "node:util";
+import { sep as filePathSeparator } from "path";
 
 const BASE_URL = `https://static.zdassets.com/translations`;
 
@@ -67,7 +68,7 @@ async function getModules() {
   for (const file of files) {
     const content = await readFile(file);
     const parsedContent = load(content);
-    const moduleName = file.split("/")[2];
+    const moduleName = file.split(filePathSeparator)[2];
     result[moduleName] = parsedContent.packages[0];
   }
 

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -10,11 +10,21 @@ import terser from "@rollup/plugin-terser";
 import svgr from "@svgr/rollup";
 import { generateImportMap } from "./generate-import-map.mjs";
 import { defineConfig } from "rollup";
+import { sep as filePathSeparator } from "path";
 
 const fileNames = "[name]-bundle.js";
 const isProduction = process.env.NODE_ENV === "production";
-const TRANSLATION_FILE_REGEX =
-  /src\/modules\/(.+?)\/translations\/locales\/.+?\.json$/;
+const TRANSLATION_FILE_REGEX = ( // IIFE
+  () => {
+    // escape the file path separator if it's a backslash (Windows)
+    const escapedSeparator = filePathSeparator.replace("\\", "\\\\");
+
+    return new RegExp(
+      ["src", "modules", "(.+?)", "translations", "locales", ".+?\.json$"].join(escapedSeparator)
+    );
+  }
+)();
+
 
 export default defineConfig([
   // Configuration for bundling the script.js file


### PR DESCRIPTION
## Description

When developing on windows multiple problems arose because the theme did not seem to build. 
The issue with `yarn start` was found on https://support.zendesk.com/hc/en-us/requests/13811934. 
So that may already be in Zendesk's backlog/workflow somewhere. I've included my implementation of the fix in this PR. 
Another issue occurred when I ran `i18n:update-translations` that's fixed here. See the commit message for details. 

I wanted Zendesk to be aware of the problem and my fixes to hopefully save them some time. Here it is. 

## Screenshots

## Checklist

I do not have a mobile device to test on and cannot test on all browsers. So I will not be finishing the checklist. 

- [x] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->