### PR TITLE
feat: add search to dropdown and multi-select fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,8 @@
   },
   "resolutions": {
     "@types/react": "^17.x",
-    "nwsapi": "^2.2.20"
+    "nwsapi": "^2.2.20",
+    "@zendeskgarden/container-utilities": "^1.0.0"
   },
   "commitlint": {
     "extends": [

--- a/src/modules/ticket-fields/fields/HighlightMatch.tsx
+++ b/src/modules/ticket-fields/fields/HighlightMatch.tsx
@@ -1,0 +1,37 @@
+interface HighlightMatchProps {
+  text: string;
+  searchValue: string;
+}
+
+/**
+ * Highlights the matching portion of text by making it bold.
+ * Case-insensitive matching.
+ */
+export function HighlightMatch({
+  text,
+  searchValue,
+}: HighlightMatchProps): JSX.Element {
+  if (!searchValue) {
+    return <span>{text}</span>;
+  }
+
+  const lowerText = text.toLowerCase();
+  const lowerSearch = searchValue.toLowerCase();
+  const index = lowerText.indexOf(lowerSearch);
+
+  if (index === -1) {
+    return <span>{text}</span>;
+  }
+
+  const before = text.slice(0, index);
+  const match = text.slice(index, index + searchValue.length);
+  const after = text.slice(index + searchValue.length);
+
+  return (
+    <span>
+      {before}
+      <strong>{match}</strong>
+      {after}
+    </span>
+  );
+}

--- a/src/modules/ticket-fields/fields/MultiSelect.test.tsx
+++ b/src/modules/ticket-fields/fields/MultiSelect.test.tsx
@@ -1,0 +1,255 @@
+import { render } from "../../test/render";
+import { screen, waitFor } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { MultiSelect } from "./MultiSelect";
+import type { TicketFieldObject } from "../data-types/TicketFieldObject";
+
+describe("MultiSelect", () => {
+  const mockOnChange = jest.fn();
+
+  const baseField: TicketFieldObject = {
+    id: 1,
+    name: "test_multiselect",
+    label: "Test MultiSelect",
+    type: "multiselect",
+    value: [],
+    error: null,
+    required: false,
+    description: "",
+    options: [
+      { name: "Option 1", value: "option_1" },
+      { name: "Option 2", value: "option_2" },
+      { name: "Option 3", value: "option_3" },
+      { name: "Option 4", value: "option_4" },
+    ],
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  describe("Rendering", () => {
+    it("renders combobox with accessible label", () => {
+      render(<MultiSelect field={baseField} onChange={mockOnChange} />);
+
+      expect(
+        screen.getByRole("combobox", { name: /test multiselect/i })
+      ).toBeInTheDocument();
+    });
+
+    it("marks field as required when required prop is true", () => {
+      const requiredField = { ...baseField, required: true };
+      render(<MultiSelect field={requiredField} onChange={mockOnChange} />);
+
+      const combobox = screen.getByRole("combobox");
+      expect(combobox).toHaveAttribute("aria-required", "true");
+    });
+
+    it("displays description hint", () => {
+      const fieldWithDescription = {
+        ...baseField,
+        description: "<p>Select multiple options</p>",
+      };
+      render(
+        <MultiSelect field={fieldWithDescription} onChange={mockOnChange} />
+      );
+
+      expect(screen.getByText("Select multiple options")).toBeInTheDocument();
+    });
+
+    it("displays error message with error validation", () => {
+      const fieldWithError = {
+        ...baseField,
+        error: "At least one option is required",
+      };
+      render(<MultiSelect field={fieldWithError} onChange={mockOnChange} />);
+
+      expect(
+        screen.getByText("At least one option is required")
+      ).toBeInTheDocument();
+    });
+
+    it("renders hidden inputs for selected values for form submission", () => {
+      const fieldWithValues = {
+        ...baseField,
+        value: ["option_1", "option_2"],
+      };
+      const { container } = render(
+        <MultiSelect field={fieldWithValues} onChange={mockOnChange} />
+      );
+
+      const hiddenInputs = container.querySelectorAll(
+        'input[type="hidden"][name="test_multiselect[]"]'
+      );
+      expect(hiddenInputs).toHaveLength(2);
+      expect(hiddenInputs[0]).toHaveValue("option_1");
+      expect(hiddenInputs[1]).toHaveValue("option_2");
+    });
+  });
+
+  describe("User Interactions", () => {
+    it("opens dropdown when clicking on the combobox", async () => {
+      const user = userEvent.setup({ delay: null });
+      render(<MultiSelect field={baseField} onChange={mockOnChange} />);
+
+      const combobox = screen.getByRole("combobox");
+      await user.click(combobox);
+
+      await waitFor(() => {
+        expect(screen.getByRole("option", { name: "Option 1" })).toBeVisible();
+      });
+    });
+
+    it("selects an option and calls onChange", async () => {
+      const user = userEvent.setup({ delay: null });
+      render(<MultiSelect field={baseField} onChange={mockOnChange} />);
+
+      const combobox = screen.getByRole("combobox");
+      await user.click(combobox);
+
+      const option1 = await screen.findByRole("option", { name: "Option 1" });
+      await user.click(option1);
+
+      expect(mockOnChange).toHaveBeenCalledWith(["option_1"]);
+    });
+
+    it("allows selecting multiple options", async () => {
+      const user = userEvent.setup({ delay: null });
+      render(<MultiSelect field={baseField} onChange={mockOnChange} />);
+
+      const combobox = screen.getByRole("combobox");
+      await user.click(combobox);
+
+      const option1 = await screen.findByRole("option", { name: "Option 1" });
+      await user.click(option1);
+
+      await user.click(combobox);
+      const option2 = await screen.findByRole("option", { name: "Option 2" });
+      await user.click(option2);
+
+      expect(mockOnChange).toHaveBeenLastCalledWith(["option_1", "option_2"]);
+    });
+
+    it("filters options when typing in search", async () => {
+      const user = userEvent.setup({ delay: null });
+      render(<MultiSelect field={baseField} onChange={mockOnChange} />);
+
+      const combobox = screen.getByRole("combobox");
+      await user.click(combobox);
+      await user.type(combobox, "Option 2");
+
+      jest.advanceTimersByTime(300); // debounce delay
+
+      await waitFor(() => {
+        expect(screen.getByRole("option", { name: /option 2/i })).toBeVisible();
+        expect(
+          screen.queryByRole("option", { name: "Option 1" })
+        ).not.toBeInTheDocument();
+      });
+    });
+
+    it("shows 'no matches found' when search has no results", async () => {
+      const user = userEvent.setup({ delay: null });
+      render(<MultiSelect field={baseField} onChange={mockOnChange} />);
+
+      const combobox = screen.getByRole("combobox");
+      await user.click(combobox);
+      await user.type(combobox, "NonExistent");
+
+      jest.advanceTimersByTime(300); // debounce delay
+
+      await waitFor(() => {
+        expect(screen.getByText("No matches found")).toBeInTheDocument();
+      });
+    });
+
+    it("highlights matching text in search results", async () => {
+      const user = userEvent.setup({ delay: null });
+      render(<MultiSelect field={baseField} onChange={mockOnChange} />);
+
+      const combobox = screen.getByRole("combobox");
+      await user.click(combobox);
+      await user.type(combobox, "2");
+
+      jest.advanceTimersByTime(300); // debounce delay
+
+      await waitFor(() => {
+        const option = screen.getByRole("option", { name: /option 2/i });
+        const strongElement = option.querySelector("strong");
+        expect(strongElement).toHaveTextContent("2");
+      });
+    });
+  });
+
+  describe("Nested Options", () => {
+    const nestedField: TicketFieldObject = {
+      ...baseField,
+      options: [
+        { name: "Cameras::DSLR::Professional", value: "cameras_dslr_pro" },
+        { name: "Cameras::DSLR::Consumer", value: "cameras_dslr_consumer" },
+        { name: "Lenses", value: "lenses" },
+      ],
+    };
+
+    it("navigates into nested groups", async () => {
+      const user = userEvent.setup({ delay: null });
+      render(<MultiSelect field={nestedField} onChange={mockOnChange} />);
+
+      const combobox = screen.getByRole("combobox");
+      await user.click(combobox);
+
+      // Click on "Cameras" group to navigate into it
+      const camerasGroup = await screen.findByRole("option", {
+        name: "Cameras",
+      });
+      await user.click(camerasGroup);
+
+      // Should now see DSLR subgroup
+      await waitFor(() => {
+        expect(
+          screen.getByRole("option", { name: "DSLR" })
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("searches nested options and shows full path", async () => {
+      const user = userEvent.setup({ delay: null });
+      render(<MultiSelect field={nestedField} onChange={mockOnChange} />);
+
+      const combobox = screen.getByRole("combobox");
+      await user.click(combobox);
+      await user.type(combobox, "Professional");
+
+      jest.advanceTimersByTime(300); // debounce delay
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("option", { name: /cameras > dslr > professional/i })
+        ).toBeVisible();
+      });
+    });
+
+    it("renders pre-selected nested options with hidden inputs", () => {
+      const fieldWithNestedValues = {
+        ...nestedField,
+        value: ["cameras_dslr_pro", "lenses"],
+      };
+      const { container } = render(
+        <MultiSelect field={fieldWithNestedValues} onChange={mockOnChange} />
+      );
+
+      const hiddenInputs = container.querySelectorAll(
+        'input[type="hidden"][name="test_multiselect[]"]'
+      );
+      expect(hiddenInputs).toHaveLength(2);
+      expect(hiddenInputs[0]).toHaveValue("cameras_dslr_pro");
+      expect(hiddenInputs[1]).toHaveValue("lenses");
+    });
+  });
+});

--- a/src/modules/ticket-fields/fields/MultiSelect.tsx
+++ b/src/modules/ticket-fields/fields/MultiSelect.tsx
@@ -6,8 +6,11 @@ import {
   OptGroup,
 } from "@zendeskgarden/react-dropdowns";
 import { Span } from "@zendeskgarden/react-typography";
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect, useCallback, useMemo } from "react";
+import { useTranslation } from "react-i18next";
 import { useNestedOptions } from "./useNestedOptions";
+import { useFieldSearch } from "./useFieldSearch";
+import { HighlightMatch } from "./HighlightMatch";
 import type { TicketFieldObject } from "../data-types/TicketFieldObject";
 
 interface MultiSelectProps {
@@ -19,17 +22,47 @@ export function MultiSelect({
   field,
   onChange,
 }: MultiSelectProps): JSX.Element {
-  const { label, options, error, value, name, required, description } = field;
+  const {
+    label,
+    options: fieldOptions,
+    error,
+    value,
+    name,
+    required,
+    description,
+  } = field;
+  const { t } = useTranslation();
   const { currentGroup, isGroupIdentifier, setCurrentGroupByIdentifier } =
     useNestedOptions({
-      options,
+      options: fieldOptions,
       hasEmptyOption: false,
     });
 
-  const [selectedValues, setSelectValues] = useState<string[]>(
+  const [selectedValues, setSelectedValues] = useState<string[]>(
     (value as string[]) || []
   );
+  const [isExpanded, setIsExpanded] = useState(false);
   const wrapperRef = useRef<HTMLDivElement>(null);
+
+  const {
+    inputValue,
+    isSearching,
+    filteredOptions,
+    optionsMap,
+    handleInputChange,
+    resetSearch,
+  } = useFieldSearch({
+    fieldOptions: fieldOptions || [],
+    currentGroupOptions: currentGroup.options,
+  });
+
+  const noResultsOption = {
+    name: t(
+      "cph-theme-ticket-fields.search-field.no-matches-found",
+      "No matches found"
+    ),
+    id: "no-results",
+  };
 
   useEffect(() => {
     if (wrapperRef.current && required) {
@@ -44,12 +77,46 @@ export function MultiSelect({
 
       if (isGroupIdentifier(lastSelectedItem)) {
         setCurrentGroupByIdentifier(lastSelectedItem);
+        resetSearch();
       } else {
-        setSelectValues(changes.selectionValue as string[]);
+        setSelectedValues(changes.selectionValue as string[]);
         onChange(changes.selectionValue as string[]);
       }
     }
+
+    if (changes.isExpanded !== undefined) {
+      setIsExpanded(changes.isExpanded);
+      if (!changes.isExpanded) {
+        resetSearch();
+      }
+    }
+
+    if (changes.inputValue !== undefined) {
+      handleInputChange(changes.inputValue);
+    }
   };
+
+  const handleFocus = useCallback(
+    (event: React.FocusEvent<HTMLInputElement>) => {
+      // Position cursor at the end of the text
+      const input = event.target;
+      const length = input.value.length;
+      input.setSelectionRange(length, length);
+    },
+    []
+  );
+
+  const visibleOptionValues = useMemo(() => {
+    if (isSearching) {
+      return new Set(filteredOptions.map((o) => o.value));
+    }
+    return new Set(currentGroup.options.map((o) => o.value));
+  }, [isSearching, filteredOptions, currentGroup.options]);
+
+  const hiddenSelectedValues = useMemo(
+    () => selectedValues.filter((val) => !visibleOptionValues.has(val)),
+    [selectedValues, visibleOptionValues]
+  );
 
   return (
     <Field>
@@ -71,17 +138,60 @@ export function MultiSelect({
       <Combobox
         ref={wrapperRef}
         isMultiselectable
-        inputProps={{ required }}
-        isEditable={false}
+        inputProps={{ required, onFocus: handleFocus }}
+        isAutocomplete
         validation={error ? "error" : undefined}
         onChange={handleChange}
+        onFocus={handleFocus}
         selectionValue={selectedValues}
+        inputValue={inputValue}
         maxHeight="auto"
+        placeholder={
+          isExpanded
+            ? t(
+                "cph-theme-ticket-fields.search-field.placeholder",
+                "Search {{label}}",
+                { label }
+              )
+            : ""
+        }
+        isExpanded={isExpanded}
       >
-        {currentGroup.type === "SubGroup" && (
+        {hiddenSelectedValues.map((val) => (
+          <Option
+            key={val}
+            value={val}
+            label={optionsMap.get(val) || val}
+            isHidden
+          />
+        ))}
+
+        {!isSearching && currentGroup.type === "SubGroup" && (
           <Option {...currentGroup.backOption} />
         )}
-        {currentGroup.type === "SubGroup" ? (
+
+        {isSearching ? (
+          <>
+            {inputValue.length > 0 && filteredOptions.length === 0 && (
+              <Option
+                isDisabled
+                key={noResultsOption.id}
+                value={noResultsOption.id}
+              >
+                {noResultsOption.name}
+              </Option>
+            )}
+            {filteredOptions.map((option) => (
+              <Option
+                key={option.value}
+                value={option.value}
+                label={option.label}
+              >
+                <HighlightMatch text={option.label} searchValue={inputValue} />
+              </Option>
+            ))}
+          </>
+        ) : currentGroup.type === "SubGroup" ? (
           <OptGroup aria-label={currentGroup.name}>
             {currentGroup.options.map((option) => (
               <Option key={option.value} {...option}>

--- a/src/modules/ticket-fields/fields/Tagger.test.tsx
+++ b/src/modules/ticket-fields/fields/Tagger.test.tsx
@@ -1,0 +1,316 @@
+import { render } from "../../test/render";
+import { screen, waitFor } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { Tagger } from "./Tagger";
+import type { TicketFieldObject } from "../data-types/TicketFieldObject";
+
+describe("Tagger", () => {
+  const mockOnChange = jest.fn();
+
+  const baseField: TicketFieldObject = {
+    id: 1,
+    name: "test_tagger",
+    label: "Test Tagger",
+    type: "tagger",
+    value: "",
+    error: null,
+    required: false,
+    description: "",
+    options: [
+      { name: "Option 1", value: "option_1" },
+      { name: "Option 2", value: "option_2" },
+      { name: "Option 3", value: "option_3" },
+      { name: "Option 4", value: "option_4" },
+    ],
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  describe("Rendering", () => {
+    it("renders combobox with accessible label", () => {
+      render(<Tagger field={baseField} onChange={mockOnChange} />);
+
+      expect(
+        screen.getByRole("combobox", { name: /test tagger/i })
+      ).toBeInTheDocument();
+    });
+
+    it("marks field as required when required prop is true", () => {
+      const requiredField = { ...baseField, required: true };
+      render(<Tagger field={requiredField} onChange={mockOnChange} />);
+
+      const combobox = screen.getByRole("combobox");
+      expect(combobox).toHaveAttribute("aria-required", "true");
+    });
+
+    it("displays description hint", () => {
+      const fieldWithDescription = {
+        ...baseField,
+        description: "<p>Select an option</p>",
+      };
+      render(<Tagger field={fieldWithDescription} onChange={mockOnChange} />);
+
+      expect(screen.getByText("Select an option")).toBeInTheDocument();
+    });
+
+    it("displays error message with error validation", () => {
+      const fieldWithError = {
+        ...baseField,
+        error: "This field is required",
+      };
+      render(<Tagger field={fieldWithError} onChange={mockOnChange} />);
+
+      expect(screen.getByText("This field is required")).toBeInTheDocument();
+    });
+
+    it("renders hidden input with empty value when no selection", () => {
+      const { container } = render(
+        <Tagger field={baseField} onChange={mockOnChange} />
+      );
+
+      const hiddenInput = container.querySelector(
+        'input[type="hidden"][name="test_tagger"]'
+      );
+      expect(hiddenInput).toHaveValue("");
+    });
+
+    it("renders hidden input with selected value for form submission", () => {
+      const fieldWithValue = {
+        ...baseField,
+        value: "option_2",
+      };
+      const { container } = render(
+        <Tagger field={fieldWithValue} onChange={mockOnChange} />
+      );
+
+      const hiddenInput = container.querySelector(
+        'input[type="hidden"][name="test_tagger"]'
+      );
+      expect(hiddenInput).toHaveValue("option_2");
+    });
+
+    it("renders with empty option by default", async () => {
+      render(<Tagger field={baseField} onChange={mockOnChange} />);
+
+      const combobox = screen.getByRole("combobox");
+      await userEvent.click(combobox);
+
+      await waitFor(() => {
+        expect(screen.getByRole("option", { name: "-" })).toBeVisible();
+      });
+    });
+  });
+
+  describe("User Interactions", () => {
+    it("opens dropdown when clicking on the combobox", async () => {
+      render(<Tagger field={baseField} onChange={mockOnChange} />);
+
+      const combobox = screen.getByRole("combobox");
+      await userEvent.click(combobox);
+
+      await waitFor(() => {
+        expect(screen.getByRole("option", { name: "Option 1" })).toBeVisible();
+      });
+    });
+
+    it("selects an option and calls onChange", async () => {
+      render(<Tagger field={baseField} onChange={mockOnChange} />);
+
+      const combobox = screen.getByRole("combobox");
+      await userEvent.click(combobox);
+
+      const option2 = await screen.findByRole("option", { name: "Option 2" });
+      await userEvent.click(option2);
+
+      expect(mockOnChange).toHaveBeenCalledWith("option_2");
+    });
+
+    it("filters options when typing in search", async () => {
+      render(<Tagger field={baseField} onChange={mockOnChange} />);
+
+      const combobox = screen.getByRole("combobox");
+      await userEvent.click(combobox);
+      await userEvent.type(combobox, "Option 3");
+
+      jest.advanceTimersByTime(300); // debounce delay
+
+      await waitFor(() => {
+        expect(screen.getByRole("option", { name: /option 3/i })).toBeVisible();
+        expect(
+          screen.queryByRole("option", { name: "Option 1" })
+        ).not.toBeInTheDocument();
+      });
+    });
+
+    it("shows 'no matches found' when search has no results", async () => {
+      render(<Tagger field={baseField} onChange={mockOnChange} />);
+
+      const combobox = screen.getByRole("combobox");
+      await userEvent.click(combobox);
+      await userEvent.type(combobox, "NonExistent");
+
+      jest.advanceTimersByTime(300); // debounce delay
+
+      await waitFor(() => {
+        expect(screen.getByText("No matches found")).toBeInTheDocument();
+      });
+    });
+
+    it("highlights matching text in search results", async () => {
+      render(<Tagger field={baseField} onChange={mockOnChange} />);
+
+      const combobox = screen.getByRole("combobox");
+      await userEvent.click(combobox);
+      await userEvent.type(combobox, "3");
+
+      jest.advanceTimersByTime(300); // debounce delay
+
+      await waitFor(() => {
+        const option = screen.getByRole("option", { name: /option 3/i });
+        const strongElement = option.querySelector("strong");
+        expect(strongElement).toHaveTextContent("3");
+      });
+    });
+
+    it("allows clearing selection by selecting empty option", async () => {
+      const fieldWithValue = {
+        ...baseField,
+        value: "option_2",
+      };
+      render(<Tagger field={fieldWithValue} onChange={mockOnChange} />);
+
+      const combobox = screen.getByRole("combobox");
+      await userEvent.click(combobox);
+
+      const emptyOption = await screen.findByRole("option", { name: "-" });
+      await userEvent.click(emptyOption);
+
+      expect(mockOnChange).toHaveBeenCalledWith("");
+    });
+  });
+
+  describe("Nested Options", () => {
+    const nestedField: TicketFieldObject = {
+      ...baseField,
+      options: [
+        { name: "Cameras::DSLR::Professional", value: "cameras_dslr_pro" },
+        { name: "Cameras::DSLR::Consumer", value: "cameras_dslr_consumer" },
+        { name: "Lenses", value: "lenses" },
+      ],
+    };
+
+    it("navigates into nested groups", async () => {
+      render(<Tagger field={nestedField} onChange={mockOnChange} />);
+
+      const combobox = screen.getByRole("combobox");
+      await userEvent.click(combobox);
+
+      // Click on "Cameras" group to navigate into it
+      const camerasGroup = await screen.findByRole("option", {
+        name: "Cameras",
+      });
+      await userEvent.click(camerasGroup);
+
+      // Should now see DSLR subgroup
+      await waitFor(() => {
+        expect(
+          screen.getByRole("option", { name: "DSLR" })
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("navigates back from nested group", async () => {
+      render(<Tagger field={nestedField} onChange={mockOnChange} />);
+
+      const combobox = screen.getByRole("combobox");
+      await userEvent.click(combobox);
+
+      // Navigate into Cameras group
+      const camerasGroup = await screen.findByRole("option", {
+        name: "Cameras",
+      });
+      await userEvent.click(camerasGroup);
+
+      // Click back button
+      const backOption = await screen.findByRole("option", { name: "Back" });
+      await userEvent.click(backOption);
+
+      // Should be back at root level
+      await waitFor(() => {
+        expect(
+          screen.getByRole("option", { name: "Cameras" })
+        ).toBeInTheDocument();
+        expect(
+          screen.getByRole("option", { name: "Lenses" })
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("searches nested options and shows full path", async () => {
+      render(<Tagger field={nestedField} onChange={mockOnChange} />);
+
+      const combobox = screen.getByRole("combobox");
+      await userEvent.click(combobox);
+      await userEvent.type(combobox, "Consumer");
+
+      jest.advanceTimersByTime(300); // debounce delay
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("option", { name: /cameras > dslr > consumer/i })
+        ).toBeVisible();
+      });
+    });
+
+    it("navigates to parent group after selecting nested option from search", async () => {
+      render(<Tagger field={nestedField} onChange={mockOnChange} />);
+
+      const combobox = screen.getByRole("combobox");
+      await userEvent.click(combobox);
+      await userEvent.type(combobox, "Professional");
+
+      jest.advanceTimersByTime(300); // debounce delay
+
+      const professionalOption = await screen.findByRole("option", {
+        name: /cameras > dslr > professional/i,
+      });
+      await userEvent.click(professionalOption);
+
+      expect(mockOnChange).toHaveBeenCalledWith("cameras_dslr_pro");
+
+      // After selection, should navigate to parent DSLR group
+      await userEvent.click(combobox);
+      await waitFor(() => {
+        expect(
+          screen.getByRole("option", { name: "Professional" })
+        ).toBeInTheDocument();
+        expect(
+          screen.getByRole("option", { name: "Consumer" })
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("initializes with correct selected nested value", () => {
+      const fieldWithNestedValue = {
+        ...nestedField,
+        value: "cameras_dslr_pro",
+      };
+      const { container } = render(
+        <Tagger field={fieldWithNestedValue} onChange={mockOnChange} />
+      );
+
+      const hiddenInput = container.querySelector(
+        'input[type="hidden"][name="test_tagger"]'
+      );
+      expect(hiddenInput).toHaveValue("cameras_dslr_pro");
+    });
+  });
+});

--- a/src/modules/ticket-fields/fields/Tagger.tsx
+++ b/src/modules/ticket-fields/fields/Tagger.tsx
@@ -1,7 +1,4 @@
-import type {
-  IComboboxProps,
-  ISelectedOption,
-} from "@zendeskgarden/react-dropdowns";
+import type { IComboboxProps } from "@zendeskgarden/react-dropdowns";
 import {
   Field,
   Combobox,
@@ -9,9 +6,12 @@ import {
   OptGroup,
 } from "@zendeskgarden/react-dropdowns";
 import { Span } from "@zendeskgarden/react-typography";
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect, useCallback } from "react";
+import { useTranslation } from "react-i18next";
 import { useNestedOptions } from "./useNestedOptions";
 import { EmptyValueOption } from "./EmptyValueOption";
+import { useFieldSearch } from "./useFieldSearch";
+import { HighlightMatch } from "./HighlightMatch";
 import type { TicketFieldObject } from "../data-types/TicketFieldObject";
 
 interface TaggerProps {
@@ -20,16 +20,61 @@ interface TaggerProps {
 }
 
 export function Tagger({ field, onChange }: TaggerProps): JSX.Element {
-  const { label, options, error, value, name, required, description } = field;
+  const {
+    label,
+    options: fieldOptions,
+    error,
+    value,
+    name,
+    required,
+    description,
+  } = field;
+  const { t } = useTranslation();
   const { currentGroup, isGroupIdentifier, setCurrentGroupByIdentifier } =
     useNestedOptions({
-      options,
+      options: fieldOptions,
       hasEmptyOption: true,
     });
 
-  const selectionValue = (value as string | undefined) ?? "";
+  const EMPTY_OPTION_LABEL = "-";
+
+  const initialValue = (value as string | undefined) ?? "";
+  const [selectionValue, setSelectionValue] = useState(initialValue);
+  const [selectedLabel, setSelectedLabel] = useState<string | null>(null);
   const [isExpanded, setIsExpanded] = useState(false);
   const wrapperRef = useRef<HTMLDivElement>(null);
+
+  const {
+    inputValue,
+    setInputValue,
+    isSearching,
+    filteredOptions,
+    optionsMap,
+    valueToGroupMap,
+    handleInputChange,
+    endSearch,
+  } = useFieldSearch({
+    fieldOptions: fieldOptions || [],
+    currentGroupOptions: currentGroup.options,
+  });
+
+  useEffect(() => {
+    if (initialValue && !selectedLabel) {
+      const foundLabel = optionsMap.get(initialValue);
+      if (foundLabel) {
+        setSelectedLabel(foundLabel);
+        setInputValue(foundLabel);
+      }
+    }
+  }, [initialValue, optionsMap, selectedLabel, setInputValue]);
+
+  const noResultsOption = {
+    name: t(
+      "cph-theme-ticket-fields.search-field.no-matches-found",
+      "No matches found"
+    ),
+    id: "no-results",
+  };
 
   useEffect(() => {
     if (wrapperRef.current && required) {
@@ -39,22 +84,58 @@ export function Tagger({ field, onChange }: TaggerProps): JSX.Element {
   }, [wrapperRef, required]);
 
   const handleChange: IComboboxProps["onChange"] = (changes) => {
-    if (
-      typeof changes.selectionValue === "string" &&
-      isGroupIdentifier(changes.selectionValue)
-    ) {
-      setCurrentGroupByIdentifier(changes.selectionValue);
-      return;
-    }
-
     if (typeof changes.selectionValue === "string") {
-      onChange(changes.selectionValue);
+      if (isGroupIdentifier(changes.selectionValue)) {
+        setCurrentGroupByIdentifier(changes.selectionValue);
+        setInputValue("");
+        endSearch();
+        if (changes.isExpanded !== undefined) {
+          setIsExpanded(true);
+        }
+        return;
+      }
+
+      const newValue = changes.selectionValue;
+      const newLabel =
+        newValue === ""
+          ? EMPTY_OPTION_LABEL
+          : optionsMap.get(newValue) || newValue;
+      setSelectionValue(newValue);
+      setSelectedLabel(newValue === "" ? null : newLabel);
+      setInputValue(newLabel);
+      onChange(newValue);
+      endSearch();
+
+      // Navigate to parent group if selecting a nested option from search
+      if (isSearching && newValue !== "") {
+        const parentGroupIdentifier = valueToGroupMap.get(newValue);
+        if (parentGroupIdentifier && isGroupIdentifier(parentGroupIdentifier)) {
+          setCurrentGroupByIdentifier(parentGroupIdentifier);
+        }
+      }
     }
 
     if (changes.isExpanded !== undefined) {
       setIsExpanded(changes.isExpanded);
+      if (!changes.isExpanded) {
+        endSearch();
+      }
+    }
+
+    if (changes.inputValue !== undefined) {
+      handleInputChange(changes.inputValue);
     }
   };
+
+  const handleFocus = useCallback(
+    (event: React.FocusEvent<HTMLInputElement>) => {
+      // Position cursor at the end of the text
+      const input = event.target;
+      const length = input.value.length;
+      input.setSelectionRange(length, length);
+    },
+    []
+  );
 
   return (
     <Field>
@@ -67,41 +148,82 @@ export function Tagger({ field, onChange }: TaggerProps): JSX.Element {
       )}
       <Combobox
         ref={wrapperRef}
-        inputProps={{ required, name }}
-        isEditable={false}
+        inputProps={{ required, onFocus: handleFocus }}
+        isAutocomplete
         validation={error ? "error" : undefined}
         onChange={handleChange}
         selectionValue={selectionValue}
-        inputValue={selectionValue}
-        renderValue={({ selection }) =>
-          (selection as ISelectedOption | null)?.label ?? <EmptyValueOption />
-        }
+        inputValue={inputValue}
+        placeholder={t(
+          "cph-theme-ticket-fields.search-field.placeholder",
+          "Search {{label}}",
+          { label }
+        )}
+        renderValue={() => selectedLabel || EMPTY_OPTION_LABEL}
         isExpanded={isExpanded}
       >
-        {currentGroup.type === "SubGroup" && (
+        {!isSearching && currentGroup.type === "SubGroup" && (
           <Option {...currentGroup.backOption} />
         )}
-        {currentGroup.type === "SubGroup" ? (
+
+        {isSearching ? (
+          <>
+            {inputValue.length > 0 && filteredOptions.length === 0 && (
+              <Option
+                isDisabled
+                key={noResultsOption.id}
+                value={noResultsOption.id}
+              >
+                {noResultsOption.name}
+              </Option>
+            )}
+            {filteredOptions.map((option) =>
+              option.value === "" ? (
+                <Option
+                  key={option.value}
+                  value={option.value}
+                  label={option.label}
+                >
+                  <EmptyValueOption />
+                </Option>
+              ) : (
+                <Option
+                  key={option.value}
+                  value={option.value}
+                  label={option.label}
+                >
+                  <HighlightMatch
+                    text={option.label}
+                    searchValue={inputValue}
+                  />
+                </Option>
+              )
+            )}
+          </>
+        ) : currentGroup.type === "SubGroup" ? (
           <OptGroup aria-label={currentGroup.name}>
-            {currentGroup.options.map((option) => (
+            {filteredOptions.map((option) => (
               <Option key={option.value} {...option}>
                 {option.menuLabel ?? option.label}
               </Option>
             ))}
           </OptGroup>
         ) : (
-          currentGroup.options.map((option) =>
-            option.value === "" ? (
-              <Option key={option.value} {...option}>
-                <EmptyValueOption />
-              </Option>
-            ) : (
-              <Option key={option.value} {...option} />
-            )
-          )
+          <>
+            {filteredOptions.map((option) =>
+              option.value === "" ? (
+                <Option key={option.value} {...option}>
+                  <EmptyValueOption />
+                </Option>
+              ) : (
+                <Option key={option.value} {...option} />
+              )
+            )}
+          </>
         )}
       </Combobox>
       {error && <Field.Message validation="error">{error}</Field.Message>}
+      <input type="hidden" name={name} value={selectionValue} />
     </Field>
   );
 }

--- a/src/modules/ticket-fields/fields/useFieldSearch.test.tsx
+++ b/src/modules/ticket-fields/fields/useFieldSearch.test.tsx
@@ -1,0 +1,371 @@
+import { renderHook, act } from "@testing-library/react-hooks";
+import { useFieldSearch } from "./useFieldSearch";
+import type { TicketFieldOptionObject } from "../data-types/TicketFieldObject";
+
+describe("useFieldSearch", () => {
+  const mockFieldOptions: TicketFieldOptionObject[] = [
+    { name: "Option 1", value: "option_1" },
+    { name: "Option 2", value: "option_2" },
+    { name: "Nested::Option 3", value: "nested_option_3" },
+    { name: "Nested::Deep::Option 4", value: "nested_deep_option_4" },
+  ];
+
+  const mockCurrentGroupOptions = [
+    { label: "Option 1", value: "option_1" },
+    { label: "Option 2", value: "option_2" },
+  ];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  describe("Initialization", () => {
+    it("initializes with correct default values", () => {
+      const { result } = renderHook(() =>
+        useFieldSearch({
+          fieldOptions: mockFieldOptions,
+          currentGroupOptions: mockCurrentGroupOptions,
+        })
+      );
+
+      expect(result.current.inputValue).toBe("");
+      expect(result.current.isSearching).toBe(false);
+      expect(result.current.filteredOptions).toEqual(mockCurrentGroupOptions);
+    });
+
+    it("builds options map correctly", () => {
+      const { result } = renderHook(() =>
+        useFieldSearch({
+          fieldOptions: mockFieldOptions,
+          currentGroupOptions: mockCurrentGroupOptions,
+        })
+      );
+
+      expect(result.current.optionsMap.get("option_1")).toBe("Option 1");
+      expect(result.current.optionsMap.get("nested_option_3")).toBe(
+        "Nested > Option 3"
+      );
+      expect(result.current.optionsMap.get("nested_deep_option_4")).toBe(
+        "Nested > Deep > Option 4"
+      );
+    });
+
+    it("builds value to group map correctly for nested options", () => {
+      const { result } = renderHook(() =>
+        useFieldSearch({
+          fieldOptions: mockFieldOptions,
+          currentGroupOptions: mockCurrentGroupOptions,
+        })
+      );
+
+      expect(result.current.valueToGroupMap.get("nested_option_3")).toBe(
+        "[Nested]"
+      );
+      expect(result.current.valueToGroupMap.get("nested_deep_option_4")).toBe(
+        "[Nested::Deep]"
+      );
+      expect(result.current.valueToGroupMap.get("option_1")).toBeUndefined();
+    });
+  });
+
+  describe("handleInputChange", () => {
+    it("updates input value and triggers debounced search", () => {
+      const { result } = renderHook(() =>
+        useFieldSearch({
+          fieldOptions: mockFieldOptions,
+          currentGroupOptions: mockCurrentGroupOptions,
+        })
+      );
+
+      act(() => {
+        result.current.handleInputChange("Option 1");
+      });
+
+      // Input value should update immediately
+      expect(result.current.inputValue).toBe("Option 1");
+
+      // Search should not trigger immediately (debounced)
+      expect(result.current.isSearching).toBe(false);
+      expect(result.current.filteredOptions).toEqual(mockCurrentGroupOptions);
+
+      // After debounce delay, search should trigger
+      act(() => {
+        jest.advanceTimersByTime(300);
+      });
+
+      expect(result.current.isSearching).toBe(true);
+      expect(result.current.filteredOptions).toHaveLength(1);
+      expect(result.current.filteredOptions[0]?.value).toBe("option_1");
+    });
+
+    it("filters nested options and shows full path", () => {
+      const { result } = renderHook(() =>
+        useFieldSearch({
+          fieldOptions: mockFieldOptions,
+          currentGroupOptions: mockCurrentGroupOptions,
+        })
+      );
+
+      act(() => {
+        result.current.handleInputChange("Option 3");
+        jest.advanceTimersByTime(300);
+      });
+
+      expect(result.current.isSearching).toBe(true);
+      expect(result.current.filteredOptions).toHaveLength(1);
+      expect(result.current.filteredOptions[0]?.label).toBe(
+        "Nested > Option 3"
+      );
+      expect(result.current.filteredOptions[0]?.menuLabel).toBe("Option 3");
+    });
+
+    it("performs case-insensitive search", () => {
+      const { result } = renderHook(() =>
+        useFieldSearch({
+          fieldOptions: mockFieldOptions,
+          currentGroupOptions: mockCurrentGroupOptions,
+        })
+      );
+
+      act(() => {
+        result.current.handleInputChange("option");
+        jest.advanceTimersByTime(300);
+      });
+
+      expect(result.current.filteredOptions).toHaveLength(4);
+    });
+
+    it("resets search when input is empty", () => {
+      const { result } = renderHook(() =>
+        useFieldSearch({
+          fieldOptions: mockFieldOptions,
+          currentGroupOptions: mockCurrentGroupOptions,
+        })
+      );
+
+      // First, do a search
+      act(() => {
+        result.current.handleInputChange("Option 1");
+        jest.advanceTimersByTime(300);
+      });
+
+      expect(result.current.isSearching).toBe(true);
+
+      // Then clear the input
+      act(() => {
+        result.current.handleInputChange("");
+        jest.advanceTimersByTime(300);
+      });
+
+      expect(result.current.isSearching).toBe(false);
+      expect(result.current.filteredOptions).toEqual(mockCurrentGroupOptions);
+    });
+  });
+
+  describe("endSearch", () => {
+    it("ends search mode and cancels pending debounce", () => {
+      const { result } = renderHook(() =>
+        useFieldSearch({
+          fieldOptions: mockFieldOptions,
+          currentGroupOptions: mockCurrentGroupOptions,
+        })
+      );
+
+      act(() => {
+        result.current.handleInputChange("Option 1");
+        jest.advanceTimersByTime(300);
+      });
+
+      expect(result.current.isSearching).toBe(true);
+
+      act(() => {
+        result.current.endSearch();
+      });
+
+      expect(result.current.isSearching).toBe(false);
+
+      // Verify debounce was cancelled
+      act(() => {
+        result.current.handleInputChange("Option 2");
+      });
+
+      act(() => {
+        result.current.endSearch();
+      });
+
+      act(() => {
+        jest.advanceTimersByTime(300);
+      });
+
+      // Should not have triggered search after endSearch
+      expect(result.current.filteredOptions).not.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ value: "option_2" }),
+        ])
+      );
+    });
+  });
+
+  describe("resetSearch", () => {
+    it("fully resets search state", () => {
+      const { result } = renderHook(() =>
+        useFieldSearch({
+          fieldOptions: mockFieldOptions,
+          currentGroupOptions: mockCurrentGroupOptions,
+        })
+      );
+
+      // Set up search state
+      act(() => {
+        result.current.handleInputChange("Option 1");
+        jest.advanceTimersByTime(300);
+      });
+
+      expect(result.current.inputValue).toBe("Option 1");
+      expect(result.current.isSearching).toBe(true);
+      expect(result.current.filteredOptions).toHaveLength(1);
+
+      // Reset everything
+      act(() => {
+        result.current.resetSearch();
+      });
+
+      expect(result.current.inputValue).toBe("");
+      expect(result.current.isSearching).toBe(false);
+      expect(result.current.filteredOptions).toEqual(mockCurrentGroupOptions);
+    });
+
+    it("cancels pending debounced search", () => {
+      const { result } = renderHook(() =>
+        useFieldSearch({
+          fieldOptions: mockFieldOptions,
+          currentGroupOptions: mockCurrentGroupOptions,
+        })
+      );
+
+      act(() => {
+        result.current.handleInputChange("Option 1");
+      });
+
+      // Reset before debounce completes
+      act(() => {
+        result.current.resetSearch();
+      });
+
+      act(() => {
+        jest.advanceTimersByTime(300);
+      });
+
+      // Should remain in initial state
+      expect(result.current.inputValue).toBe("");
+      expect(result.current.isSearching).toBe(false);
+      expect(result.current.filteredOptions).toEqual(mockCurrentGroupOptions);
+    });
+  });
+
+  describe("cancelSearch", () => {
+    it("cancels pending debounced search without changing state", () => {
+      const { result } = renderHook(() =>
+        useFieldSearch({
+          fieldOptions: mockFieldOptions,
+          currentGroupOptions: mockCurrentGroupOptions,
+        })
+      );
+
+      act(() => {
+        result.current.handleInputChange("Option 1");
+      });
+
+      const inputValueBeforeCancel = result.current.inputValue;
+
+      act(() => {
+        result.current.cancelSearch();
+      });
+
+      act(() => {
+        jest.advanceTimersByTime(300);
+      });
+
+      // Input value should remain, but search should not have triggered
+      expect(result.current.inputValue).toBe(inputValueBeforeCancel);
+      expect(result.current.isSearching).toBe(false);
+      expect(result.current.filteredOptions).toEqual(mockCurrentGroupOptions);
+    });
+  });
+
+  describe("currentGroupOptions updates", () => {
+    it("updates filtered options when currentGroupOptions change and not searching", () => {
+      const { result, rerender } = renderHook(
+        ({ currentGroupOptions }) =>
+          useFieldSearch({
+            fieldOptions: mockFieldOptions,
+            currentGroupOptions,
+          }),
+        {
+          initialProps: { currentGroupOptions: mockCurrentGroupOptions },
+        }
+      );
+
+      const newGroupOptions = [{ label: "New Option", value: "new_option" }];
+
+      rerender({ currentGroupOptions: newGroupOptions });
+
+      expect(result.current.filteredOptions).toEqual(newGroupOptions);
+    });
+
+    it("does not update filtered options when searching", () => {
+      const { result, rerender } = renderHook(
+        ({ currentGroupOptions }) =>
+          useFieldSearch({
+            fieldOptions: mockFieldOptions,
+            currentGroupOptions,
+          }),
+        {
+          initialProps: { currentGroupOptions: mockCurrentGroupOptions },
+        }
+      );
+
+      act(() => {
+        result.current.handleInputChange("Option 1");
+        jest.advanceTimersByTime(300);
+      });
+
+      const searchResults = result.current.filteredOptions;
+      const newGroupOptions = [{ label: "New Option", value: "new_option" }];
+
+      rerender({ currentGroupOptions: newGroupOptions });
+
+      // Should keep search results
+      expect(result.current.filteredOptions).toEqual(searchResults);
+    });
+  });
+
+  describe("cleanup", () => {
+    it("cancels debounced search when hook unmounts", () => {
+      const { result, unmount } = renderHook(() =>
+        useFieldSearch({
+          fieldOptions: mockFieldOptions,
+          currentGroupOptions: mockCurrentGroupOptions,
+        })
+      );
+
+      act(() => {
+        result.current.handleInputChange("Option 1");
+      });
+
+      unmount();
+
+      act(() => {
+        jest.advanceTimersByTime(300);
+      });
+
+      // Should not throw error after unmount
+    });
+  });
+});

--- a/src/modules/ticket-fields/fields/useFieldSearch.tsx
+++ b/src/modules/ticket-fields/fields/useFieldSearch.tsx
@@ -1,0 +1,187 @@
+import { useState, useEffect, useCallback, useMemo } from "react";
+import debounce from "lodash.debounce";
+import type { TicketFieldOptionObject } from "../data-types/TicketFieldObject";
+
+interface OptionProps {
+  value: string;
+  label: string;
+  menuLabel?: string;
+}
+
+/**
+ * Builds a map of option values to their display labels.
+ * Nested options (with "::" in the name) are formatted as "Part1 > Part2 > Part3".
+ */
+function buildOptionsMap(
+  options: TicketFieldOptionObject[]
+): Map<string, string> {
+  const map = new Map<string, string>();
+
+  for (const option of options) {
+    const { name, value } = option;
+    if (name.includes("::")) {
+      const parts = name.split("::");
+      map.set(value, parts.join(" > "));
+    } else {
+      map.set(value, name);
+    }
+  }
+
+  return map;
+}
+
+/**
+ * Searches through all options, including nested ones for matches.
+ * Returns a flat list of matching options with formatted labels.
+ */
+function searchAllOptions(
+  options: TicketFieldOptionObject[],
+  searchValue: string
+): OptionProps[] {
+  const results: OptionProps[] = [];
+  const lowerSearch = searchValue.toLowerCase();
+
+  for (const option of options) {
+    const { name, value } = option;
+
+    if (name.toLowerCase().includes(lowerSearch)) {
+      if (name.includes("::")) {
+        const parts = name.split("::");
+        results.push({
+          value,
+          label: parts.join(" > "),
+          menuLabel: parts[parts.length - 1],
+        });
+      } else {
+        results.push({
+          value,
+          label: name,
+        });
+      }
+    }
+  }
+
+  return results;
+}
+
+interface UseFieldSearchProps {
+  fieldOptions: TicketFieldOptionObject[];
+  currentGroupOptions: OptionProps[];
+}
+
+interface UseFieldSearchResult {
+  // Read-only state
+  inputValue: string;
+  isSearching: boolean;
+  filteredOptions: OptionProps[];
+  optionsMap: Map<string, string>;
+  valueToGroupMap: Map<string, string>;
+
+  // Actions
+  setInputValue: (value: string) => void;
+  handleInputChange: (value: string) => void;
+  endSearch: () => void;
+  resetSearch: () => void;
+  cancelSearch: () => void;
+}
+
+/**
+ * Custom hook to manage search functionality for dropdown fields.
+ * Handles search input, debounced filtering, and option mapping.
+ */
+export function useFieldSearch({
+  fieldOptions,
+  currentGroupOptions,
+}: UseFieldSearchProps): UseFieldSearchResult {
+  const [inputValue, setInputValue] = useState<string>("");
+  const [isSearching, setIsSearching] = useState(false);
+  const [filteredOptions, setFilteredOptions] =
+    useState<OptionProps[]>(currentGroupOptions);
+
+  const optionsMap = useMemo(
+    () => buildOptionsMap(fieldOptions || []),
+    [fieldOptions]
+  );
+
+  // Map option values to their parent group identifiers for navigation after search selection
+  const valueToGroupMap = useMemo(() => {
+    const map = new Map<string, string>();
+    (fieldOptions || []).forEach((option) => {
+      if (option.name.includes("::")) {
+        const parts = option.name.split("::");
+        const groupIdentifier = `[${parts.slice(0, -1).join("::")}]`;
+        map.set(option.value, groupIdentifier);
+      }
+    });
+    return map;
+  }, [fieldOptions]);
+
+  useEffect(() => {
+    if (!isSearching) {
+      setFilteredOptions(currentGroupOptions);
+    }
+  }, [currentGroupOptions, isSearching]);
+
+  const filterOptions = useCallback(
+    (searchValue: string) => {
+      if (!searchValue || searchValue === "*") {
+        setIsSearching(false);
+        setFilteredOptions(currentGroupOptions);
+        return;
+      }
+
+      setIsSearching(true);
+      const allResults = searchAllOptions(fieldOptions || [], searchValue);
+      setFilteredOptions(allResults);
+    },
+    [currentGroupOptions, fieldOptions]
+  );
+
+  const debouncedFilterOptions = useMemo(
+    () => debounce(filterOptions, 300),
+    [filterOptions]
+  );
+
+  useEffect(() => {
+    return () => debouncedFilterOptions.cancel();
+  }, [debouncedFilterOptions]);
+
+  // High-level actions for consumers
+  const handleInputChange = useCallback(
+    (value: string) => {
+      setInputValue(value);
+      debouncedFilterOptions(value);
+    },
+    [debouncedFilterOptions]
+  );
+
+  const resetSearch = useCallback(() => {
+    debouncedFilterOptions.cancel();
+    setIsSearching(false);
+    setInputValue("");
+    setFilteredOptions(currentGroupOptions);
+  }, [currentGroupOptions, debouncedFilterOptions]);
+
+  const endSearch = useCallback(() => {
+    debouncedFilterOptions.cancel();
+    setIsSearching(false);
+  }, [debouncedFilterOptions]);
+
+  const cancelSearch = useCallback(() => {
+    debouncedFilterOptions.cancel();
+  }, [debouncedFilterOptions]);
+
+  return {
+    inputValue,
+    isSearching,
+    filteredOptions,
+    optionsMap,
+    valueToGroupMap,
+
+    setInputValue,
+    handleInputChange,
+    endSearch,
+    resetSearch,
+    cancelSearch,
+  };
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5120,7 +5120,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@zendeskgarden/container-utilities@npm:^1.0.14, @zendeskgarden/container-utilities@npm:^1.0.6":
+"@zendeskgarden/container-utilities@npm:^1.0.0":
   version: 1.0.14
   resolution: "@zendeskgarden/container-utilities@npm:1.0.14"
   dependencies:
@@ -5130,19 +5130,6 @@ __metadata:
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
   checksum: 10c0/9d30b274496ea77d06d4823cd35772f370ade8f7fcf1dc76e5d7ac0968b3dbb73b5667b2efba6145e46d2bc34f66add7892e5a39403fa0ef8f67facb2bce00f0
-  languageName: node
-  linkType: hard
-
-"@zendeskgarden/container-utilities@npm:^2.0.0, @zendeskgarden/container-utilities@npm:^2.0.2, @zendeskgarden/container-utilities@npm:^2.0.4, @zendeskgarden/container-utilities@npm:^2.0.5":
-  version: 2.0.5
-  resolution: "@zendeskgarden/container-utilities@npm:2.0.5"
-  dependencies:
-    "@babel/runtime": "npm:^7.8.4"
-    "@reach/auto-id": "npm:^0.18.0"
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0
-    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-  checksum: 10c0/110e2faddd3610dcd774a29762d86e845f045fc5dff0b44c7f32164f54096ba78ce1e4c70b913cf45bb91dea5755c56952c519a45e10de846c956726f7324992
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Added possibility to search in drop-down fields: Tagger and MultiSelect component. DropDown component is used only for system fields.

PR with translations: https://github.com/zendesk/copenhagen_theme/pull/758

Jira: [GG-3415](https://zendesk.atlassian.net/browse/GG-3415) & [GG-3416](https://zendesk.atlassian.net/browse/GG-3416)
## Screenshots

<!-- (optional) when applicable, please include some screenshots or gifs that illustrate the changes -->

https://github.com/user-attachments/assets/72d5595a-c6af-4283-93fd-b68f4a39dc99


## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->

[GG-3415]: https://zendesk.atlassian.net/browse/GG-3415?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GG-3416]: https://zendesk.atlassian.net/browse/GG-3416?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ