### PR TITLE
feat: filter ticket fields by current brand form

### DIFF
--- a/src/modules/request-list/data-types/TicketForm.ts
+++ b/src/modules/request-list/data-types/TicketForm.ts
@@ -1,0 +1,5 @@
+export interface TicketForm {
+  id: number;
+  active: boolean;
+  ticket_field_ids: number[];
+}

--- a/src/modules/request-list/data-types/index.ts
+++ b/src/modules/request-list/data-types/index.ts
@@ -6,3 +6,4 @@ export * from "./RequestUser";
 export * from "./TicketField";
 export * from "./FilterValue";
 export * from "./CustomStatus";
+export * from "./TicketForm";

--- a/src/modules/request-list/hooks/useTicketFields.test.ts
+++ b/src/modules/request-list/hooks/useTicketFields.test.ts
@@ -29,7 +29,6 @@ const inactiveTicketField: TicketField = {
 
 beforeEach(() => {
   jest.resetAllMocks();
-  global.fetch = jest.fn();
 });
 
 afterEach(() => {
@@ -37,28 +36,22 @@ afterEach(() => {
 });
 
 test("fetches all ticket fields via ticket_fields api call and returns the active ones", async () => {
-  fetchAllCursorPages.mockResolvedValueOnce([
-    activeTicketField,
-    inactiveTicketField,
-  ]);
-
-  (global.fetch as jest.Mock).mockResolvedValueOnce({
-    ok: true,
-    json: async () => ({
-      ticket_forms: [
-        {
-          active: true,
-          ticket_field_ids: [10],
-        },
-      ],
-    }),
-  });
+  fetchAllCursorPages
+    .mockResolvedValueOnce([activeTicketField, inactiveTicketField])
+    .mockResolvedValueOnce([
+      {
+        id: 1,
+        active: true,
+        ticket_field_ids: [10],
+      },
+    ]);
 
   const { result, waitForNextUpdate } = renderHook(() => useTicketFields("dk"));
 
   await waitForNextUpdate();
 
   expect(fetchAllCursorPages.mock.calls[0][1]).toEqual("ticket_fields");
+  expect(fetchAllCursorPages.mock.calls[1][1]).toEqual("ticket_forms");
 
   expect(result.current).toEqual({
     ticketFields: [activeTicketField],
@@ -90,22 +83,15 @@ test("filters out inactive subject field", async () => {
     custom_field_options: [],
   };
 
-  fetchAllCursorPages.mockResolvedValueOnce([
-    activeTicketField,
-    inactiveSubjectField,
-  ]);
-
-  (global.fetch as jest.Mock).mockResolvedValueOnce({
-    ok: true,
-    json: async () => ({
-      ticket_forms: [
-        {
-          active: true,
-          ticket_field_ids: [10, 30],
-        },
-      ],
-    }),
-  });
+  fetchAllCursorPages
+    .mockResolvedValueOnce([activeTicketField, inactiveSubjectField])
+    .mockResolvedValueOnce([
+      {
+        id: 1,
+        active: true,
+        ticket_field_ids: [10, 30],
+      },
+    ]);
 
   const { result, waitForNextUpdate } = renderHook(() => useTicketFields("dk"));
 
@@ -127,21 +113,15 @@ test("only returns ticket fields present in active ticket forms", async () => {
     title_in_portal: "Active field 40",
   };
 
-  fetchAllCursorPages.mockResolvedValueOnce([
-    activeTicketField,
-    { ...inactiveTicketField, id: 30, active: true },
-    activeCustomField40,
-  ]);
-
-  (global.fetch as jest.Mock).mockResolvedValueOnce({
-    ok: true,
-    json: async () => ({
-      ticket_forms: [
-        { active: true, ticket_field_ids: [10, 40] },
-        { active: false, ticket_field_ids: [30] },
-      ],
-    }),
-  });
+  fetchAllCursorPages
+    .mockResolvedValueOnce([
+      activeTicketField,
+      { ...inactiveTicketField, id: 30, active: true },
+      activeCustomField40,
+    ])
+    .mockResolvedValueOnce([
+      { id: 1, active: true, ticket_field_ids: [10, 40] },
+    ]);
 
   const { result, waitForNextUpdate } = renderHook(() => useTicketFields("dk"));
 

--- a/src/modules/request-list/hooks/useTicketFields.test.ts
+++ b/src/modules/request-list/hooks/useTicketFields.test.ts
@@ -27,11 +27,32 @@ const inactiveTicketField: TicketField = {
   custom_field_options: [],
 };
 
+beforeEach(() => {
+  jest.resetAllMocks();
+  global.fetch = jest.fn();
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
 test("fetches all ticket fields via ticket_fields api call and returns the active ones", async () => {
-  fetchAllCursorPages.mockReturnValueOnce([
+  fetchAllCursorPages.mockResolvedValueOnce([
     activeTicketField,
     inactiveTicketField,
   ]);
+
+  (global.fetch as jest.Mock).mockResolvedValueOnce({
+    ok: true,
+    json: async () => ({
+      ticket_forms: [
+        {
+          active: true,
+          ticket_field_ids: [10],
+        },
+      ],
+    }),
+  });
 
   const { result, waitForNextUpdate } = renderHook(() => useTicketFields("dk"));
 
@@ -47,17 +68,15 @@ test("fetches all ticket fields via ticket_fields api call and returns the activ
 });
 
 test("handles exceptions", async () => {
-  fetchAllCursorPages.mockRejectedValue("Network error");
+  fetchAllCursorPages.mockRejectedValueOnce(new Error("Network error"));
 
   const { result, waitForNextUpdate } = renderHook(() => useTicketFields("dk"));
 
   await waitForNextUpdate();
 
-  expect(result.current).toEqual({
-    ticketFields: [],
-    error: "Network error",
-    isLoading: true,
-  });
+  expect(result.current.error).toEqual(new Error("Network error"));
+  expect(result.current.ticketFields).toEqual([]);
+  expect(result.current.isLoading).toBe(false);
 });
 
 test("filters out inactive subject field", async () => {
@@ -71,10 +90,22 @@ test("filters out inactive subject field", async () => {
     custom_field_options: [],
   };
 
-  fetchAllCursorPages.mockReturnValueOnce([
+  fetchAllCursorPages.mockResolvedValueOnce([
     activeTicketField,
     inactiveSubjectField,
   ]);
+
+  (global.fetch as jest.Mock).mockResolvedValueOnce({
+    ok: true,
+    json: async () => ({
+      ticket_forms: [
+        {
+          active: true,
+          ticket_field_ids: [10, 30],
+        },
+      ],
+    }),
+  });
 
   const { result, waitForNextUpdate } = renderHook(() => useTicketFields("dk"));
 
@@ -82,6 +113,42 @@ test("filters out inactive subject field", async () => {
 
   expect(result.current).toEqual({
     ticketFields: [activeTicketField],
+    error: undefined,
+    isLoading: false,
+  });
+});
+
+test("only returns ticket fields present in active ticket forms", async () => {
+  const activeCustomField40: TicketField = {
+    ...inactiveTicketField,
+    id: 40,
+    active: true,
+    title: "Active field 40",
+    title_in_portal: "Active field 40",
+  };
+
+  fetchAllCursorPages.mockResolvedValueOnce([
+    activeTicketField,
+    { ...inactiveTicketField, id: 30, active: true },
+    activeCustomField40,
+  ]);
+
+  (global.fetch as jest.Mock).mockResolvedValueOnce({
+    ok: true,
+    json: async () => ({
+      ticket_forms: [
+        { active: true, ticket_field_ids: [10, 40] },
+        { active: false, ticket_field_ids: [30] },
+      ],
+    }),
+  });
+
+  const { result, waitForNextUpdate } = renderHook(() => useTicketFields("dk"));
+
+  await waitForNextUpdate();
+
+  expect(result.current).toEqual({
+    ticketFields: [activeTicketField, activeCustomField40],
     error: undefined,
     isLoading: false,
   });

--- a/src/modules/request-list/hooks/useTicketFields.ts
+++ b/src/modules/request-list/hooks/useTicketFields.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import type { CursorPaginatedResponse } from "../utils/pagination/CursorPaginatedResponse";
-import type { TicketField } from "../data-types";
+import type { TicketField, TicketForm } from "../data-types";
 import { fetchAllCursorPages } from "../utils/pagination/fetchAllCursorPages";
 
 interface UseTicketFields {
@@ -16,6 +16,20 @@ async function listTicketFields(
   const response = await fetch(
     `/api/v2/ticket_fields.json?locale=${locale}&page[size]=${pageSize}`
   );
+
+  if (!response.ok) {
+    throw new Error(response.statusText);
+  }
+  return await response.json();
+}
+
+async function listTicketForms(
+  locale: string
+): Promise<{ ticket_forms: TicketForm[] }> {
+  const response = await fetch(
+    `/api/v2/ticket_forms?locale=${locale}&associated_to_brand=true`
+  );
+
   if (!response.ok) {
     throw new Error(response.statusText);
   }
@@ -29,21 +43,35 @@ export function useTicketFields(locale: string): UseTicketFields {
 
   async function fetchTicketFields() {
     try {
-      const response = await fetchAllCursorPages(
-        () => listTicketFields(locale),
-        "ticket_fields"
+      const [response, tfResponse] = await Promise.all([
+        fetchAllCursorPages(() => listTicketFields(locale), "ticket_fields"),
+        listTicketForms(locale),
+      ]);
+
+      const activeTicketFieldIds = new Set<number>(
+        tfResponse.ticket_forms
+          .filter((ticketForm) => ticketForm.active)
+          .flatMap((ticketForm) => ticketForm.ticket_field_ids ?? [])
       );
-      setTicketFields(response.filter((ticketField) => ticketField.active));
+
+      setTicketFields(
+        response.filter(
+          (ticketField) =>
+            ticketField.active && activeTicketFieldIds.has(ticketField.id)
+        )
+      );
 
       setIsLoading(false);
     } catch (error) {
       setError(error as Error);
+    } finally {
+      setIsLoading(false);
     }
   }
 
   useEffect(() => {
     fetchTicketFields();
-  }, []);
+  }, [locale]);
 
   return { ticketFields, error, isLoading };
 }

--- a/src/modules/request-list/hooks/useTicketFields.ts
+++ b/src/modules/request-list/hooks/useTicketFields.ts
@@ -24,10 +24,11 @@ async function listTicketFields(
 }
 
 async function listTicketForms(
-  locale: string
-): Promise<{ ticket_forms: TicketForm[] }> {
+  locale: string,
+  pageSize = 100
+): Promise<CursorPaginatedResponse<"ticket_forms", TicketForm>> {
   const response = await fetch(
-    `/api/v2/ticket_forms?locale=${locale}&associated_to_brand=true`
+    `/api/v2/ticket_forms?locale=${locale}&associated_to_brand=true&active=true&form_type=all&page[size]=${pageSize}`
   );
 
   if (!response.ok) {
@@ -43,19 +44,17 @@ export function useTicketFields(locale: string): UseTicketFields {
 
   async function fetchTicketFields() {
     try {
-      const [response, tfResponse] = await Promise.all([
+      const [ticketFields, ticketForms] = await Promise.all([
         fetchAllCursorPages(() => listTicketFields(locale), "ticket_fields"),
-        listTicketForms(locale),
+        fetchAllCursorPages(() => listTicketForms(locale), "ticket_forms"),
       ]);
 
       const activeTicketFieldIds = new Set<number>(
-        tfResponse.ticket_forms
-          .filter((ticketForm) => ticketForm.active)
-          .flatMap((ticketForm) => ticketForm.ticket_field_ids ?? [])
+        ticketForms.flatMap((ticketForm) => ticketForm.ticket_field_ids ?? [])
       );
 
       setTicketFields(
-        response.filter(
+        ticketFields.filter(
           (ticketField) =>
             ticketField.active && activeTicketFieldIds.has(ticketField.id)
         )
@@ -71,7 +70,7 @@ export function useTicketFields(locale: string): UseTicketFields {
 
   useEffect(() => {
     fetchTicketFields();
-  }, [locale]);
+  }, []);
 
   return { ticketFields, error, isLoading };
 }


### PR DESCRIPTION
## Description
- Customers have requested ticket fields to only display if associated with the brand that is currently being viewed.
 To achieve this, the api for ticket fields does not provide an option but the api for ticket forms does - so we fetch ticket forms for the current brand, filter for active forms, then filter the ticket fields to only display if included in the active forms for the brand.

- Also added "**finally**" clause to make sure isLoading will always be set to false



https://zendesk.atlassian.net/jira/software/c/projects/GG/boards/8177?selectedIssue=GG-4963&visitedUserSeg=true

## Screenshots

before, fields for a form belonging to another domain displayed:
<img width="1611" height="1029" alt="image" src="https://github.com/user-attachments/assets/e6445987-dd41-4cdc-81e0-64a40f6d251f" />


after, fields for a form belonging to another domain (BoopBrandCheckbox) is filtered out, as well as date field that is not currently used by any form:

<img width="1658" height="799" alt="image" src="https://github.com/user-attachments/assets/e751ee91-afbe-4d3d-ab89-758b5c115457" />


## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->