### PR TITLE
[LB-3924] feat: display approval request decision origin

### DIFF
--- a/src/modules/approval-requests/components/approval-request/ApprovalRequestDetails.test.tsx
+++ b/src/modules/approval-requests/components/approval-request/ApprovalRequestDetails.test.tsx
@@ -99,7 +99,102 @@ describe("ApprovalRequestDetails", () => {
     expect(screen.getByText("Reason")).toBeInTheDocument();
     expect(screen.getByText(/this looks good to me/i)).toBeInTheDocument();
     expect(screen.getByText("Decided")).toBeInTheDocument();
-    expect(screen.getByText(/this looks good to me/i)).toBeInTheDocument();
+    expect(screen.queryByText(/via Slack/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/via Zendesk/)).not.toBeInTheDocument();
+  });
+
+  it("shows 'via Slack' next to decided date when decision origination_type is SLACK_ORIGINATION", () => {
+    const slackDecisionRequest: ApprovalRequest = {
+      ...mockApprovalRequest,
+      status: "approved",
+      decided_at: "2024-02-21T15:45:00Z",
+      decisions: [
+        {
+          decision_notes: "Looks good to me",
+          decided_at: "2024-02-21T15:45:00Z",
+          decided_by_user: {
+            id: 456,
+            name: "Jane Approver",
+            photo: { content_url: null },
+          },
+          status: "approved",
+          origination_type: "SLACK_ORIGINATION",
+        },
+      ],
+    };
+
+    render(
+      <ApprovalRequestDetails
+        approvalRequest={slackDecisionRequest}
+        baseLocale="en-US"
+      />
+    );
+
+    expect(screen.getByText(/via Slack/)).toBeInTheDocument();
+    expect(screen.queryByText(/via Zendesk/)).not.toBeInTheDocument();
+  });
+
+  it("shows 'via Zendesk' next to decided date when decision origination_type is UI_ORIGINATION", () => {
+    const uiDecisionRequest: ApprovalRequest = {
+      ...mockApprovalRequest,
+      status: "approved",
+      decided_at: "2024-02-21T15:45:00Z",
+      decisions: [
+        {
+          decision_notes: "Approved via UI",
+          decided_at: "2024-02-21T15:45:00Z",
+          decided_by_user: {
+            id: 456,
+            name: "Jane Approver",
+            photo: { content_url: null },
+          },
+          status: "approved",
+          origination_type: "UI_ORIGINATION",
+        },
+      ],
+    };
+
+    render(
+      <ApprovalRequestDetails
+        approvalRequest={uiDecisionRequest}
+        baseLocale="en-US"
+      />
+    );
+
+    expect(screen.getByText(/via Zendesk/)).toBeInTheDocument();
+    expect(screen.queryByText(/via Slack/)).not.toBeInTheDocument();
+  });
+
+  it("does not show 'via' labels for withdrawn requests even when decision has origination_type", () => {
+    const withdrawnWithOriginationType: ApprovalRequest = {
+      ...mockApprovalRequest,
+      status: "withdrawn",
+      withdrawn_reason: "No longer needed",
+      decided_at: "2024-02-21T15:45:00Z",
+      decisions: [
+        {
+          decision_notes: "Was approved",
+          decided_at: "2024-02-21T15:45:00Z",
+          decided_by_user: {
+            id: 456,
+            name: "Jane Approver",
+            photo: { content_url: null },
+          },
+          status: "approved",
+          origination_type: "SLACK_ORIGINATION",
+        },
+      ],
+    };
+
+    render(
+      <ApprovalRequestDetails
+        approvalRequest={withdrawnWithOriginationType}
+        baseLocale="en-US"
+      />
+    );
+
+    expect(screen.queryByText(/via Slack/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/via Zendesk/)).not.toBeInTheDocument();
   });
 
   it("renders a withdrawn approval request with the withdrawal reason", () => {

--- a/src/modules/approval-requests/components/approval-request/ApprovalRequestDetails.tsx
+++ b/src/modules/approval-requests/components/approval-request/ApprovalRequestDetails.tsx
@@ -10,6 +10,7 @@ import { formatApprovalRequestDate } from "../../utils";
 import { APPROVAL_REQUEST_STATES } from "../../constants";
 import ApprovalRequestPreviousDecision from "./ApprovalRequestPreviousDecision";
 import { getSentByLabel } from "../../getSentByLabel";
+import { getDecisionOriginLabel } from "../../getDecisionOriginLabel";
 
 const Container = styled(Grid)`
   padding: ${(props) => props.theme.space.base * 6}px; /* 24px */
@@ -78,6 +79,21 @@ function ApprovalRequestDetails({
   const shouldShowPreviousDecision =
     approvalRequest.status === APPROVAL_REQUEST_STATES.WITHDRAWN &&
     approvalRequest.decisions.length > 0;
+
+  const formattedDecidedAt = approvalRequest.decided_at
+    ? formatApprovalRequestDate(approvalRequest.decided_at, baseLocale)
+    : "";
+
+  // The `origination_type` field on decisions is only present when arturo `approvals_slack_notifications` is enabled
+  const decisionOriginLabel =
+    approvalRequest.status !== APPROVAL_REQUEST_STATES.WITHDRAWN
+      ? getDecisionOriginLabel(
+          approvalRequest.decisions[0]?.origination_type,
+          formattedDecidedAt,
+          t
+        )
+      : "";
+
   return (
     <Container>
       <ApprovalRequestHeader isBold>
@@ -176,12 +192,9 @@ function ApprovalRequestDetails({
             </FieldLabel>
           </Grid.Col>
           <Grid.Col size={8}>
-            <MD>
-              {formatApprovalRequestDate(
-                approvalRequest.decided_at,
-                baseLocale
-              )}
-            </MD>
+            <WrappedText>
+              {decisionOriginLabel || formattedDecidedAt}
+            </WrappedText>
           </Grid.Col>
         </DetailRow>
       )}

--- a/src/modules/approval-requests/constants.ts
+++ b/src/modules/approval-requests/constants.ts
@@ -9,3 +9,8 @@ export const APPROVAL_REQUEST_STATES = {
   REJECTED: "rejected",
   WITHDRAWN: "withdrawn",
 } as const;
+
+export const APPROVAL_DECISION_ORIGINATIONS = {
+  SLACK: "SLACK_ORIGINATION",
+  UI: "UI_ORIGINATION",
+} as const;

--- a/src/modules/approval-requests/getDecisionOriginLabel.test.ts
+++ b/src/modules/approval-requests/getDecisionOriginLabel.test.ts
@@ -1,0 +1,49 @@
+import { getDecisionOriginLabel } from "./getDecisionOriginLabel";
+import { APPROVAL_DECISION_ORIGINATIONS } from "./constants";
+
+describe("getDecisionOriginLabel", () => {
+  const mockT = (
+    key: string,
+    defaultValue: string,
+    options?: { date: string }
+  ) => defaultValue.replace("{{date}}", options?.date ?? "");
+
+  const testDate = "January 15, 2025";
+
+  it('returns "{{date}} via Slack" when origination_type is SLACK_ORIGINATION', () => {
+    const result = getDecisionOriginLabel(
+      APPROVAL_DECISION_ORIGINATIONS.SLACK,
+      testDate,
+      mockT
+    );
+    expect(result).toBe("January 15, 2025 via Slack");
+  });
+
+  it('returns "{{date}} via Zendesk" when origination_type is UI_ORIGINATION', () => {
+    const result = getDecisionOriginLabel(
+      APPROVAL_DECISION_ORIGINATIONS.UI,
+      testDate,
+      mockT
+    );
+    expect(result).toBe("January 15, 2025 via Zendesk");
+  });
+
+  it("returns empty string when origination_type is undefined", () => {
+    const result = getDecisionOriginLabel(undefined, testDate, mockT);
+    expect(result).toBe("");
+  });
+
+  it("returns empty string when origination_type is an unknown value", () => {
+    const result = getDecisionOriginLabel(
+      "UNKNOWN_ORIGINATION",
+      testDate,
+      mockT
+    );
+    expect(result).toBe("");
+  });
+
+  it("returns empty string when origination_type is an empty string", () => {
+    const result = getDecisionOriginLabel("", testDate, mockT);
+    expect(result).toBe("");
+  });
+});

--- a/src/modules/approval-requests/getDecisionOriginLabel.ts
+++ b/src/modules/approval-requests/getDecisionOriginLabel.ts
@@ -1,0 +1,25 @@
+import { APPROVAL_DECISION_ORIGINATIONS } from "./constants";
+
+export function getDecisionOriginLabel(
+  originationType: string | undefined,
+  date: string,
+  t: (key: string, defaultValue: string, options?: { date: string }) => string
+): string {
+  if (originationType === APPROVAL_DECISION_ORIGINATIONS.SLACK) {
+    return t(
+      "approval-requests.request.approval-request-details.via-slack",
+      "{{date}} via Slack",
+      { date }
+    );
+  }
+
+  if (originationType === APPROVAL_DECISION_ORIGINATIONS.UI) {
+    return t(
+      "approval-requests.request.approval-request-details.via-zendesk",
+      "{{date}} via Zendesk",
+      { date }
+    );
+  }
+
+  return "";
+}

--- a/src/modules/approval-requests/translations/en-us.yml
+++ b/src/modules/approval-requests/translations/en-us.yml
@@ -107,6 +107,16 @@ parts:
       screenshot: "https://drive.google.com/file/d/1xpM_3Rt3hCD8aE-U7mEbL0Sh5dsC0ScN/view?usp=drive_link"
       value: "Decided"
   - translation:
+      key: "approval-requests.request.approval-request-details.via-slack"
+      title: "Text indicating the decision was made via Slack. {{date}} is the formatted decision date (e.g. 'January 15, 2025')."
+      screenshot: "https://drive.google.com/file/d/1kccCR9hkZJ1XBWPieOmF7-D5IfdjnUuF/view?usp=sharing"
+      value: "{{date}} via Slack"
+  - translation:
+      key: "approval-requests.request.approval-request-details.via-zendesk"
+      title: "Text indicating the decision was made via Zendesk. {{date}} is the formatted decision date (e.g. 'January 15, 2025')."
+      screenshot: "https://drive.google.com/file/d/18QElSP6O0TQQeHrTSMSVmmWee-P8OScu/view?usp=sharing"
+      value: "{{date}} via Zendesk"
+  - translation:
       key: "approval-requests.request.approval-request-details.withdrawn-on"
       title: "Label for the withdrawn date on an approval request - Subject: 'approval request'"
       screenshot: "https://drive.google.com/file/d/1hkgy-71WFkLQnZ0PmEHFaWhfnuguiUmv/view?usp=drive_link"

--- a/src/modules/approval-requests/types.ts
+++ b/src/modules/approval-requests/types.ts
@@ -17,6 +17,7 @@ export interface ApprovalDecision {
   };
   decision_notes: string | null;
   status: ApprovalRequestStatus;
+  origination_type?: string;
 }
 
 export type ApprovalRequestStatus =


### PR DESCRIPTION
## Description
Display approval request decision origin.

## Screenshots

**via Slack origin**
<img width="1110" height="578" alt="approval-requests request approval-request-details via-slack" src="https://github.com/user-attachments/assets/f6df81ad-a0cc-4613-b940-e031530609b2" />

**via Zendesk origin**
<img width="1095" height="515" alt="approval-requests request approval-request-details via-zendesk" src="https://github.com/user-attachments/assets/85b3a333-d1a4-4aa2-8d2e-9b565fd2911c" />

## Checklist
- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->