### PR TITLE
feat: preview mode in sc item

### DIFF
--- a/src/modules/service-catalog/components/service-catalog-item/ItemRequestForm.tsx
+++ b/src/modules/service-catalog/components/service-catalog-item/ItemRequestForm.tsx
@@ -148,6 +148,7 @@ interface ItemRequestFormProps {
   assetIds: string[];
   onAttachmentUploadingChange: (isUploading: boolean) => void;
   isFormInitializing: boolean;
+  isPreviewMode?: boolean;
 }
 
 export function ItemRequestForm({
@@ -176,6 +177,7 @@ export function ItemRequestForm({
   assetIds,
   onAttachmentUploadingChange,
   isFormInitializing,
+  isPreviewMode = false,
 }: ItemRequestFormProps) {
   const { t } = useTranslation();
 
@@ -378,7 +380,21 @@ export function ItemRequestForm({
           {isFormInitializing ? (
             <ButtonSkeleton />
           ) : (
-            <Button isPrimary size="large" isStretched type="submit">
+            <Button
+              isPrimary
+              size="large"
+              isStretched
+              type="submit"
+              disabled={isPreviewMode}
+              title={
+                isPreviewMode
+                  ? t(
+                      "service-catalog.item.preview-mode.submit-disabled-tooltip",
+                      "Submitting requests is disabled while previewing a draft"
+                    )
+                  : undefined
+              }
+            >
               {t("service-catalog.item.submit-button", "Submit request")}
             </Button>
           )}

--- a/src/modules/service-catalog/components/service-catalog-item/PreviewModeBanner.spec.tsx
+++ b/src/modules/service-catalog/components/service-catalog-item/PreviewModeBanner.spec.tsx
@@ -1,0 +1,79 @@
+import { render, screen, within } from "@testing-library/react";
+import { ThemeProvider } from "styled-components";
+import { DEFAULT_THEME } from "@zendeskgarden/react-theming";
+import { PreviewModeBanner } from "./PreviewModeBanner";
+
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (_key: string, defaultValue: string) => defaultValue,
+  }),
+}));
+
+const renderWithTheme = (component: React.ReactElement) => {
+  return render(
+    <ThemeProvider theme={DEFAULT_THEME}>{component}</ThemeProvider>
+  );
+};
+
+describe("PreviewModeBanner", () => {
+  let originalBodyPaddingTop: string;
+
+  beforeEach(() => {
+    originalBodyPaddingTop = document.body.style.paddingTop;
+    document.body.style.removeProperty("padding-top");
+  });
+
+  afterEach(() => {
+    document.body.style.removeProperty("padding-top");
+    document.body.style.paddingTop = originalBodyPaddingTop;
+  });
+
+  it("renders a Garden Global Alert with the title and message", () => {
+    renderWithTheme(<PreviewModeBanner />);
+
+    const banner = screen.getByTestId("preview-mode-banner");
+    expect(banner).toBeInTheDocument();
+
+    const alert = within(banner).getByRole("status");
+    expect(alert).toBeInTheDocument();
+
+    expect(within(banner).getByText("Preview mode")).toBeInTheDocument();
+    expect(
+      within(banner).getByText(
+        "If you navigate away from this page or click on anything outside of this preview, you'll exit the preview mode."
+      )
+    ).toBeInTheDocument();
+  });
+
+  it("portals to a fixed host pinned at the top of the body with the highest z-index", () => {
+    renderWithTheme(<PreviewModeBanner />);
+
+    const host = document.body.firstElementChild as HTMLElement;
+    expect(host.getAttribute("data-preview-mode-banner-host")).toBe("true");
+    expect(host.style.position).toBe("fixed");
+    expect(host.style.top).toBe("0px");
+    expect(host.style.zIndex).toBe("2147483647");
+  });
+
+  it("reserves body padding-top to keep page content below the banner", () => {
+    renderWithTheme(<PreviewModeBanner />);
+
+    expect(document.body.style.paddingTop).not.toBe("");
+  });
+
+  it("removes its host element and restores body padding-top on unmount", () => {
+    document.body.style.paddingTop = "64px";
+
+    const { unmount } = renderWithTheme(<PreviewModeBanner />);
+    expect(
+      document.querySelector("[data-preview-mode-banner-host]")
+    ).not.toBeNull();
+
+    unmount();
+
+    expect(
+      document.querySelector("[data-preview-mode-banner-host]")
+    ).toBeNull();
+    expect(document.body.style.paddingTop).toBe("64px");
+  });
+});

--- a/src/modules/service-catalog/components/service-catalog-item/PreviewModeBanner.tsx
+++ b/src/modules/service-catalog/components/service-catalog-item/PreviewModeBanner.tsx
@@ -1,0 +1,116 @@
+import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import styled from "styled-components";
+import { GlobalAlert } from "@zendeskgarden/react-notifications";
+import { getColor } from "@zendeskgarden/react-theming";
+import { useTranslation } from "react-i18next";
+import { Z_INDEX_ABOVE_NAVBAR } from "../../../shared/notifications/constants";
+
+const StyledGlobalAlert = styled(GlobalAlert)`
+  background: ${({ theme }) => getColor({ theme, hue: "blue", shade: 200 })};
+  border-bottom: 1px solid
+    ${({ theme }) => getColor({ theme, hue: "blue", shade: 300 })};
+  color: ${({ theme }) => getColor({ theme, hue: "blue", shade: 700 })};
+  box-shadow: none;
+
+  svg {
+    color: ${({ theme }) => getColor({ theme, hue: "blue", shade: 600 })};
+  }
+`;
+
+const StyledGlobalAlertTitle = styled(GlobalAlert.Title)`
+  color: ${({ theme }) => getColor({ theme, hue: "blue", shade: 800 })};
+`;
+
+export function PreviewModeBanner() {
+  const { t } = useTranslation();
+  const [portalHost, setPortalHost] = useState<HTMLDivElement | null>(null);
+  const initialBodyPaddingTopRef = useRef<string>("");
+
+  useEffect(() => {
+    const host = document.createElement("div");
+    host.setAttribute("data-preview-mode-banner-host", "true");
+    host.style.position = "fixed";
+    host.style.top = "0";
+    host.style.left = "0";
+    host.style.right = "0";
+    host.style.zIndex = String(Z_INDEX_ABOVE_NAVBAR);
+
+    initialBodyPaddingTopRef.current = document.body.style.paddingTop;
+
+    document.body.prepend(host);
+    setPortalHost(host);
+
+    return () => {
+      host.remove();
+      document.body.style.paddingTop = initialBodyPaddingTopRef.current;
+      setPortalHost(null);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!portalHost) {
+      return;
+    }
+
+    let lastPadding = "";
+    let animationFrameId: number | null = null;
+
+    const applyLayout = () => {
+      animationFrameId = null;
+      const bannerHeight = portalHost.offsetHeight;
+      const nextPadding = `${bannerHeight}px`;
+      if (nextPadding !== lastPadding) {
+        document.body.style.paddingTop = nextPadding;
+        lastPadding = nextPadding;
+      }
+    };
+
+    const scheduleApply = () => {
+      if (animationFrameId !== null) {
+        return;
+      }
+      animationFrameId = window.requestAnimationFrame(applyLayout);
+    };
+
+    applyLayout();
+
+    let resizeObserver: ResizeObserver | undefined;
+    if (typeof ResizeObserver !== "undefined") {
+      resizeObserver = new ResizeObserver(scheduleApply);
+      resizeObserver.observe(portalHost);
+    }
+
+    window.addEventListener("resize", scheduleApply);
+
+    return () => {
+      if (animationFrameId !== null) {
+        window.cancelAnimationFrame(animationFrameId);
+      }
+      resizeObserver?.disconnect();
+      window.removeEventListener("resize", scheduleApply);
+      document.body.style.paddingTop = initialBodyPaddingTopRef.current;
+    };
+  }, [portalHost]);
+
+  if (!portalHost) {
+    return null;
+  }
+
+  return createPortal(
+    <div data-testid="preview-mode-banner">
+      <StyledGlobalAlert type="info">
+        <GlobalAlert.Content>
+          <StyledGlobalAlertTitle>
+            {t("service-catalog.item.preview-mode.title", "Preview mode")}
+          </StyledGlobalAlertTitle>
+          {t(
+            "service-catalog.item.preview-mode.message",
+            "If you navigate away from this page or click on anything outside of this preview, you'll exit the preview mode."
+          )}
+        </GlobalAlert.Content>
+      </StyledGlobalAlert>
+    </div>,
+    portalHost
+  );
+}

--- a/src/modules/service-catalog/components/service-catalog-item/ServiceCatalogItem.spec.tsx
+++ b/src/modules/service-catalog/components/service-catalog-item/ServiceCatalogItem.spec.tsx
@@ -6,6 +6,7 @@ import { submitServiceItemRequest } from "./submitServiceItemRequest";
 import * as notifications from "../../../shared/notifications";
 import type { ServiceCatalogItem as ServiceCatalogItemType } from "../../data-types/ServiceCatalogItem";
 import type { TicketFieldObject } from "../../../ticket-fields/data-types/TicketFieldObject";
+import { PREVIEW_MODE_HTML_CLASS } from "../../constants";
 
 // Mock react-i18next
 jest.mock("react-i18next", () => ({
@@ -43,15 +44,29 @@ jest.mock("../../hooks/useAttachmentsOption", () => ({
 jest.mock("./ItemRequestForm", () => ({
   ItemRequestForm: ({
     onSubmit,
+    isPreviewMode,
   }: {
     onSubmit: (e: React.FormEvent<HTMLFormElement>) => void;
+    isPreviewMode?: boolean;
   }) => (
-    <form data-testid="item-request-form" onSubmit={onSubmit}>
-      <button type="submit">Submit</button>
+    <form
+      data-testid="item-request-form"
+      data-preview-mode={isPreviewMode ? "true" : "false"}
+      onSubmit={onSubmit}
+    >
+      <button type="submit" disabled={isPreviewMode}>
+        Submit
+      </button>
     </form>
   ),
   ASSET_TYPE_KEY: "zen:custom_object:standard::itam_asset_type",
   ASSET_KEY: "zen:custom_object:standard::itam_asset",
+}));
+
+// Mock PreviewModeBanner so we can assert it renders without testing portal
+// behaviour here (it has its own dedicated specs).
+jest.mock("./PreviewModeBanner", () => ({
+  PreviewModeBanner: () => <div data-testid="preview-mode-banner-mock" />,
 }));
 
 import { useServiceCatalogItem } from "../../hooks/useServiceCatalogItem";
@@ -99,11 +114,17 @@ describe("ServiceCatalogItem", () => {
     thumbnail_url: "",
     categories: [],
     allow_request_on_behalf: false,
+    published_at: "2025-01-01T00:00:00Z",
     custom_object_fields: {
       "standard::asset_option": "",
       "standard::asset_type_option": "",
       "standard::attachment_option": "",
     },
+  };
+
+  const mockDraftServiceCatalogItem: ServiceCatalogItemType = {
+    ...mockServiceCatalogItem,
+    published_at: null,
   };
 
   const mockRequestFields: TicketFieldObject[] = [
@@ -163,6 +184,178 @@ describe("ServiceCatalogItem", () => {
       isAssetTypeHidden: false,
       assetTypeIds: [],
       assetIds: [],
+    });
+  });
+
+  describe("preview mode", () => {
+    const baseHref = "http://localhost/hc/en-us/services/123";
+    const PREVIEW_CLASS = PREVIEW_MODE_HTML_CLASS;
+
+    const mockLocation = (search: string) => {
+      window.history.replaceState(null, "", `${baseHref}${search}`);
+    };
+
+    beforeEach(() => {
+      window.history.replaceState(null, "", baseHref);
+      document.documentElement.classList.remove(PREVIEW_CLASS);
+    });
+
+    afterEach(() => {
+      window.history.replaceState(null, "", baseHref);
+      document.documentElement.classList.remove(PREVIEW_CLASS);
+    });
+
+    it("does not render the preview banner for published items without the preview query param", () => {
+      mockLocation("");
+      mockUseServiceCatalogItem.mockReturnValue({
+        serviceCatalogItem: mockServiceCatalogItem,
+        errorFetchingItem: null,
+      });
+
+      renderWithTheme(<ServiceCatalogItem {...defaultProps} />);
+
+      expect(
+        screen.queryByTestId("preview-mode-banner-mock")
+      ).not.toBeInTheDocument();
+      expect(screen.getByTestId("item-request-form")).toHaveAttribute(
+        "data-preview-mode",
+        "false"
+      );
+      expect(document.documentElement).not.toHaveClass(PREVIEW_CLASS);
+    });
+
+    it("does not render the preview banner for published items even when ?preview=true is in the URL", () => {
+      mockLocation("?preview=true");
+      mockUseServiceCatalogItem.mockReturnValue({
+        serviceCatalogItem: mockServiceCatalogItem,
+        errorFetchingItem: null,
+      });
+
+      renderWithTheme(<ServiceCatalogItem {...defaultProps} />);
+
+      expect(
+        screen.queryByTestId("preview-mode-banner-mock")
+      ).not.toBeInTheDocument();
+      expect(screen.getByTestId("item-request-form")).toHaveAttribute(
+        "data-preview-mode",
+        "false"
+      );
+      expect(document.documentElement).not.toHaveClass(PREVIEW_CLASS);
+    });
+
+    it("removes ?preview=true from the URL once a published item is loaded", () => {
+      mockLocation("?preview=true&category_id=42");
+      mockUseServiceCatalogItem.mockReturnValue({
+        serviceCatalogItem: mockServiceCatalogItem,
+        errorFetchingItem: null,
+      });
+
+      renderWithTheme(<ServiceCatalogItem {...defaultProps} />);
+
+      expect(window.location.search).not.toContain("preview=true");
+      // Other params are preserved
+      expect(window.location.search).toContain("category_id=42");
+    });
+
+    it("activates preview mode for draft items even without the preview query param", () => {
+      mockLocation("");
+      mockUseServiceCatalogItem.mockReturnValue({
+        serviceCatalogItem: mockDraftServiceCatalogItem,
+        errorFetchingItem: null,
+      });
+
+      renderWithTheme(<ServiceCatalogItem {...defaultProps} />);
+
+      expect(
+        screen.getByTestId("preview-mode-banner-mock")
+      ).toBeInTheDocument();
+      expect(screen.getByTestId("item-request-form")).toHaveAttribute(
+        "data-preview-mode",
+        "true"
+      );
+      expect(screen.getByRole("button", { name: "Submit" })).toBeDisabled();
+      expect(document.documentElement).toHaveClass(PREVIEW_CLASS);
+    });
+
+    it("adds ?preview=true to the URL once a draft item is loaded so a refresh enters preview cleanly", () => {
+      mockLocation("?category_id=42");
+      mockUseServiceCatalogItem.mockReturnValue({
+        serviceCatalogItem: mockDraftServiceCatalogItem,
+        errorFetchingItem: null,
+      });
+
+      renderWithTheme(<ServiceCatalogItem {...defaultProps} />);
+
+      expect(window.location.search).toContain("preview=true");
+      // Other params are preserved
+      expect(window.location.search).toContain("category_id=42");
+    });
+
+    it("does not modify the URL when the param already matches the item state", () => {
+      mockLocation("?preview=true");
+      mockUseServiceCatalogItem.mockReturnValue({
+        serviceCatalogItem: mockDraftServiceCatalogItem,
+        errorFetchingItem: null,
+      });
+
+      const replaceStateSpy = jest.spyOn(window.history, "replaceState");
+      renderWithTheme(<ServiceCatalogItem {...defaultProps} />);
+
+      expect(replaceStateSpy).not.toHaveBeenCalled();
+      replaceStateSpy.mockRestore();
+    });
+
+    it("renders the preview banner and disables submit for draft items with the preview query param", () => {
+      mockLocation("?preview=true");
+      mockUseServiceCatalogItem.mockReturnValue({
+        serviceCatalogItem: mockDraftServiceCatalogItem,
+        errorFetchingItem: null,
+      });
+
+      renderWithTheme(<ServiceCatalogItem {...defaultProps} />);
+
+      expect(
+        screen.getByTestId("preview-mode-banner-mock")
+      ).toBeInTheDocument();
+      expect(screen.getByTestId("item-request-form")).toHaveAttribute(
+        "data-preview-mode",
+        "true"
+      );
+      expect(screen.getByRole("button", { name: "Submit" })).toBeDisabled();
+      expect(document.documentElement).toHaveClass(PREVIEW_CLASS);
+    });
+
+    it("removes the preview class from the root element on unmount", () => {
+      mockLocation("?preview=true");
+      mockUseServiceCatalogItem.mockReturnValue({
+        serviceCatalogItem: mockDraftServiceCatalogItem,
+        errorFetchingItem: null,
+      });
+
+      const { unmount } = renderWithTheme(
+        <ServiceCatalogItem {...defaultProps} />
+      );
+      expect(document.documentElement).toHaveClass(PREVIEW_CLASS);
+
+      unmount();
+      expect(document.documentElement).not.toHaveClass(PREVIEW_CLASS);
+    });
+
+    it("does not submit the form when in preview mode", async () => {
+      mockLocation("?preview=true");
+      mockUseServiceCatalogItem.mockReturnValue({
+        serviceCatalogItem: mockDraftServiceCatalogItem,
+        errorFetchingItem: null,
+      });
+
+      renderWithTheme(<ServiceCatalogItem {...defaultProps} />);
+
+      const form = screen.getByTestId("item-request-form");
+      fireEvent.submit(form);
+
+      await waitFor(() => {
+        expect(mockSubmitServiceItemRequest).not.toHaveBeenCalled();
+      });
     });
   });
 

--- a/src/modules/service-catalog/components/service-catalog-item/ServiceCatalogItem.tsx
+++ b/src/modules/service-catalog/components/service-catalog-item/ServiceCatalogItem.tsx
@@ -4,6 +4,7 @@ import { createPortal } from "react-dom";
 import { useItemFormFields } from "../../hooks/useItemFormFields";
 import { ItemRequestForm } from "./ItemRequestForm";
 import { CategorySelector } from "./CategorySelector";
+import { PreviewModeBanner } from "./PreviewModeBanner";
 import type { Organization } from "../../../ticket-fields/data-types/Organization";
 import { useServiceCatalogItem } from "../../hooks/useServiceCatalogItem";
 import { submitServiceItemRequest } from "./submitServiceItemRequest";
@@ -16,6 +17,9 @@ import {
   AttachmentsInputName,
   ASSET_TYPE_KEY,
   ASSET_KEY,
+  PREVIEW_MODE_HTML_CLASS,
+  PREVIEW_MODE_QUERY_PARAM,
+  PREVIEW_MODE_QUERY_PARAM_VALUE,
 } from "../../constants";
 import type { Attachment } from "../../../ticket-fields/data-types/AttachmentsField";
 import { useAttachmentsOption } from "../../hooks/useAttachmentsOption";
@@ -153,7 +157,56 @@ export function ServiceCatalogItem({
     isLoadingAttachmentsOption ||
     !hasResolvedCategory;
 
+  const hasPreviewQueryParam =
+    typeof window !== "undefined" &&
+    new URLSearchParams(window.location.search).get(
+      PREVIEW_MODE_QUERY_PARAM
+    ) === PREVIEW_MODE_QUERY_PARAM_VALUE;
+
+  // Before the API resolves we trust the URL param to avoid a flicker; once
+  // the item is known, draft state is authoritative — published items never
+  // show preview UI even if the URL accidentally carries the param.
+  const isPreviewMode = serviceCatalogItem
+    ? serviceCatalogItem.published_at === null
+    : hasPreviewQueryParam;
+
+  useEffect(() => {
+    if (typeof document === "undefined" || !isPreviewMode) {
+      return undefined;
+    }
+
+    document.documentElement.classList.add(PREVIEW_MODE_HTML_CLASS);
+
+    return () => {
+      document.documentElement.classList.remove(PREVIEW_MODE_HTML_CLASS);
+    };
+  }, [isPreviewMode]);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || !serviceCatalogItem) {
+      return;
+    }
+
+    const url = new URL(window.location.href);
+    const isDraft = serviceCatalogItem.published_at === null;
+    const urlHasParam =
+      url.searchParams.get(PREVIEW_MODE_QUERY_PARAM) ===
+      PREVIEW_MODE_QUERY_PARAM_VALUE;
+
+    if (isDraft && !urlHasParam) {
+      url.searchParams.set(
+        PREVIEW_MODE_QUERY_PARAM,
+        PREVIEW_MODE_QUERY_PARAM_VALUE
+      );
+      window.history.replaceState(null, "", url.toString());
+    } else if (!isDraft && urlHasParam) {
+      url.searchParams.delete(PREVIEW_MODE_QUERY_PARAM);
+      window.history.replaceState(null, "", url.toString());
+    }
+  }, [serviceCatalogItem]);
+
   const canSubmit =
+    !isPreviewMode &&
     !isFormInitializing &&
     !isSubmitting &&
     !isUploadingAttachments &&
@@ -274,6 +327,12 @@ export function ServiceCatalogItem({
   const handleRequestSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
+    // Submitting requests is not allowed while previewing a draft. Bail out
+    // silently so the admin doesn't see a misleading error toast.
+    if (isPreviewMode) {
+      return;
+    }
+
     if (!canSubmit) {
       notifySubmitError();
       return;
@@ -350,6 +409,7 @@ export function ServiceCatalogItem({
 
   return (
     <Container>
+      {isPreviewMode && <PreviewModeBanner />}
       {categorySelectorContainer &&
         serviceCatalogItem &&
         selectedCategoryId &&
@@ -389,6 +449,7 @@ export function ServiceCatalogItem({
           assetIds={assetIds}
           onAttachmentUploadingChange={setIsUploadingAttachments}
           isFormInitializing={isFormInitializing}
+          isPreviewMode={isPreviewMode}
         />
       )}
     </Container>

--- a/src/modules/service-catalog/components/service-catalog-list/ServiceCatalogListItem.spec.tsx
+++ b/src/modules/service-catalog/components/service-catalog-list/ServiceCatalogListItem.spec.tsx
@@ -20,6 +20,7 @@ describe("ServiceCatalogListItem", () => {
     thumbnail_url: "",
     categories: [],
     allow_request_on_behalf: false,
+    published_at: "2025-01-01T00:00:00Z",
     custom_object_fields: {
       "standard::asset_option": "",
       "standard::asset_type_option": "",

--- a/src/modules/service-catalog/constants/index.ts
+++ b/src/modules/service-catalog/constants/index.ts
@@ -2,3 +2,15 @@ export const AttachmentsInputName = "attachments" as const;
 
 export const ASSET_TYPE_KEY = "zen:custom_object:standard::itam_asset_type";
 export const ASSET_KEY = "zen:custom_object:standard::itam_asset";
+
+// Marker class added to <html> when the page is in preview mode. CSS in
+// styles/_service_catalog.scss uses it to hide product chrome (admin shell,
+// trial banners) so admins can see the page exactly as end-users would.
+// IMPORTANT: keep in sync with the inline script in templates/service_page.hbs.
+export const PREVIEW_MODE_HTML_CLASS = "is-service-catalog-preview";
+
+// Query parameter that drives preview mode. When present and equal to "true",
+// the inline script in templates/service_page.hbs adds the marker class to
+// <html> synchronously, before first paint, eliminating the chrome flicker.
+export const PREVIEW_MODE_QUERY_PARAM = "preview";
+export const PREVIEW_MODE_QUERY_PARAM_VALUE = "true";

--- a/src/modules/service-catalog/data-types/ServiceCatalogItem.ts
+++ b/src/modules/service-catalog/data-types/ServiceCatalogItem.ts
@@ -12,6 +12,9 @@ export interface ServiceCatalogItem {
   thumbnail_url: string;
   categories: ServiceCatalogItemCategory[];
   allow_request_on_behalf: boolean;
+  // null when the item is a draft (not yet published). Populated only for
+  // authorized users (admins/managers) previewing a draft item.
+  published_at: string | null;
   custom_object_fields: {
     "standard::asset_option": string;
     "standard::asset_type_option": string;

--- a/src/modules/service-catalog/hooks/useItemFormFields.spec.ts
+++ b/src/modules/service-catalog/hooks/useItemFormFields.spec.ts
@@ -11,6 +11,7 @@ describe("useItemFormFields", () => {
     thumbnail_url: "",
     categories: [],
     allow_request_on_behalf: false,
+    published_at: "2025-01-01T00:00:00Z",
     custom_object_fields: {
       "standard::asset_option": "",
       "standard::asset_type_option": "",

--- a/style.css
+++ b/style.css
@@ -4855,3 +4855,10 @@ zd-summary-block {
   align-items: center;
   gap: 20px;
 }
+
+.is-service-catalog-preview #navbar-container,
+.is-service-catalog-preview .navbar-container,
+.is-service-catalog-preview .assembly-bar,
+.is-service-catalog-preview [data-garden-id="chrome.subnav"] {
+  display: none !important;
+}

--- a/styles/_service_catalog.scss
+++ b/styles/_service_catalog.scss
@@ -24,3 +24,18 @@
     gap: 20px;
   }
 }
+
+// Preview mode marker class added to <html> when the page is opened with
+// `?preview=true` (synchronously via the inline script in service_page.hbs)
+// or when the React app detects a draft item via the API response
+// (ServiceCatalogItem). The selectors below target Zendesk product chrome
+// elements injected outside of the help center theme — they are brittle and
+// must be revisited if Zendesk shell changes its DOM contract.
+.is-service-catalog-preview {
+  #navbar-container,
+  .navbar-container,
+  .assembly-bar,
+  [data-garden-id="chrome.subnav"] {
+    display: none !important;
+  }
+}

--- a/templates/service_page.hbs
+++ b/templates/service_page.hbs
@@ -1,3 +1,13 @@
+<script type="text/javascript">
+  (function () {
+    try {
+      var params = new URLSearchParams(window.location.search);
+      if (params.get("preview") === "true") {
+        document.documentElement.classList.add("is-service-catalog-preview");
+      }
+    } catch (e) {}
+  })();
+</script>
 <div class="container-divider"></div>
 <div class="container">
   <div class="sub-nav">


### PR DESCRIPTION
## Description

Render a Service Catalog item in preview mode on the Help Center: pinned banner at the top, request submission disabled, drafts rendered without errors.

## Screenshots

<img width="1728" height="876" alt="image" src="https://github.com/user-attachments/assets/a8ae87d0-0cac-4471-934c-ff1b2bdd11b6" />

## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->