### PR TITLE
fix: trim category name in dropdown

### DIFF
--- a/src/modules/service-catalog/components/service-catalog-item/CategorySelector.tsx
+++ b/src/modules/service-catalog/components/service-catalog-item/CategorySelector.tsx
@@ -3,12 +3,34 @@ import { Button } from "@zendeskgarden/react-buttons";
 import ChevronIcon from "@zendeskgarden/svg-icons/src/16/chevron-down-stroke.svg";
 import { useTranslation } from "react-i18next";
 import type { ServiceCatalogItemCategory } from "../../data-types/ServiceCatalogItem";
+import styled from "styled-components";
 
 interface CategorySelectorProps {
   categories: ServiceCatalogItemCategory[];
   selectedCategoryId: string;
   onCategoryChange: (categoryId: string) => void;
 }
+
+const StyledMenu = styled(Menu)`
+  max-width: min(420px, calc(100vw - 32px));
+
+  [data-garden-id="dropdowns.menu.item.content"] {
+    min-width: 0;
+    flex: 1 1 auto;
+    overflow: hidden;
+    white-space: normal;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow-wrap: anywhere;
+  }
+`;
+
+const StyledItem = styled(Item)`
+  white-space: normal;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+`;
 
 export function CategorySelector({
   categories,
@@ -22,7 +44,7 @@ export function CategorySelector({
   }
 
   return (
-    <Menu
+    <StyledMenu
       button={(props) => (
         <Button {...props} isBasic>
           {t("service-catalog.item.change-category", "Change category")}
@@ -39,7 +61,7 @@ export function CategorySelector({
     >
       <ItemGroup type="radio">
         {categories.map((cat) => (
-          <Item
+          <StyledItem
             key={cat.id}
             value={cat.id}
             isSelected={cat.id === selectedCategoryId}
@@ -48,9 +70,9 @@ export function CategorySelector({
             {cat.path?.length > 0 && (
               <Item.Meta>{cat.path.join(" > ")}</Item.Meta>
             )}
-          </Item>
+          </StyledItem>
         ))}
       </ItemGroup>
-    </Menu>
+    </StyledMenu>
   );
 }

--- a/styles/_breadcrumbs.scss
+++ b/styles/_breadcrumbs.scss
@@ -9,11 +9,13 @@
   display: flex;
 
   li {
+    display: inline-block;
     color: $secondary-text-color;
     font-size: $font-size-small;
     max-width: 450px;
     overflow: hidden;
     text-overflow: ellipsis;
+    white-space: nowrap;
 
     + li::before {
       content: ">";


### PR DESCRIPTION
## Description

Fix dropdown and breadcrumbs layout for long category names

## Reference

- https://zendesk.atlassian.net/browse/PDSC-605

## Screenshots

<img width="1288" height="618" alt="Screenshot 2026-04-09 at 16 15 38" src="https://github.com/user-attachments/assets/ff3babfc-7fbf-42fc-b821-d0bd93e34fe7" />

## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->