### PR TITLE
[PDSC-636] feat: implement requester modal ui

### DIFF
--- a/src/modules/service-catalog/components/change-user-modal/ChangeUserForm.tsx
+++ b/src/modules/service-catalog/components/change-user-modal/ChangeUserForm.tsx
@@ -1,22 +1,16 @@
 import type React from "react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import { Modal } from "@zendeskgarden/react-modals";
 import styled from "styled-components";
 import { getColor } from "@zendeskgarden/react-theming";
-import { Anchor, Button } from "@zendeskgarden/react-buttons";
+import { Button } from "@zendeskgarden/react-buttons";
 import { useTranslation } from "react-i18next";
 import type { IComboboxProps } from "@zendeskgarden/react-dropdowns";
 import { Combobox, Field, Option } from "@zendeskgarden/react-dropdowns";
 import { Span } from "@zendeskgarden/react-typography";
-import debounce from "lodash.debounce";
 import UserCircleStrokeIcon from "@zendeskgarden/svg-icons/src/16/user-circle-stroke.svg";
-import PlusIcon from "@zendeskgarden/svg-icons/src/16/plus-stroke.svg";
-
-interface UserOption {
-  id: string;
-  name: string;
-  email: string;
-}
+import type { UserOption } from "../../data-types/UserOption";
+import { useUserSearch } from "../../hooks/useUserSearch";
 
 interface ChangeUserFormProps {
   onCancel: () => void;
@@ -59,31 +53,13 @@ const StyledContainer = styled.div`
 `;
 
 const StyledOptionContent = styled.div`
-  align-items: none;
+  display: flex;
   flex-direction: column;
-  gap: none;
 `;
 
 const StyledModalFooter = styled(Modal.Footer)`
   padding: 32px 40px;
   border-top: 1px solid rgb(232, 234, 236);
-`;
-
-const StyledAnchor = styled(Anchor)`
-  line-height: normal;
-  display: inline-flex;
-  align-items: center;
-  gap: ${(props) => props.theme.space.xs};
-`;
-
-const DropdownFooter = styled.div`
-  padding: ${(props) => props.theme.space.sm} ${(props) => props.theme.space.xs};
-  border-top: ${(props) => props.theme.borders.sm}
-    ${({ theme }) => getColor({ theme, hue: "grey", shade: 300 })};
-  background: ${({ theme }) =>
-    getColor({ theme, variable: "background.default" })};
-  bottom: 0;
-  z-index: 2;
 `;
 
 export const ChangeUserForm: React.FC<ChangeUserFormProps> = ({
@@ -96,13 +72,16 @@ export const ChangeUserForm: React.FC<ChangeUserFormProps> = ({
   const [userError, setUserError] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
 
-  const [options, setOptions] = useState<UserOption[]>([]);
   const [inputValue, setInputValue] = useState<string>(
     selectedUser?.name ?? ""
   );
-  const [isLoadingOptions, setIsLoadingOptions] = useState<boolean>(false);
   const [isCreating, setIsCreating] = useState(false);
   const isTyping = useRef<boolean>(false);
+
+  const { options, isLoadingOptions, searchUsers, clearOptions } =
+    useUserSearch(selectedUser, () => {
+      isTyping.current = false;
+    });
 
   const highlightMatch = (text: string, query: string) => {
     if (!query.trim()) return text;
@@ -141,54 +120,6 @@ export const ChangeUserForm: React.FC<ChangeUserFormProps> = ({
     email: "",
   };
 
-  const fetchUsers = useCallback(
-    async (searchQuery: string) => {
-      setIsLoadingOptions(true);
-
-      try {
-        const response = await fetch(
-          `/hc/api/v2/service_catalog/users?query=${encodeURIComponent(
-            searchQuery
-          )}`
-        );
-
-        const data = await response.json();
-        if (response.ok) {
-          const userOptions = data.users.map((user: UserOption) => ({
-            id: user.id,
-            name: user.name,
-            email: user.email,
-          }));
-          setOptions(
-            selectedUser
-              ? [
-                  selectedUser,
-                  ...userOptions.filter(
-                    (o: UserOption) => o.id !== selectedUser.id
-                  ),
-                ]
-              : userOptions
-          );
-        }
-      } catch (error) {
-        console.error("Error fetching users:", error);
-        setOptions([]);
-      } finally {
-        setIsLoadingOptions(false);
-      }
-    },
-    [selectedUser]
-  );
-
-  const debouncedFetchUsers = useMemo(
-    () =>
-      debounce((query: string) => {
-        fetchUsers(query);
-        isTyping.current = false;
-      }, 300),
-    [fetchUsers]
-  );
-
   const handleChange = useCallback<NonNullable<IComboboxProps["onChange"]>>(
     ({ inputValue, selectionValue }) => {
       if (selectionValue !== undefined) {
@@ -211,15 +142,15 @@ export const ChangeUserForm: React.FC<ChangeUserFormProps> = ({
         isTyping.current = true; // Mark as typing
 
         if (inputValue.trim().length >= 3) {
-          debouncedFetchUsers(inputValue.trim());
+          searchUsers(inputValue.trim());
         } else {
-          setOptions([]);
+          clearOptions();
           setSelectedUser(null);
           isTyping.current = false;
         }
       }
     },
-    [debouncedFetchUsers, fetchUsers, options]
+    [options, searchUsers, clearOptions, setSelectedUser]
   );
 
   const handleCreate = async () => {
@@ -235,10 +166,6 @@ export const ChangeUserForm: React.FC<ChangeUserFormProps> = ({
     } finally {
       setIsCreating(false);
     }
-  };
-
-  const handleExpand = () => {
-    // Combobox manages its own open/closed state
   };
 
   const setSelectedUserFromInput = useCallback(() => {
@@ -285,12 +212,6 @@ export const ChangeUserForm: React.FC<ChangeUserFormProps> = ({
     [isLoadingOptions, setSelectedUserFromInput]
   );
 
-  useEffect(() => {
-    return () => {
-      debouncedFetchUsers.cancel();
-    };
-  }, [debouncedFetchUsers]);
-
   const displayOptions = isLoadingOptions
     ? [loadingOption]
     : options.length === 0
@@ -318,7 +239,6 @@ export const ChangeUserForm: React.FC<ChangeUserFormProps> = ({
                 inputValue={inputValue}
                 selectionValue={selectedUser?.id}
                 onChange={handleChange}
-                onFocus={handleExpand}
                 validation={userError ? "error" : undefined}
                 data-test-id="user-autocomplete-input"
                 isAutocomplete
@@ -362,15 +282,6 @@ export const ChangeUserForm: React.FC<ChangeUserFormProps> = ({
                       </StyledOption>
                     ))
                   : null}
-                <DropdownFooter>
-                  <StyledAnchor isUnderlined={false}>
-                    <PlusIcon />
-                    {t(
-                      "service-catalog.change-user-modal.add-user",
-                      "Add User"
-                    )}
-                  </StyledAnchor>
-                </DropdownFooter>
               </Combobox>
               {userError && (
                 <Field.Message

--- a/src/modules/service-catalog/components/change-user-modal/ChangeUserForm.tsx
+++ b/src/modules/service-catalog/components/change-user-modal/ChangeUserForm.tsx
@@ -1,0 +1,469 @@
+import type React from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Modal } from "@zendeskgarden/react-modals";
+import styled from "styled-components";
+import { getColor } from "@zendeskgarden/react-theming";
+import { Anchor, Button } from "@zendeskgarden/react-buttons";
+import { useTranslation } from "react-i18next";
+import type { IComboboxProps } from "@zendeskgarden/react-dropdowns";
+import { Combobox, Field, Option } from "@zendeskgarden/react-dropdowns";
+import { Span } from "@zendeskgarden/react-typography";
+import debounce from "lodash.debounce";
+import UserCircleStrokeIcon from "@zendeskgarden/svg-icons/src/16/user-circle-stroke.svg";
+import PlusIcon from "@zendeskgarden/svg-icons/src/16/plus-stroke.svg";
+
+interface UserOption {
+  id: string;
+  name: string;
+  email: string;
+}
+
+interface ChangeUserFormProps {
+  onCancel: () => void;
+  onCreate: (userName: string, userId: string | null) => Promise<void> | void;
+}
+
+const StyledHeader = styled(Modal.Header)`
+  color: ${({ theme }) => getColor({ theme, hue: "successHue", shade: 700 })};
+`;
+
+const FormContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${(props) => props.theme.space.md};
+`;
+
+const StyledModalBody = styled(Modal.Body)`
+  padding-bottom: 48px;
+`;
+
+const StyledOption = styled(Option)`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: ${(props) => props.theme.space.sm};
+`;
+
+const OptionContent = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: ${(props) => props.theme.space.sm};
+`;
+
+const StyledContainer = styled.div`
+  display: flex;
+  gap: ${(props) => props.theme.space.xs};
+`;
+
+const StyledOptionContent = styled.div`
+  align-items: none;
+  flex-direction: column;
+  gap: none;
+`;
+
+const StyledModalFooter = styled(Modal.Footer)`
+  padding: 32px 40px;
+  border-top: 1px solid rgb(232, 234, 236);
+`;
+
+const StyledAnchor = styled(Anchor)`
+  line-height: normal;
+  display: inline-flex;
+  align-items: center;
+  gap: ${(props) => props.theme.space.xs};
+`;
+
+const DropdownFooter = styled.div`
+  padding: ${(props) => props.theme.space.sm} ${(props) => props.theme.space.xs};
+  border-top: ${(props) => props.theme.borders.sm}
+    ${({ theme }) => getColor({ theme, hue: "grey", shade: 300 })};
+  background: ${({ theme }) =>
+    getColor({ theme, variable: "background.default" })};
+  bottom: 0;
+  z-index: 2;
+`;
+
+// Mock data based on the provided structure
+const mockUsersData = {
+  data: {
+    usersAutocomplete: [
+      {
+        id: "9632214379006",
+        email: "qwe@gmail.com",
+        name: "qwe",
+        role: "END_USER",
+      },
+      {
+        id: "9632214379007",
+        email: "test@example.com",
+        name: "Test User",
+        role: "END_USER",
+      },
+      {
+        id: "9632214379008",
+        email: "john.doe@company.com",
+        name: "John Doe",
+        role: "AGENT",
+      },
+      {
+        id: "9632214379009",
+        email: "jenny.kelly@company.com",
+        name: "Jenny Kelly",
+        role: "END_USER",
+      },
+    ],
+  },
+};
+
+export const ChangeUserForm: React.FC<ChangeUserFormProps> = ({
+  onCancel,
+  onCreate,
+}) => {
+  const { t } = useTranslation();
+  const [userError, setUserError] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const [options, setOptions] = useState<UserOption[]>([]);
+  const [selectedUser, setSelectedUser] = useState<UserOption | null>(null);
+  const [inputValue, setInputValue] = useState<string>("");
+  const [isLoadingOptions, setIsLoadingOptions] = useState<boolean>(false);
+  const [isCreating, setIsCreating] = useState(false);
+  const isTyping = useRef(false);
+
+  const highlightMatch = (text: string, query: string) => {
+    if (!query.trim()) return text;
+
+    const index = text.toLowerCase().indexOf(query.toLowerCase());
+    if (index === -1) return text;
+
+    const before = text.slice(0, index);
+    const match = text.slice(index, index + query.length);
+    const after = text.slice(index + query.length);
+
+    return (
+      <>
+        {before}
+        <strong>{match}</strong>
+        {after}
+      </>
+    );
+  };
+
+  const loadingOption: UserOption = {
+    id: "loading",
+    name: t(
+      "service-catalog.change-user-modal.loading-users",
+      "Loading users..."
+    ),
+    email: "",
+  };
+
+  const noResultsOption: UserOption = {
+    id: "no-results",
+    name: t(
+      "service-catalog.change-user-modal.no-matches-found",
+      "Type to search"
+    ),
+    email: "",
+  };
+
+  const fetchUsers = useCallback(
+    async (searchQuery: string) => {
+      setIsLoadingOptions(true);
+
+      try {
+        // TODO: Replace with actual GraphQL API call
+        // For now, using mock data with client-side filtering
+        const filteredUsers = mockUsersData.data.usersAutocomplete.filter(
+          (user) =>
+            user.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
+            user.email.toLowerCase().includes(searchQuery.toLowerCase())
+        );
+
+        const userOptions: UserOption[] = filteredUsers.map((user) => ({
+          id: user.id,
+          name: user.name,
+          email: user.email,
+        }));
+
+        if (selectedUser) {
+          const filteredOptions = userOptions.filter(
+            (option) => option.id !== selectedUser.id
+          );
+          setOptions([selectedUser, ...filteredOptions]);
+        } else {
+          setOptions(userOptions);
+        }
+
+        /*
+        // Actual GraphQL implementation would look like:
+        const response = await fetch('/api/v2/graphql', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            query: `
+              query UsersAutocomplete($query: String!) {
+                usersAutocomplete(query: $query) {
+                  id
+                  name
+                  email
+                  role
+                }
+              }
+            `,
+            variables: { query: searchQuery }
+          })
+        });
+
+        const data = await response.json();
+        if (response.ok) {
+          const userOptions = data.data.usersAutocomplete.map((user: any) => ({
+            id: user.id,
+            name: user.name,
+            email: user.email,
+          }));
+          setOptions(userOptions);
+        }
+        */
+      } catch (error) {
+        console.error("Error fetching users:", error);
+        setOptions([]);
+      } finally {
+        setIsLoadingOptions(false);
+      }
+    },
+    [selectedUser]
+  );
+
+  const debouncedFetchUsers = useMemo(
+    () =>
+      debounce((query: string) => {
+        fetchUsers(query);
+        isTyping.current = false;
+      }, 300),
+    [fetchUsers]
+  );
+
+  const handleChange = useCallback<NonNullable<IComboboxProps["onChange"]>>(
+    ({ inputValue, selectionValue }) => {
+      if (selectionValue !== undefined) {
+        const selectedOption = options.find((opt) => opt.id === selectionValue);
+
+        if (
+          selectedOption &&
+          selectedOption.id !== "loading" &&
+          selectedOption.id !== "no-results"
+        ) {
+          setSelectedUser(selectedOption);
+          setInputValue(selectedOption.name);
+          setUserError(false);
+          isTyping.current = false;
+        }
+      }
+
+      if (inputValue !== undefined) {
+        setInputValue(inputValue);
+        isTyping.current = true; // Mark as typing
+
+        if (inputValue.trim().length >= 1) {
+          debouncedFetchUsers(inputValue.trim());
+        } else {
+          setOptions([]);
+          setSelectedUser(null);
+          isTyping.current = false;
+        }
+      }
+    },
+    [debouncedFetchUsers, fetchUsers, options]
+  );
+
+  const handleCreate = async () => {
+    if (!selectedUser) {
+      setUserError(true);
+      return;
+    }
+
+    setIsCreating(true);
+    try {
+      await onCreate(selectedUser.name, selectedUser.id);
+    } catch (error) {
+      console.error("Error changing user:", error);
+    } finally {
+      setIsCreating(false);
+    }
+  };
+
+  const handleExpand = () => {
+    // Combobox manages its own open/closed state
+  };
+
+  const setSelectedUserFromInput = useCallback(() => {
+    if (!inputValue.trim()) {
+      if (selectedUser) {
+        setSelectedUser(null);
+        setUserError(false);
+      }
+      return;
+    }
+
+    if (
+      selectedUser &&
+      (selectedUser.name.toLowerCase() === inputValue.toLowerCase() ||
+        selectedUser.email.toLowerCase() === inputValue.toLowerCase())
+    ) {
+      return;
+    }
+
+    const match = options.find(
+      (opt) => opt.name.toLowerCase() === inputValue.toLowerCase()
+    );
+
+    if (match) {
+      setSelectedUser(match);
+      setInputValue(match.name);
+      setUserError(false);
+    }
+  }, [inputValue, options, selectedUser]);
+
+  const handleBlur = useCallback(() => {
+    if (!isTyping.current) {
+      setSelectedUserFromInput();
+    }
+  }, [setSelectedUserFromInput]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Enter" && !isTyping.current && !isLoadingOptions) {
+        setSelectedUserFromInput();
+        // Combobox will close automatically on Enter
+      }
+    },
+    [isLoadingOptions, setSelectedUserFromInput]
+  );
+
+  useEffect(() => {
+    return () => {
+      debouncedFetchUsers.cancel();
+    };
+  }, [debouncedFetchUsers]);
+
+  const displayOptions = isLoadingOptions
+    ? [loadingOption]
+    : options.length === 0
+    ? [noResultsOption] // Show "No results" when no options (whether typed or not)
+    : options;
+
+  return (
+    <>
+      <StyledHeader tag="h2">
+        {t("service-catalog.change-user-modal.title", "Change user")}
+      </StyledHeader>
+      <StyledModalBody>
+        <FormContainer>
+          <Field>
+            <Field.Label>
+              {t(
+                "service-catalog.change-user-modal.select-user-label",
+                "Select user* (required)"
+              )}
+            </Field.Label>
+            <Combobox
+              ref={inputRef}
+              inputValue={inputValue}
+              selectionValue={selectedUser?.id}
+              onChange={handleChange}
+              onFocus={handleExpand}
+              validation={userError ? "error" : undefined}
+              data-test-id="user-autocomplete-input"
+              isAutocomplete
+              placeholder={t(
+                "service-catalog.change-user-modal.search-placeholder",
+                "Search users..."
+              )}
+              renderValue={() => selectedUser?.name || ""}
+              inputProps={{
+                onBlur: handleBlur,
+                onKeyDown: handleKeyDown,
+              }}
+            >
+              {displayOptions.length > 0
+                ? displayOptions.map((option) => (
+                    <StyledOption
+                      key={option.id}
+                      value={option.id}
+                      label={option.name}
+                      isDisabled={
+                        option.id === "loading" || option.id === "no-results"
+                      }
+                    >
+                      {option.email ? (
+                        <StyledContainer>
+                          <UserCircleStrokeIcon />
+                          <StyledOptionContent>
+                            <span>
+                              {highlightMatch(option.name, inputValue)}
+                            </span>
+                            <Option.Meta>
+                              <Span hue="grey">{option.email}</Span>
+                            </Option.Meta>
+                          </StyledOptionContent>
+                        </StyledContainer>
+                      ) : (
+                        <OptionContent>
+                          <span>{option.name}</span>
+                        </OptionContent>
+                      )}
+                    </StyledOption>
+                  ))
+                : null}
+              <DropdownFooter>
+                <StyledAnchor
+                  isUnderlined={false}
+                  // TODO: Next step - implement Add User functionality
+                  // onClick={handleAddUser}
+                >
+                  <PlusIcon />
+                  {t("service-catalog.change-user-modal.add-user", "Add User")}
+                </StyledAnchor>
+              </DropdownFooter>
+            </Combobox>
+            {userError && (
+              <Field.Message
+                validation="error"
+                validationLabel={t(
+                  "service-catalog.validation.error.aria.label",
+                  "Error"
+                )}
+              >
+                {t(
+                  "service-catalog.change-user-modal.user-required",
+                  "Select a user"
+                )}
+              </Field.Message>
+            )}
+          </Field>
+        </FormContainer>
+      </StyledModalBody>
+      <StyledModalFooter>
+        <Modal.FooterItem>
+          <Button onClick={onCancel} isBasic data-test-id="cancel-button">
+            {t("service-catalog.change-user-modal.cancel", "Cancel")}
+          </Button>
+        </Modal.FooterItem>
+        <Modal.FooterItem>
+          <Button
+            isPrimary
+            onClick={handleCreate}
+            disabled={isCreating || !selectedUser}
+            data-test-id="change-user-button"
+          >
+            {t("service-catalog.change-user-modal.change-user", "Save")}
+          </Button>
+        </Modal.FooterItem>
+      </StyledModalFooter>
+    </>
+  );
+};

--- a/src/modules/service-catalog/components/change-user-modal/ChangeUserForm.tsx
+++ b/src/modules/service-catalog/components/change-user-modal/ChangeUserForm.tsx
@@ -21,6 +21,8 @@ interface UserOption {
 interface ChangeUserFormProps {
   onCancel: () => void;
   onCreate: (userName: string, userId: string | null) => Promise<void> | void;
+  selectedUser: UserOption | null;
+  setSelectedUser: (user: UserOption | null) => void;
 }
 
 const StyledHeader = styled(Modal.Header)`
@@ -84,52 +86,23 @@ const DropdownFooter = styled.div`
   z-index: 2;
 `;
 
-// Mock data based on the provided structure
-const mockUsersData = {
-  data: {
-    usersAutocomplete: [
-      {
-        id: "9632214379006",
-        email: "qwe@gmail.com",
-        name: "qwe",
-        role: "END_USER",
-      },
-      {
-        id: "9632214379007",
-        email: "test@example.com",
-        name: "Test User",
-        role: "END_USER",
-      },
-      {
-        id: "9632214379008",
-        email: "john.doe@company.com",
-        name: "John Doe",
-        role: "AGENT",
-      },
-      {
-        id: "9632214379009",
-        email: "jenny.kelly@company.com",
-        name: "Jenny Kelly",
-        role: "END_USER",
-      },
-    ],
-  },
-};
-
 export const ChangeUserForm: React.FC<ChangeUserFormProps> = ({
   onCancel,
   onCreate,
+  selectedUser,
+  setSelectedUser,
 }) => {
   const { t } = useTranslation();
   const [userError, setUserError] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
 
   const [options, setOptions] = useState<UserOption[]>([]);
-  const [selectedUser, setSelectedUser] = useState<UserOption | null>(null);
-  const [inputValue, setInputValue] = useState<string>("");
+  const [inputValue, setInputValue] = useState<string>(
+    selectedUser?.name ?? ""
+  );
   const [isLoadingOptions, setIsLoadingOptions] = useState<boolean>(false);
   const [isCreating, setIsCreating] = useState(false);
-  const isTyping = useRef(false);
+  const isTyping = useRef<boolean>(false);
 
   const highlightMatch = (text: string, query: string) => {
     if (!query.trim()) return text;
@@ -173,61 +146,30 @@ export const ChangeUserForm: React.FC<ChangeUserFormProps> = ({
       setIsLoadingOptions(true);
 
       try {
-        // TODO: Replace with actual GraphQL API call
-        // For now, using mock data with client-side filtering
-        const filteredUsers = mockUsersData.data.usersAutocomplete.filter(
-          (user) =>
-            user.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
-            user.email.toLowerCase().includes(searchQuery.toLowerCase())
+        const response = await fetch(
+          `/hc/api/v2/service_catalog/users?query=${encodeURIComponent(
+            searchQuery
+          )}`
         );
-
-        const userOptions: UserOption[] = filteredUsers.map((user) => ({
-          id: user.id,
-          name: user.name,
-          email: user.email,
-        }));
-
-        if (selectedUser) {
-          const filteredOptions = userOptions.filter(
-            (option) => option.id !== selectedUser.id
-          );
-          setOptions([selectedUser, ...filteredOptions]);
-        } else {
-          setOptions(userOptions);
-        }
-
-        /*
-        // Actual GraphQL implementation would look like:
-        const response = await fetch('/api/v2/graphql', {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify({
-            query: `
-              query UsersAutocomplete($query: String!) {
-                usersAutocomplete(query: $query) {
-                  id
-                  name
-                  email
-                  role
-                }
-              }
-            `,
-            variables: { query: searchQuery }
-          })
-        });
 
         const data = await response.json();
         if (response.ok) {
-          const userOptions = data.data.usersAutocomplete.map((user: any) => ({
+          const userOptions = data.users.map((user: UserOption) => ({
             id: user.id,
             name: user.name,
             email: user.email,
           }));
-          setOptions(userOptions);
+          setOptions(
+            selectedUser
+              ? [
+                  selectedUser,
+                  ...userOptions.filter(
+                    (o: UserOption) => o.id !== selectedUser.id
+                  ),
+                ]
+              : userOptions
+          );
         }
-        */
       } catch (error) {
         console.error("Error fetching users:", error);
         setOptions([]);
@@ -268,7 +210,7 @@ export const ChangeUserForm: React.FC<ChangeUserFormProps> = ({
         setInputValue(inputValue);
         isTyping.current = true; // Mark as typing
 
-        if (inputValue.trim().length >= 1) {
+        if (inputValue.trim().length >= 3) {
           debouncedFetchUsers(inputValue.trim());
         } else {
           setOptions([]);
@@ -285,7 +227,6 @@ export const ChangeUserForm: React.FC<ChangeUserFormProps> = ({
       setUserError(true);
       return;
     }
-
     setIsCreating(true);
     try {
       await onCreate(selectedUser.name, selectedUser.id);
@@ -361,90 +302,92 @@ export const ChangeUserForm: React.FC<ChangeUserFormProps> = ({
       <StyledHeader tag="h2">
         {t("service-catalog.change-user-modal.title", "Change user")}
       </StyledHeader>
+
       <StyledModalBody>
         <FormContainer>
-          <Field>
-            <Field.Label>
-              {t(
-                "service-catalog.change-user-modal.select-user-label",
-                "Select user* (required)"
-              )}
-            </Field.Label>
-            <Combobox
-              ref={inputRef}
-              inputValue={inputValue}
-              selectionValue={selectedUser?.id}
-              onChange={handleChange}
-              onFocus={handleExpand}
-              validation={userError ? "error" : undefined}
-              data-test-id="user-autocomplete-input"
-              isAutocomplete
-              placeholder={t(
-                "service-catalog.change-user-modal.search-placeholder",
-                "Search users..."
-              )}
-              renderValue={() => selectedUser?.name || ""}
-              inputProps={{
-                onBlur: handleBlur,
-                onKeyDown: handleKeyDown,
-              }}
-            >
-              {displayOptions.length > 0
-                ? displayOptions.map((option) => (
-                    <StyledOption
-                      key={option.id}
-                      value={option.id}
-                      label={option.name}
-                      isDisabled={
-                        option.id === "loading" || option.id === "no-results"
-                      }
-                    >
-                      {option.email ? (
-                        <StyledContainer>
-                          <UserCircleStrokeIcon />
-                          <StyledOptionContent>
-                            <span>
-                              {highlightMatch(option.name, inputValue)}
-                            </span>
-                            <Option.Meta>
-                              <Span hue="grey">{option.email}</Span>
-                            </Option.Meta>
-                          </StyledOptionContent>
-                        </StyledContainer>
-                      ) : (
-                        <OptionContent>
-                          <span>{option.name}</span>
-                        </OptionContent>
-                      )}
-                    </StyledOption>
-                  ))
-                : null}
-              <DropdownFooter>
-                <StyledAnchor
-                  isUnderlined={false}
-                  // TODO: Next step - implement Add User functionality
-                  // onClick={handleAddUser}
-                >
-                  <PlusIcon />
-                  {t("service-catalog.change-user-modal.add-user", "Add User")}
-                </StyledAnchor>
-              </DropdownFooter>
-            </Combobox>
-            {userError && (
-              <Field.Message
-                validation="error"
-                validationLabel={t(
-                  "service-catalog.validation.error.aria.label",
-                  "Error"
-                )}
-              >
+          <>
+            <Field>
+              <Field.Label>
                 {t(
-                  "service-catalog.change-user-modal.user-required",
-                  "Select a user"
+                  "service-catalog.change-user-modal.select-user-label",
+                  "Select user* (required)"
                 )}
-              </Field.Message>
-            )}
-          </Field>
+              </Field.Label>
+              <Combobox
+                ref={inputRef}
+                inputValue={inputValue}
+                selectionValue={selectedUser?.id}
+                onChange={handleChange}
+                onFocus={handleExpand}
+                validation={userError ? "error" : undefined}
+                data-test-id="user-autocomplete-input"
+                isAutocomplete
+                placeholder={t(
+                  "service-catalog.change-user-modal.search-placeholder",
+                  "Search users..."
+                )}
+                renderValue={() => selectedUser?.name || ""}
+                inputProps={{
+                  onBlur: handleBlur,
+                  onKeyDown: handleKeyDown,
+                }}
+              >
+                {displayOptions.length > 0
+                  ? displayOptions.map((option) => (
+                      <StyledOption
+                        key={option.id}
+                        value={option.id}
+                        label={option.name}
+                        isDisabled={
+                          option.id === "loading" || option.id === "no-results"
+                        }
+                      >
+                        {option.email ? (
+                          <StyledContainer>
+                            <UserCircleStrokeIcon />
+                            <StyledOptionContent>
+                              <span>
+                                {highlightMatch(option.name, inputValue)}
+                              </span>
+                              <Option.Meta>
+                                <Span hue="grey">{option.email}</Span>
+                              </Option.Meta>
+                            </StyledOptionContent>
+                          </StyledContainer>
+                        ) : (
+                          <OptionContent>
+                            <span>{option.name}</span>
+                          </OptionContent>
+                        )}
+                      </StyledOption>
+                    ))
+                  : null}
+                <DropdownFooter>
+                  <StyledAnchor isUnderlined={false}>
+                    <PlusIcon />
+                    {t(
+                      "service-catalog.change-user-modal.add-user",
+                      "Add User"
+                    )}
+                  </StyledAnchor>
+                </DropdownFooter>
+              </Combobox>
+              {userError && (
+                <Field.Message
+                  validation="error"
+                  validationLabel={t(
+                    "service-catalog.validation.error.aria.label",
+                    "Error"
+                  )}
+                >
+                  {t(
+                    "service-catalog.change-user-modal.user-required",
+                    "Select a user"
+                  )}
+                </Field.Message>
+              )}
+            </Field>
+          </>
         </FormContainer>
       </StyledModalBody>
       <StyledModalFooter>

--- a/src/modules/service-catalog/components/change-user-modal/index.tsx
+++ b/src/modules/service-catalog/components/change-user-modal/index.tsx
@@ -1,0 +1,33 @@
+import type React from "react";
+import { Close, Modal } from "@zendeskgarden/react-modals";
+import { ChangeUserForm } from "./ChangeUserForm";
+import { useTranslation } from "react-i18next";
+
+interface ChangeUserModalProps {
+  userId: string | null;
+  onClose: () => void;
+  onCreate: (userName: string, userId: string | null) => Promise<void> | void;
+}
+
+export const ChangeUserModal: React.FC<ChangeUserModalProps> = ({
+  onClose,
+  onCreate,
+}) => {
+  const { t } = useTranslation();
+
+  const handleCreate = async (userName: string, userId: string | null) => {
+    await onCreate(userName, userId);
+  };
+
+  return (
+    <Modal onClose={onClose} focusOnMount={false}>
+      <ChangeUserForm onCancel={onClose} onCreate={handleCreate} />
+      <Close
+        aria-label={t(
+          "service-catalog.change-user-modal.close",
+          "Close dialog"
+        )}
+      />
+    </Modal>
+  );
+};

--- a/src/modules/service-catalog/components/change-user-modal/index.tsx
+++ b/src/modules/service-catalog/components/change-user-modal/index.tsx
@@ -2,15 +2,9 @@ import type React from "react";
 import { Close, Modal } from "@zendeskgarden/react-modals";
 import { ChangeUserForm } from "./ChangeUserForm";
 import { useTranslation } from "react-i18next";
-
-interface UserOption {
-  id: string;
-  name: string;
-  email: string;
-}
+import type { UserOption } from "../../data-types/UserOption";
 
 interface ChangeUserModalProps {
-  userId: string | null;
   onClose: () => void;
   onCreate: (userName: string, userId: string | null) => Promise<void> | void;
   selectedUser: UserOption | null;

--- a/src/modules/service-catalog/components/change-user-modal/index.tsx
+++ b/src/modules/service-catalog/components/change-user-modal/index.tsx
@@ -3,15 +3,25 @@ import { Close, Modal } from "@zendeskgarden/react-modals";
 import { ChangeUserForm } from "./ChangeUserForm";
 import { useTranslation } from "react-i18next";
 
+interface UserOption {
+  id: string;
+  name: string;
+  email: string;
+}
+
 interface ChangeUserModalProps {
   userId: string | null;
   onClose: () => void;
   onCreate: (userName: string, userId: string | null) => Promise<void> | void;
+  selectedUser: UserOption | null;
+  setSelectedUser: (user: UserOption | null) => void;
 }
 
 export const ChangeUserModal: React.FC<ChangeUserModalProps> = ({
   onClose,
   onCreate,
+  selectedUser,
+  setSelectedUser,
 }) => {
   const { t } = useTranslation();
 
@@ -21,7 +31,12 @@ export const ChangeUserModal: React.FC<ChangeUserModalProps> = ({
 
   return (
     <Modal onClose={onClose} focusOnMount={false}>
-      <ChangeUserForm onCancel={onClose} onCreate={handleCreate} />
+      <ChangeUserForm
+        onCancel={onClose}
+        onCreate={handleCreate}
+        selectedUser={selectedUser}
+        setSelectedUser={setSelectedUser}
+      />
       <Close
         aria-label={t(
           "service-catalog.change-user-modal.close",

--- a/src/modules/service-catalog/components/service-catalog-item/ItemRequestForm.tsx
+++ b/src/modules/service-catalog/components/service-catalog-item/ItemRequestForm.tsx
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import { Fragment, useCallback } from "react";
+import { Fragment, useCallback, useState } from "react";
 import { RequestFormField } from "../../../ticket-fields";
 import { Button, Anchor } from "@zendeskgarden/react-buttons";
 import { getColor } from "@zendeskgarden/react-theming";
@@ -22,6 +22,7 @@ import type {
   AttachmentsOption,
 } from "../../data-types/Attachments";
 import { Skeleton } from "@zendeskgarden/react-loaders";
+import { ChangeUserModal } from "../change-user-modal/index";
 
 const Form = styled.form`
   display: flex;
@@ -178,6 +179,20 @@ export function ItemRequestForm({
   isFormInitializing,
 }: ItemRequestFormProps) {
   const { t } = useTranslation();
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const handleOpenModal = () => {
+    setIsModalOpen(true);
+  };
+
+  const handleCloseModal = () => {
+    setIsModalOpen(false);
+  };
+
+  const handleChangeUser = async () => {
+    // TODO: Implement user change logic
+    handleCloseModal();
+  };
 
   const buildLookupFieldOptions = async (
     records: CustomObjectRecord[],
@@ -347,43 +362,52 @@ export function ItemRequestForm({
   };
 
   return (
-    <Form onSubmit={onSubmit} noValidate>
-      <LeftColumn>
-        <CollapsibleDescription
-          title={serviceCatalogItem.name}
-          description={serviceCatalogItem.description}
-          thumbnailUrl={serviceCatalogItem.thumbnail_url}
-        />
-        <FieldsContainer>{renderRequestFields()}</FieldsContainer>
-      </LeftColumn>
-      <RightColumn>
-        <ButtonWrapper>
-          <ButtonContainer>
-            <UserNameWrapper>
-              <Span isBold>{t("service-catalog.item.user", "User")}</Span>
-              <Span>{userName}</Span>
-            </UserNameWrapper>
-            {requestOnBehalfEnabled && (
-              <>
-                <Anchor isUnderlined={false}>
-                  {t(
-                    "service-catalog.item.change-user-requesting-on-behalf",
-                    "Change"
-                  )}
-                </Anchor>
-              </>
-            )}
-          </ButtonContainer>
+    <>
+      <Form onSubmit={onSubmit} noValidate>
+        <LeftColumn>
+          <CollapsibleDescription
+            title={serviceCatalogItem.name}
+            description={serviceCatalogItem.description}
+            thumbnailUrl={serviceCatalogItem.thumbnail_url}
+          />
+          <FieldsContainer>{renderRequestFields()}</FieldsContainer>
+        </LeftColumn>
+        <RightColumn>
+          <ButtonWrapper>
+            <ButtonContainer>
+              <UserNameWrapper>
+                <Span isBold>{t("service-catalog.item.user", "User")}</Span>
+                <Span>{userName}</Span>
+              </UserNameWrapper>
+              {requestOnBehalfEnabled && (
+                <>
+                  <Anchor isUnderlined={false} onClick={handleOpenModal}>
+                    {t(
+                      "service-catalog.item.change-user-requesting-on-behalf",
+                      "Change"
+                    )}
+                  </Anchor>
+                </>
+              )}
+            </ButtonContainer>
 
-          {isFormInitializing ? (
-            <ButtonSkeleton />
-          ) : (
-            <Button isPrimary size="large" isStretched type="submit">
-              {t("service-catalog.item.submit-button", "Submit request")}
-            </Button>
-          )}
-        </ButtonWrapper>
-      </RightColumn>
-    </Form>
+            {isFormInitializing ? (
+              <ButtonSkeleton />
+            ) : (
+              <Button isPrimary size="large" isStretched type="submit">
+                {t("service-catalog.item.submit-button", "Submit request")}
+              </Button>
+            )}
+          </ButtonWrapper>
+        </RightColumn>
+      </Form>
+      {isModalOpen && (
+        <ChangeUserModal
+          userId={userId.toString()}
+          onClose={handleCloseModal}
+          onCreate={handleChangeUser}
+        />
+      )}
+    </>
   );
 }

--- a/src/modules/service-catalog/components/service-catalog-item/ItemRequestForm.tsx
+++ b/src/modules/service-catalog/components/service-catalog-item/ItemRequestForm.tsx
@@ -9,6 +9,7 @@ import { CollapsibleDescription } from "./CollapsibleDescription";
 import type { TicketFieldObject } from "../../../ticket-fields/data-types/TicketFieldObject";
 import type { CustomObjectRecord } from "../../../ticket-fields/data-types/CustomObjectRecord";
 import type { ITAMAssetOptionObject } from "../../data-types/ITAMAssetOptionObject";
+import type { UserOption } from "../../data-types/UserOption";
 import { Span } from "@zendeskgarden/react-typography";
 import { Option } from "@zendeskgarden/react-dropdowns";
 import { Attachments } from "../../../ticket-fields/fields/attachments/Attachments";
@@ -150,12 +151,6 @@ interface ItemRequestFormProps {
   onAttachmentUploadingChange: (isUploading: boolean) => void;
   isFormInitializing: boolean;
   isPreviewMode?: boolean;
-}
-
-interface UserOption {
-  id: string;
-  name: string;
-  email: string;
 }
 
 export function ItemRequestForm({
@@ -427,7 +422,6 @@ export function ItemRequestForm({
       </Form>
       {isModalOpen && (
         <ChangeUserModal
-          userId={userId.toString()}
           onClose={handleCloseModal}
           onCreate={handleChangeUser}
           setSelectedUser={setSelectedUser}

--- a/src/modules/service-catalog/components/service-catalog-item/ItemRequestForm.tsx
+++ b/src/modules/service-catalog/components/service-catalog-item/ItemRequestForm.tsx
@@ -152,6 +152,12 @@ interface ItemRequestFormProps {
   isPreviewMode?: boolean;
 }
 
+interface UserOption {
+  id: string;
+  name: string;
+  email: string;
+}
+
 export function ItemRequestForm({
   requestFields,
   serviceCatalogItem,
@@ -182,6 +188,8 @@ export function ItemRequestForm({
 }: ItemRequestFormProps) {
   const { t } = useTranslation();
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [selectedUser, setSelectedUser] = useState<UserOption | null>(null);
+  const [displayedUserName, setDisplayedUserName] = useState(userName);
 
   const handleOpenModal = () => {
     setIsModalOpen(true);
@@ -191,8 +199,8 @@ export function ItemRequestForm({
     setIsModalOpen(false);
   };
 
-  const handleChangeUser = async () => {
-    // TODO: Implement user change logic
+  const handleChangeUser = async (newUserName: string) => {
+    setDisplayedUserName(newUserName);
     handleCloseModal();
   };
 
@@ -379,7 +387,7 @@ export function ItemRequestForm({
             <ButtonContainer>
               <UserNameWrapper>
                 <Span isBold>{t("service-catalog.item.user", "User")}</Span>
-                <Span>{userName}</Span>
+                <Span>{displayedUserName}</Span>
               </UserNameWrapper>
               {requestOnBehalfEnabled && (
                 <>
@@ -422,6 +430,8 @@ export function ItemRequestForm({
           userId={userId.toString()}
           onClose={handleCloseModal}
           onCreate={handleChangeUser}
+          setSelectedUser={setSelectedUser}
+          selectedUser={selectedUser}
         />
       )}
     </>

--- a/src/modules/service-catalog/components/service-catalog-item/ItemRequestForm.tsx
+++ b/src/modules/service-catalog/components/service-catalog-item/ItemRequestForm.tsx
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import { Fragment, useCallback } from "react";
+import { Fragment, useCallback, useState } from "react";
 import { RequestFormField } from "../../../ticket-fields";
 import { Button, Anchor } from "@zendeskgarden/react-buttons";
 import { getColor } from "@zendeskgarden/react-theming";
@@ -22,6 +22,7 @@ import type {
   AttachmentsOption,
 } from "../../data-types/Attachments";
 import { Skeleton } from "@zendeskgarden/react-loaders";
+import { ChangeUserModal } from "../change-user-modal/index";
 
 const Form = styled.form`
   display: flex;
@@ -180,6 +181,20 @@ export function ItemRequestForm({
   isPreviewMode = false,
 }: ItemRequestFormProps) {
   const { t } = useTranslation();
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const handleOpenModal = () => {
+    setIsModalOpen(true);
+  };
+
+  const handleCloseModal = () => {
+    setIsModalOpen(false);
+  };
+
+  const handleChangeUser = async () => {
+    // TODO: Implement user change logic
+    handleCloseModal();
+  };
 
   const buildLookupFieldOptions = async (
     records: CustomObjectRecord[],
@@ -349,57 +364,66 @@ export function ItemRequestForm({
   };
 
   return (
-    <Form onSubmit={onSubmit} noValidate>
-      <LeftColumn>
-        <CollapsibleDescription
-          title={serviceCatalogItem.name}
-          description={serviceCatalogItem.description}
-          thumbnailUrl={serviceCatalogItem.thumbnail_url}
-        />
-        <FieldsContainer>{renderRequestFields()}</FieldsContainer>
-      </LeftColumn>
-      <RightColumn>
-        <ButtonWrapper>
-          <ButtonContainer>
-            <UserNameWrapper>
-              <Span isBold>{t("service-catalog.item.user", "User")}</Span>
-              <Span>{userName}</Span>
-            </UserNameWrapper>
-            {requestOnBehalfEnabled && (
-              <>
-                <Anchor isUnderlined={false}>
-                  {t(
-                    "service-catalog.item.change-user-requesting-on-behalf",
-                    "Change"
-                  )}
-                </Anchor>
-              </>
-            )}
-          </ButtonContainer>
+    <>
+      <Form onSubmit={onSubmit} noValidate>
+        <LeftColumn>
+          <CollapsibleDescription
+            title={serviceCatalogItem.name}
+            description={serviceCatalogItem.description}
+            thumbnailUrl={serviceCatalogItem.thumbnail_url}
+          />
+          <FieldsContainer>{renderRequestFields()}</FieldsContainer>
+        </LeftColumn>
+        <RightColumn>
+          <ButtonWrapper>
+            <ButtonContainer>
+              <UserNameWrapper>
+                <Span isBold>{t("service-catalog.item.user", "User")}</Span>
+                <Span>{userName}</Span>
+              </UserNameWrapper>
+              {requestOnBehalfEnabled && (
+                <>
+                  <Anchor isUnderlined={false} onClick={handleOpenModal}>
+                    {t(
+                      "service-catalog.item.change-user-requesting-on-behalf",
+                      "Change"
+                    )}
+                  </Anchor>
+                </>
+              )}
+            </ButtonContainer>
 
-          {isFormInitializing ? (
-            <ButtonSkeleton />
-          ) : (
-            <Button
-              isPrimary
-              size="large"
-              isStretched
-              type="submit"
-              disabled={isPreviewMode}
-              title={
-                isPreviewMode
-                  ? t(
-                      "service-catalog.item.preview-mode.submit-disabled-tooltip",
-                      "Submitting requests is disabled while previewing a draft"
-                    )
-                  : undefined
-              }
-            >
-              {t("service-catalog.item.submit-button", "Submit request")}
-            </Button>
-          )}
-        </ButtonWrapper>
-      </RightColumn>
-    </Form>
+            {isFormInitializing ? (
+              <ButtonSkeleton />
+            ) : (
+              <Button
+                isPrimary
+                size="large"
+                isStretched
+                type="submit"
+                disabled={isPreviewMode}
+                title={
+                  isPreviewMode
+                    ? t(
+                        "service-catalog.item.preview-mode.submit-disabled-tooltip",
+                        "Submitting requests is disabled while previewing a draft"
+                      )
+                    : undefined
+                }
+              >
+                {t("service-catalog.item.submit-button", "Submit request")}
+              </Button>
+            )}
+          </ButtonWrapper>
+        </RightColumn>
+      </Form>
+      {isModalOpen && (
+        <ChangeUserModal
+          userId={userId.toString()}
+          onClose={handleCloseModal}
+          onCreate={handleChangeUser}
+        />
+      )}
+    </>
   );
 }

--- a/src/modules/service-catalog/components/service-catalog-item/ServiceCatalogItem.spec.tsx
+++ b/src/modules/service-catalog/components/service-catalog-item/ServiceCatalogItem.spec.tsx
@@ -113,7 +113,7 @@ describe("ServiceCatalogItem", () => {
     form_id: 100,
     thumbnail_url: "",
     categories: [],
-    allow_request_on_behalf: false,
+    is_request_on_behalf: false,
     published_at: "2025-01-01T00:00:00Z",
     custom_object_fields: {
       "standard::asset_option": "",

--- a/src/modules/service-catalog/components/service-catalog-item/ServiceCatalogItem.tsx
+++ b/src/modules/service-catalog/components/service-catalog-item/ServiceCatalogItem.tsx
@@ -119,8 +119,7 @@ export function ServiceCatalogItem({
   const attachmentsOptionId =
     serviceCatalogItem?.custom_object_fields?.["standard::attachment_option"];
 
-  const requestOnBehalfEnabled = true;
-  // const requestOnBehalfEnabled = serviceCatalogItem?.allow_request_on_behalf;
+  const requestOnBehalfEnabled = serviceCatalogItem?.is_request_on_behalf;
 
   const {
     attachmentsOption,

--- a/src/modules/service-catalog/components/service-catalog-item/ServiceCatalogItem.tsx
+++ b/src/modules/service-catalog/components/service-catalog-item/ServiceCatalogItem.tsx
@@ -119,7 +119,8 @@ export function ServiceCatalogItem({
   const attachmentsOptionId =
     serviceCatalogItem?.custom_object_fields?.["standard::attachment_option"];
 
-  const requestOnBehalfEnabled = serviceCatalogItem?.allow_request_on_behalf;
+  const requestOnBehalfEnabled = true;
+  // const requestOnBehalfEnabled = serviceCatalogItem?.allow_request_on_behalf;
 
   const {
     attachmentsOption,

--- a/src/modules/service-catalog/components/service-catalog-item/ServiceCatalogItem.tsx
+++ b/src/modules/service-catalog/components/service-catalog-item/ServiceCatalogItem.tsx
@@ -115,7 +115,8 @@ export function ServiceCatalogItem({
   const attachmentsOptionId =
     serviceCatalogItem?.custom_object_fields?.["standard::attachment_option"];
 
-  const requestOnBehalfEnabled = serviceCatalogItem?.allow_request_on_behalf;
+  const requestOnBehalfEnabled = true;
+  // const requestOnBehalfEnabled = serviceCatalogItem?.allow_request_on_behalf;
 
   const {
     attachmentsOption,

--- a/src/modules/service-catalog/components/service-catalog-list/ServiceCatalogListItem.spec.tsx
+++ b/src/modules/service-catalog/components/service-catalog-list/ServiceCatalogListItem.spec.tsx
@@ -19,7 +19,7 @@ describe("ServiceCatalogListItem", () => {
     form_id: 456,
     thumbnail_url: "",
     categories: [],
-    allow_request_on_behalf: false,
+    is_request_on_behalf: false,
     published_at: "2025-01-01T00:00:00Z",
     custom_object_fields: {
       "standard::asset_option": "",

--- a/src/modules/service-catalog/data-types/ServiceCatalogItem.ts
+++ b/src/modules/service-catalog/data-types/ServiceCatalogItem.ts
@@ -11,7 +11,7 @@ export interface ServiceCatalogItem {
   form_id: number;
   thumbnail_url: string;
   categories: ServiceCatalogItemCategory[];
-  allow_request_on_behalf: boolean;
+  is_request_on_behalf: boolean;
   // null when the item is a draft (not yet published). Populated only for
   // authorized users (admins/managers) previewing a draft item.
   published_at: string | null;

--- a/src/modules/service-catalog/data-types/UserOption.ts
+++ b/src/modules/service-catalog/data-types/UserOption.ts
@@ -1,0 +1,5 @@
+export interface UserOption {
+  id: string;
+  name: string;
+  email: string;
+}

--- a/src/modules/service-catalog/hooks/useItemFormFields.spec.ts
+++ b/src/modules/service-catalog/hooks/useItemFormFields.spec.ts
@@ -10,7 +10,7 @@ describe("useItemFormFields", () => {
     form_id: 1,
     thumbnail_url: "",
     categories: [],
-    allow_request_on_behalf: false,
+    is_request_on_behalf: false,
     published_at: "2025-01-01T00:00:00Z",
     custom_object_fields: {
       "standard::asset_option": "",

--- a/src/modules/service-catalog/hooks/useUserSearch.spec.ts
+++ b/src/modules/service-catalog/hooks/useUserSearch.spec.ts
@@ -1,0 +1,166 @@
+import { renderHook, act } from "@testing-library/react-hooks";
+import { useUserSearch } from "./useUserSearch";
+import type { UserOption } from "../data-types/UserOption";
+
+const userA: UserOption = {
+  id: "1",
+  name: "Alice",
+  email: "alice@example.com",
+};
+const userB: UserOption = { id: "2", name: "Bob", email: "bob@example.com" };
+
+const okResponse = (users: UserOption[]) => ({
+  ok: true,
+  json: () => Promise.resolve({ users }),
+});
+
+describe("useUserSearch", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  it("debounces the search and fetches the encoded query", async () => {
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValue(okResponse([userA])) as jest.Mock;
+    global.fetch = fetchMock;
+
+    const { result } = renderHook(() => useUserSearch(null));
+
+    act(() => {
+      result.current.searchUsers("a b");
+      result.current.searchUsers("ali");
+    });
+
+    // Nothing fires before the debounce window elapses.
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    await act(async () => {
+      jest.advanceTimersByTime(300);
+    });
+
+    // Only the last call fires, once.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/hc/api/v2/service_catalog/users?query=ali",
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
+    );
+    expect(result.current.options).toEqual([userA]);
+    expect(result.current.isLoadingOptions).toBe(false);
+  });
+
+  it("invokes onSearchFired when a debounced search fires", async () => {
+    global.fetch = jest.fn().mockResolvedValue(okResponse([])) as jest.Mock;
+    const onSearchFired = jest.fn();
+
+    const { result } = renderHook(() => useUserSearch(null, onSearchFired));
+
+    act(() => {
+      result.current.searchUsers("ali");
+    });
+    expect(onSearchFired).not.toHaveBeenCalled();
+
+    await act(async () => {
+      jest.advanceTimersByTime(300);
+    });
+
+    expect(onSearchFired).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the selected user first in the results, de-duplicated", async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValue(okResponse([userB, userA])) as jest.Mock;
+
+    const { result } = renderHook(() => useUserSearch(userA));
+
+    await act(async () => {
+      result.current.searchUsers("user");
+      jest.advanceTimersByTime(300);
+    });
+
+    // userA is hoisted to the front and not duplicated.
+    expect(result.current.options).toEqual([userA, userB]);
+  });
+
+  it("aborts the previous request when a new search fires", async () => {
+    const abortSpy = jest.spyOn(AbortController.prototype, "abort");
+    global.fetch = jest
+      .fn()
+      .mockResolvedValue(okResponse([userA])) as jest.Mock;
+
+    const { result } = renderHook(() => useUserSearch(null));
+
+    // First request goes in flight.
+    await act(async () => {
+      result.current.searchUsers("ali");
+      jest.advanceTimersByTime(300);
+    });
+
+    // Second request should abort the first.
+    await act(async () => {
+      result.current.searchUsers("bob");
+      jest.advanceTimersByTime(300);
+    });
+    // Let any settled promises flush so no state update escapes act().
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(abortSpy).toHaveBeenCalled();
+    abortSpy.mockRestore();
+  });
+
+  it("clearOptions cancels pending searches and empties the list", async () => {
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValue(okResponse([userA])) as jest.Mock;
+    global.fetch = fetchMock;
+
+    const { result } = renderHook(() => useUserSearch(null));
+
+    // Populate options first.
+    await act(async () => {
+      result.current.searchUsers("ali");
+      jest.advanceTimersByTime(300);
+    });
+    expect(result.current.options).toEqual([userA]);
+
+    // Queue another search, then clear before it fires.
+    await act(async () => {
+      result.current.searchUsers("bob");
+      result.current.clearOptions();
+      jest.advanceTimersByTime(300);
+    });
+
+    expect(result.current.options).toEqual([]);
+    // The queued "bob" search was cancelled, so no second fetch happened.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("empties options on fetch error", async () => {
+    global.fetch = jest
+      .fn()
+      .mockRejectedValue(new Error("network")) as jest.Mock;
+    const consoleError = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    const { result } = renderHook(() => useUserSearch(null));
+
+    await act(async () => {
+      result.current.searchUsers("ali");
+      jest.advanceTimersByTime(300);
+    });
+
+    expect(result.current.options).toEqual([]);
+    expect(result.current.isLoadingOptions).toBe(false);
+    consoleError.mockRestore();
+  });
+});

--- a/src/modules/service-catalog/hooks/useUserSearch.ts
+++ b/src/modules/service-catalog/hooks/useUserSearch.ts
@@ -1,0 +1,98 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import debounce from "lodash.debounce";
+import type { UserOption } from "../data-types/UserOption";
+
+const SEARCH_DEBOUNCE_MS = 300;
+
+export function useUserSearch(
+  selectedUser: UserOption | null,
+  onSearchFired?: () => void
+) {
+  const [options, setOptions] = useState<UserOption[]>([]);
+  const [isLoadingOptions, setIsLoadingOptions] = useState(false);
+
+  // Read the latest values inside the (stable) fetch without recreating it.
+  const selectedUserRef = useRef(selectedUser);
+  useEffect(() => {
+    selectedUserRef.current = selectedUser;
+  }, [selectedUser]);
+
+  const onSearchFiredRef = useRef(onSearchFired);
+  useEffect(() => {
+    onSearchFiredRef.current = onSearchFired;
+  }, [onSearchFired]);
+
+  // Tracks the in-flight request so we can abort it and ignore stale results.
+  const abortControllerRef = useRef<AbortController | null>(null);
+
+  const fetchUsers = useCallback(async (searchQuery: string) => {
+    abortControllerRef.current?.abort();
+    const controller = new AbortController();
+    abortControllerRef.current = controller;
+
+    setIsLoadingOptions(true);
+
+    try {
+      const response = await fetch(
+        `/hc/api/v2/service_catalog/users?query=${encodeURIComponent(
+          searchQuery
+        )}`,
+        { signal: controller.signal }
+      );
+
+      const data = await response.json();
+      if (response.ok) {
+        const selected = selectedUserRef.current;
+        const userOptions: UserOption[] = data.users.map(
+          (user: UserOption) => ({
+            id: user.id,
+            name: user.name,
+            email: user.email,
+          })
+        );
+        setOptions(
+          selected
+            ? [selected, ...userOptions.filter((o) => o.id !== selected.id)]
+            : userOptions
+        );
+      }
+    } catch (error) {
+      // A newer search aborted this one; the newer request owns the state.
+      if (error instanceof DOMException && error.name === "AbortError") {
+        return;
+      }
+      console.error("Error fetching users:", error);
+      setOptions([]);
+    } finally {
+      // Only the most recent request may clear the loading flag, otherwise an
+      // aborted request would hide the spinner for the one still running.
+      if (abortControllerRef.current === controller) {
+        setIsLoadingOptions(false);
+      }
+    }
+  }, []);
+
+  const searchUsers = useMemo(
+    () =>
+      debounce((query: string) => {
+        fetchUsers(query);
+        onSearchFiredRef.current?.();
+      }, SEARCH_DEBOUNCE_MS),
+    [fetchUsers]
+  );
+
+  const clearOptions = useCallback(() => {
+    searchUsers.cancel();
+    abortControllerRef.current?.abort();
+    setOptions([]);
+  }, [searchUsers]);
+
+  useEffect(() => {
+    return () => {
+      searchUsers.cancel();
+      abortControllerRef.current?.abort();
+    };
+  }, [searchUsers]);
+
+  return { options, isLoadingOptions, searchUsers, clearOptions };
+}


### PR DESCRIPTION
## Description

This PR adds "Change User" modal with autocomplete user search functionality to allow changing the requester on behalf of whom the service catalog request is being submitted. The end of implementation on changing/adding a current user will be in a follow-up PR.

## Screenshots

https://github.com/user-attachments/assets/95658c51-6cd6-4fb6-9cc2-81060729d97b

## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->