### PR TITLE
[PDSC-583] refactor: handle form readiness

### DIFF
--- a/src/modules/service-catalog/components/service-catalog-item/ItemRequestForm.tsx
+++ b/src/modules/service-catalog/components/service-catalog-item/ItemRequestForm.tsx
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import { Fragment, useCallback, useState } from "react";
+import { Fragment, useCallback } from "react";
 import { RequestFormField } from "../../../ticket-fields";
 import { Button } from "@zendeskgarden/react-buttons";
 import { getColor } from "@zendeskgarden/react-theming";
@@ -21,6 +21,7 @@ import type {
   AttachmentsError,
   AttachmentsOption,
 } from "../../data-types/Attachments";
+import { Skeleton } from "@zendeskgarden/react-loaders";
 
 const Form = styled.form`
   display: flex;
@@ -95,6 +96,12 @@ const LeftColumn = styled.div`
   }
 `;
 
+const ButtonSkeleton = styled(Skeleton)`
+  width: 100%;
+  height: 48px;
+  display: block;
+`;
+
 const isAssetField = (f: TicketFieldObject) =>
   f.relationship_target_type === ASSET_KEY;
 const isAssetTypeField = (f: TicketFieldObject) =>
@@ -125,7 +132,8 @@ interface ItemRequestFormProps {
   isAssetTypeHidden: boolean;
   assetTypeIds: string[];
   assetIds: string[];
-  isSubmitting: boolean;
+  onAttachmentUploadingChange: (isUploading: boolean) => void;
+  isFormInitializing: boolean;
 }
 
 export function ItemRequestForm({
@@ -150,11 +158,10 @@ export function ItemRequestForm({
   isAssetTypeHidden,
   assetTypeIds,
   assetIds,
-  isSubmitting,
+  onAttachmentUploadingChange,
+  isFormInitializing,
 }: ItemRequestFormProps) {
   const { t } = useTranslation();
-
-  const [isUploadingAttachments, setIsUploadingAttachments] = useState(false);
 
   const buildLookupFieldOptions = async (
     records: CustomObjectRecord[],
@@ -228,9 +235,9 @@ export function ItemRequestForm({
   const handleAttachmentsOnUpload = useCallback(
     (status: boolean) => {
       setAttachmentsRequiredError(null);
-      setIsUploadingAttachments(status);
+      onAttachmentUploadingChange(status);
     },
-    [setAttachmentsRequiredError, setIsUploadingAttachments]
+    [setAttachmentsRequiredError, onAttachmentUploadingChange]
   );
 
   const renderRequestFields = () => {
@@ -335,15 +342,13 @@ export function ItemRequestForm({
       </LeftColumn>
       <RightColumn>
         <ButtonWrapper>
-          <Button
-            disabled={isUploadingAttachments || isSubmitting}
-            isPrimary
-            size="large"
-            isStretched
-            type="submit"
-          >
-            {t("service-catalog.item.submit-button", "Submit request")}
-          </Button>
+          {isFormInitializing ? (
+            <ButtonSkeleton />
+          ) : (
+            <Button isPrimary size="large" isStretched type="submit">
+              {t("service-catalog.item.submit-button", "Submit request")}
+            </Button>
+          )}
         </ButtonWrapper>
       </RightColumn>
     </Form>

--- a/src/modules/service-catalog/components/service-catalog-item/ServiceCatalogItem.tsx
+++ b/src/modules/service-catalog/components/service-catalog-item/ServiceCatalogItem.tsx
@@ -126,6 +126,7 @@ export function ServiceCatalogItem({
   const [assetTypeError, setAssetTypeError] = useState<string | null>(null);
   const [assetError, setAssetError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isUploadingAttachments, setIsUploadingAttachments] = useState(false);
 
   useEffect(() => {
     const handlePageShow = (e: PageTransitionEvent) => {
@@ -137,6 +138,23 @@ export function ServiceCatalogItem({
     window.addEventListener("pageshow", handlePageShow);
     return () => window.removeEventListener("pageshow", handlePageShow);
   }, []);
+
+  const hasCategories = (serviceCatalogItem?.categories?.length ?? 0) > 0;
+
+  const hasResolvedCategory = !hasCategories || !!selectedCategoryId;
+
+  const isFormInitializing =
+    !serviceCatalogItem ||
+    isRequestFieldsLoading ||
+    isLoadingAttachmentsOption ||
+    !hasResolvedCategory;
+
+  const canSubmit =
+    !isFormInitializing &&
+    !isSubmitting &&
+    !isUploadingAttachments &&
+    !!serviceCatalogItem &&
+    !!associatedLookupField;
 
   const handleFieldChange = (
     field: TicketFieldObject,
@@ -251,6 +269,12 @@ export function ServiceCatalogItem({
 
   const handleRequestSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
+
+    if (!canSubmit) {
+      notifySubmitError();
+      return;
+    }
+
     const form = e.currentTarget;
     const formData = new FormData(form);
     const isAssetTypeFieldHidden = formData.get("isAssetTypeHidden") === "true";
@@ -357,7 +381,8 @@ export function ServiceCatalogItem({
           isAssetTypeHidden={isAssetTypeHidden}
           assetTypeIds={assetTypeIds}
           assetIds={assetIds}
-          isSubmitting={isSubmitting}
+          onAttachmentUploadingChange={setIsUploadingAttachments}
+          isFormInitializing={isFormInitializing}
         />
       )}
     </Container>


### PR DESCRIPTION
## Description

The submit button is guarded during form initialization to prevent premature submissions

## Reference

- https://zendesk.atlassian.net/browse/PDSC-583

## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->