### PR TITLE
feat: add translations for RoB

### DIFF
--- a/src/modules/service-catalog/translations/en-us.yml
+++ b/src/modules/service-catalog/translations/en-us.yml
@@ -222,7 +222,7 @@ parts:
       key: "service-catalog.change-user-modal.add-user"
       title: "Link text to add a new user in Change User modal dropdown footer"
       screenshot: "https://drive.google.com/file/d/1J9wEdvh_WC0j2aoRbQUA6nEHPFDv2NVd/view?usp=share_link"
-      value: "Add User"
+      value: "Add user"
   - translation:
       key: "service-catalog.validation.error.aria.label"
       title: "[A11Y] Hidden label for screen readers for validation error messages"
@@ -257,7 +257,7 @@ parts:
       key: "service-catalog.change-user-modal.new-user-email"
       title: "Label for email input field in Add User form"
       screenshot: "https://drive.google.com/file/d/1Br5FvhlHzgUPl4FQlQnZcDA83pXKmHea/view?usp=share_link"
-      value: "E-mail"
+      value: "Email"
   - translation:
       key: "service-catalog.change-user-modal.new-user-name-required"
       title: "Error message when name field is empty in Add User form"
@@ -267,4 +267,4 @@ parts:
       key: "service-catalog.change-user-modal.new-user-email-exists"
       title: "Error message when email already exists in Add User form"
       screenshot: "https://drive.google.com/file/d/1Br5FvhlHzgUPl4FQlQnZcDA83pXKmHea/view?usp=share_link"
-      value: "This email is already being used by an user."
+      value: "This email is already being used by a user."

--- a/src/modules/service-catalog/translations/en-us.yml
+++ b/src/modules/service-catalog/translations/en-us.yml
@@ -188,3 +188,83 @@ parts:
       title: "Label for the navigation item in the service catalog sidebar that shows uncategorized services"
       screenshot: "https://drive.google.com/file/d/1QaRvkzKPV1ptp6fQ2JLeUJV91p6vBftE/view?usp=share_link"
       value: "Uncategorized"
+  - translation:
+      key: "service-catalog.change-user-modal.close"
+      title: "[A11Y] Hidden label for screen readers for close button in Change User modal"
+      screenshot: "https://drive.google.com/file/d/1J9wEdvh_WC0j2aoRbQUA6nEHPFDv2NVd/view?usp=share_link"
+      value: "Close modal"
+  - translation:
+      key: "service-catalog.change-user-modal.title"
+      title: "Modal title for changing the requester user"
+      screenshot: "https://drive.google.com/file/d/1J9wEdvh_WC0j2aoRbQUA6nEHPFDv2NVd/view?usp=share_link"
+      value: "Change user"
+  - translation:
+      key: "service-catalog.change-user-modal.select-user-label"
+      title: "Label for user selection dropdown in Change User modal"
+      screenshot: "https://drive.google.com/file/d/1J9wEdvh_WC0j2aoRbQUA6nEHPFDv2NVd/view?usp=share_link"
+      value: "Select user* (required)"
+  - translation:
+      key: "service-catalog.change-user-modal.search-placeholder"
+      title: "Placeholder text for user search input in Change User modal"
+      screenshot: "https://drive.google.com/file/d/1J9wEdvh_WC0j2aoRbQUA6nEHPFDv2NVd/view?usp=share_link"
+      value: "Search users..."
+  - translation:
+      key: "service-catalog.change-user-modal.loading-users"
+      title: "Loading state message while fetching users in Change User modal"
+      screenshot: "https://drive.google.com/file/d/1vGrS-VCQ3sjR2rjuCItssLuJhmrll98D/view?usp=share_link"
+      value: "Loading users..."
+  - translation:
+      key: "service-catalog.change-user-modal.no-matches-found"
+      title: "Empty state message when no users match the search in Change User modal"
+      screenshot: "https://drive.google.com/file/d/1J9wEdvh_WC0j2aoRbQUA6nEHPFDv2NVd/view?usp=share_link"
+      value: "Type to search"
+  - translation:
+      key: "service-catalog.change-user-modal.add-user"
+      title: "Link text to add a new user in Change User modal dropdown footer"
+      screenshot: "https://drive.google.com/file/d/1J9wEdvh_WC0j2aoRbQUA6nEHPFDv2NVd/view?usp=share_link"
+      value: "Add User"
+  - translation:
+      key: "service-catalog.validation.error.aria.label"
+      title: "[A11Y] Hidden label for screen readers for validation error messages"
+      screenshot: "https://drive.google.com/file/d/1J9wEdvh_WC0j2aoRbQUA6nEHPFDv2NVd/view?usp=share_link"
+      value: "Error"
+  - translation:
+      key: "service-catalog.change-user-modal.user-required"
+      title: "Error message when user tries to save without selecting a user"
+      screenshot: "https://drive.google.com/file/d/1NzYBWHmHQZPPia0ud3uLWy41haGPQwUn/view?usp=share_link"
+      value: "Select a user"
+  - translation:
+      key: "service-catalog.change-user-modal.cancel"
+      title: "Cancel button text in Change User modal"
+      screenshot: "https://drive.google.com/file/d/1J9wEdvh_WC0j2aoRbQUA6nEHPFDv2NVd/view?usp=share_link"
+      value: "Cancel"
+  - translation:
+      key: "service-catalog.change-user-modal.change-user"
+      title: "Save/Submit button text in Change User modal"
+      screenshot: "https://drive.google.com/file/d/1J9wEdvh_WC0j2aoRbQUA6nEHPFDv2NVd/view?usp=share_link"
+      value: "Save"
+  - translation:
+      key: "service-catalog.item.change-user-requesting-on-behalf"
+      title: "Link text to change the requester user on behalf of whom the request is being submitted"
+      screenshot: "https://drive.google.com/file/d/1k5um4vxeW-SV1vQlblYJFU4uHzdejvju/view?usp=share_link"
+      value: "Change"
+  - translation:
+      key: "service-catalog.change-user-modal.new-user-name"
+      title: "Label for name input field in Add User form"
+      screenshot: "https://drive.google.com/file/d/1Br5FvhlHzgUPl4FQlQnZcDA83pXKmHea/view?usp=share_link"
+      value: "Name*"
+  - translation:
+      key: "service-catalog.change-user-modal.new-user-email"
+      title: "Label for email input field in Add User form"
+      screenshot: "https://drive.google.com/file/d/1Br5FvhlHzgUPl4FQlQnZcDA83pXKmHea/view?usp=share_link"
+      value: "E-mail"
+  - translation:
+      key: "service-catalog.change-user-modal.new-user-name-required"
+      title: "Error message when name field is empty in Add User form"
+      screenshot: "https://drive.google.com/file/d/1Br5FvhlHzgUPl4FQlQnZcDA83pXKmHea/view?usp=share_link"
+      value: "Enter a name"
+  - translation:
+      key: "service-catalog.change-user-modal.new-user-email-exists"
+      title: "Error message when email already exists in Add User form"
+      screenshot: "https://drive.google.com/file/d/1Br5FvhlHzgUPl4FQlQnZcDA83pXKmHea/view?usp=share_link"
+      value: "This email is already being used by an user."


### PR DESCRIPTION
## Description

This PR adds 17 new translation keys to support the Request on Behalf (RoB) feature in the service catalog module, specifically for the Change User modal functionality:

**Change User Modal:**

Modal title, close button, and user selection UI
Search placeholder and loading states
Validation error messages
Action buttons (Cancel/Save)

**Add User Form:**

Name and email input field labels
Validation error messages (name required, email already exists)

**Accessibility:**

Screen reader labels for close button and error states


## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->