### PR TITLE
[PDSC-627] feat: add current user name as a default requester

### DIFF
--- a/src/modules/service-catalog/components/service-catalog-item/ItemRequestForm.tsx
+++ b/src/modules/service-catalog/components/service-catalog-item/ItemRequestForm.tsx
@@ -1,7 +1,7 @@
 import styled from "styled-components";
 import { Fragment, useCallback } from "react";
 import { RequestFormField } from "../../../ticket-fields";
-import { Button } from "@zendeskgarden/react-buttons";
+import { Button, Anchor } from "@zendeskgarden/react-buttons";
 import { getColor } from "@zendeskgarden/react-theming";
 import { useTranslation } from "react-i18next";
 import type { ServiceCatalogItem } from "../../data-types/ServiceCatalogItem";
@@ -48,7 +48,6 @@ const FieldsContainer = styled.div`
 
 const ButtonWrapper = styled.div`
   flex: 1;
-  margin-inline-start: ${(props) => props.theme.space.xl};
   padding: ${(props) => props.theme.space.lg};
   border: ${(props) => props.theme.borders.sm}
     ${({ theme }) => getColor({ theme, hue: "grey", shade: 300 })};
@@ -102,6 +101,19 @@ const ButtonSkeleton = styled(Skeleton)`
   display: block;
 `;
 
+const UserNameWrapper = styled.div`
+  margin-bottom: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: ${(props) => props.theme.space.xxs};
+`;
+
+const ButtonContainer = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+`;
+
 const isAssetField = (f: TicketFieldObject) =>
   f.relationship_target_type === ASSET_KEY;
 const isAssetTypeField = (f: TicketFieldObject) =>
@@ -114,6 +126,8 @@ interface ItemRequestFormProps {
   hasAtMentions: boolean;
   userRole: string;
   userId: number;
+  requestOnBehalfEnabled: boolean | undefined;
+  userName: string;
   brandId: number;
   defaultOrganizationId: string | null;
   handleChange: (
@@ -143,6 +157,8 @@ export function ItemRequestForm({
   hasAtMentions,
   userRole,
   userId,
+  requestOnBehalfEnabled,
+  userName,
   brandId,
   defaultOrganizationId,
   handleChange,
@@ -342,6 +358,23 @@ export function ItemRequestForm({
       </LeftColumn>
       <RightColumn>
         <ButtonWrapper>
+          <ButtonContainer>
+            <UserNameWrapper>
+              <Span isBold>{t("service-catalog.item.user", "User")}</Span>
+              <Span>{userName}</Span>
+            </UserNameWrapper>
+            {requestOnBehalfEnabled && (
+              <>
+                <Anchor isUnderlined={false}>
+                  {t(
+                    "service-catalog.item.change-user-requesting-on-behalf",
+                    "Change"
+                  )}
+                </Anchor>
+              </>
+            )}
+          </ButtonContainer>
+
           {isFormInitializing ? (
             <ButtonSkeleton />
           ) : (

--- a/src/modules/service-catalog/components/service-catalog-item/ServiceCatalogItem.spec.tsx
+++ b/src/modules/service-catalog/components/service-catalog-item/ServiceCatalogItem.spec.tsx
@@ -86,6 +86,7 @@ describe("ServiceCatalogItem", () => {
     userRole: "end_user",
     userId: 123,
     brandId: 456,
+    userName: "Test User",
     organizations: [],
     helpCenterPath: "/hc/en-us",
   };
@@ -97,6 +98,7 @@ describe("ServiceCatalogItem", () => {
     form_id: 100,
     thumbnail_url: "",
     categories: [],
+    allow_request_on_behalf: false,
     custom_object_fields: {
       "standard::asset_option": "",
       "standard::asset_type_option": "",

--- a/src/modules/service-catalog/components/service-catalog-item/ServiceCatalogItem.tsx
+++ b/src/modules/service-catalog/components/service-catalog-item/ServiceCatalogItem.tsx
@@ -48,6 +48,7 @@ export interface ServiceCatalogItemProps {
   brandId: number;
   organizations: Array<Organization>;
   helpCenterPath: string;
+  userName: string;
 }
 
 function getCategoryIdFromUrl(): string | null {
@@ -63,6 +64,7 @@ export function ServiceCatalogItem({
   organizations,
   userId,
   brandId,
+  userName,
   helpCenterPath,
 }: ServiceCatalogItemProps) {
   const { serviceCatalogItem, errorFetchingItem } =
@@ -112,6 +114,8 @@ export function ServiceCatalogItem({
 
   const attachmentsOptionId =
     serviceCatalogItem?.custom_object_fields?.["standard::attachment_option"];
+
+  const requestOnBehalfEnabled = serviceCatalogItem?.allow_request_on_behalf;
 
   const {
     attachmentsOption,
@@ -368,6 +372,8 @@ export function ServiceCatalogItem({
           hasAtMentions={hasAtMentions}
           userRole={userRole}
           userId={userId}
+          requestOnBehalfEnabled={requestOnBehalfEnabled}
+          userName={userName}
           brandId={brandId}
           defaultOrganizationId={defaultOrganizationId}
           handleChange={handleFieldChange}

--- a/src/modules/service-catalog/components/service-catalog-list/ServiceCatalogListItem.spec.tsx
+++ b/src/modules/service-catalog/components/service-catalog-list/ServiceCatalogListItem.spec.tsx
@@ -19,6 +19,7 @@ describe("ServiceCatalogListItem", () => {
     form_id: 456,
     thumbnail_url: "",
     categories: [],
+    allow_request_on_behalf: false,
     custom_object_fields: {
       "standard::asset_option": "",
       "standard::asset_type_option": "",

--- a/src/modules/service-catalog/data-types/ServiceCatalogItem.ts
+++ b/src/modules/service-catalog/data-types/ServiceCatalogItem.ts
@@ -11,6 +11,7 @@ export interface ServiceCatalogItem {
   form_id: number;
   thumbnail_url: string;
   categories: ServiceCatalogItemCategory[];
+  allow_request_on_behalf: boolean;
   custom_object_fields: {
     "standard::asset_option": string;
     "standard::asset_type_option": string;

--- a/src/modules/service-catalog/hooks/useItemFormFields.spec.ts
+++ b/src/modules/service-catalog/hooks/useItemFormFields.spec.ts
@@ -10,6 +10,7 @@ describe("useItemFormFields", () => {
     form_id: 1,
     thumbnail_url: "",
     categories: [],
+    allow_request_on_behalf: false,
     custom_object_fields: {
       "standard::asset_option": "",
       "standard::asset_type_option": "",

--- a/templates/service_page.hbs
+++ b/templates/service_page.hbs
@@ -26,6 +26,7 @@
     hasAtMentions: {{json help_center.at_mentions_enabled}},
     userRole: {{json user.role}},
     userId: {{json user.id}},
+    userName: {{json user.name}},
     brandId: {{json brand.id}},
     organizations: {{json user.organizations}},
     serviceCatalogItemId: id,


### PR DESCRIPTION
## Description

- Display the current user's name as the default requester on the service catalog item request form

- Show a "Change" anchor next to the user name when the `allow_request_on_behalf` flag is enabled on the service catalog item, to support future request-on-behalf functionality

## Reference

- https://zendesk.atlassian.net/browse/PDSC-627

## Screenshots

<img width="1266" height="392" alt="Screenshot 2026-04-16 at 09 56 54" src="https://github.com/user-attachments/assets/95b00343-d5f8-4064-a1c4-ca8872c85e76" />


## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->