### PR TITLE
feat: add sorting in service catalog items

### DIFF
--- a/src/modules/service-catalog/components/service-catalog-list/LoadingState.tsx
+++ b/src/modules/service-catalog/components/service-catalog-list/LoadingState.tsx
@@ -1,6 +1,6 @@
 import { Grid } from "@zendeskgarden/react-grid";
-import { Skeleton } from "@zendeskgarden/react-loaders";
 import styled from "styled-components";
+import { ServiceCatalogListItemSkeleton } from "./ServiceCatalogListItemSkeleton";
 
 const StyledGrid = styled(Grid)`
   padding: 0;
@@ -12,20 +12,25 @@ const StyledCol = styled(Grid.Col)`
   }
 `;
 
-const SkeletonCol = () => (
-  <StyledCol xs={12} sm={6} md={4} lg={3}>
-    <Skeleton width="100%" height="140px" />
-  </StyledCol>
-);
+const DEFAULT_SKELETON_COUNT = 8;
 
-export const LoadingState = () => {
+interface LoadingStateProps {
+  count?: number;
+}
+
+export const LoadingState = ({
+  count = DEFAULT_SKELETON_COUNT,
+}: LoadingStateProps) => {
+  const safeCount = Math.max(1, count);
+
   return (
     <StyledGrid>
       <Grid.Row wrap="wrap">
-        <SkeletonCol />
-        <SkeletonCol />
-        <SkeletonCol />
-        <SkeletonCol />
+        {Array.from({ length: safeCount }, (_, index) => (
+          <StyledCol key={index} xs={12} sm={6} md={4} lg={3}>
+            <ServiceCatalogListItemSkeleton />
+          </StyledCol>
+        ))}
       </Grid.Row>
     </StyledGrid>
   );

--- a/src/modules/service-catalog/components/service-catalog-list/ServiceCatalogList.spec.tsx
+++ b/src/modules/service-catalog/components/service-catalog-list/ServiceCatalogList.spec.tsx
@@ -1,0 +1,281 @@
+import { act } from "react-dom/test-utils";
+import { render } from "../../../test/render";
+import { screen, waitFor } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { ServiceCatalogList } from "./ServiceCatalogList";
+
+const HELP_CENTER_PATH = "/hc/en-us";
+
+const emptyResponse = {
+  service_catalog_items: [],
+  meta: { before_cursor: null, after_cursor: null, has_more: false },
+  count: 0,
+};
+
+function mockFetch() {
+  const fetchMock = jest.fn(() =>
+    Promise.resolve({
+      json: () => Promise.resolve(emptyResponse),
+      status: 200,
+      ok: true,
+    })
+  ) as jest.Mock;
+  global.fetch = fetchMock;
+  return fetchMock;
+}
+
+function setUrl(search: string) {
+  window.history.replaceState(
+    {},
+    "",
+    `${window.location.pathname}${search ? `?${search}` : ""}`
+  );
+}
+
+function getSortParamsFromCall(fetchMock: jest.Mock, callIndex: number) {
+  const url = fetchMock.mock.calls[callIndex]?.[0] as string | undefined;
+  const params = new URLSearchParams(url?.split("?")[1] ?? "");
+  return {
+    sort_by: params.get("sort_by"),
+    sort_order: params.get("sort_order"),
+  };
+}
+
+describe("ServiceCatalogList sorting", () => {
+  beforeEach(() => {
+    setUrl("");
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    setUrl("");
+  });
+
+  describe("initial sort from URL", () => {
+    it("uses the default name_asc sort when no sort param is in the URL", async () => {
+      const fetchMock = mockFetch();
+
+      render(
+        <ServiceCatalogList
+          helpCenterPath={HELP_CENTER_PATH}
+          selectedCategoryId={null}
+          selectedCategoryName={null}
+        />
+      );
+
+      await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+
+      expect(getSortParamsFromCall(fetchMock, 0)).toEqual({
+        sort_by: "name",
+        sort_order: "asc",
+      });
+    });
+
+    it("uses the sort option from the URL when present and valid", async () => {
+      setUrl("sort=name_desc");
+      const fetchMock = mockFetch();
+
+      render(
+        <ServiceCatalogList
+          helpCenterPath={HELP_CENTER_PATH}
+          selectedCategoryId={null}
+          selectedCategoryName={null}
+        />
+      );
+
+      await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+
+      expect(getSortParamsFromCall(fetchMock, 0)).toEqual({
+        sort_by: "name",
+        sort_order: "desc",
+      });
+    });
+
+    it("falls back to the default sort when the URL sort param is invalid", async () => {
+      setUrl("sort=invalid_value");
+      const fetchMock = mockFetch();
+
+      render(
+        <ServiceCatalogList
+          helpCenterPath={HELP_CENTER_PATH}
+          selectedCategoryId={null}
+          selectedCategoryName={null}
+        />
+      );
+
+      await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+
+      expect(getSortParamsFromCall(fetchMock, 0)).toEqual({
+        sort_by: "name",
+        sort_order: "asc",
+      });
+    });
+
+    it("displays the sort label that matches the URL state", async () => {
+      setUrl("sort=created_at_desc");
+      mockFetch();
+
+      render(
+        <ServiceCatalogList
+          helpCenterPath={HELP_CENTER_PATH}
+          selectedCategoryId={null}
+          selectedCategoryName={null}
+        />
+      );
+
+      expect(
+        await screen.findByRole("button", { name: /Newest/ })
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("changing sort updates URL", () => {
+    it("writes the new sort to the URL when a non-default option is chosen", async () => {
+      const fetchMock = mockFetch();
+
+      render(
+        <ServiceCatalogList
+          helpCenterPath={HELP_CENTER_PATH}
+          selectedCategoryId={null}
+          selectedCategoryName={null}
+        />
+      );
+
+      await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+
+      const user = userEvent.setup();
+      await user.click(screen.getByRole("button", { name: /A-Z/ }));
+      await user.click(screen.getByRole("menuitemradio", { name: "Z-A" }));
+
+      await waitFor(() => {
+        const params = new URLSearchParams(window.location.search);
+        expect(params.get("sort")).toBe("name_desc");
+      });
+    });
+
+    it("removes the sort param from the URL when switching back to the default", async () => {
+      setUrl("sort=name_desc");
+      const fetchMock = mockFetch();
+
+      render(
+        <ServiceCatalogList
+          helpCenterPath={HELP_CENTER_PATH}
+          selectedCategoryId={null}
+          selectedCategoryName={null}
+        />
+      );
+
+      await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+
+      const user = userEvent.setup();
+      await user.click(screen.getByRole("button", { name: /Z-A/ }));
+      await user.click(screen.getByRole("menuitemradio", { name: "A-Z" }));
+
+      await waitFor(() => {
+        const params = new URLSearchParams(window.location.search);
+        expect(params.get("sort")).toBeNull();
+      });
+    });
+
+    it("preserves other query params when updating the sort param", async () => {
+      setUrl("category_id=cat-1");
+      const fetchMock = mockFetch();
+
+      render(
+        <ServiceCatalogList
+          helpCenterPath={HELP_CENTER_PATH}
+          selectedCategoryId={null}
+          selectedCategoryName={null}
+        />
+      );
+
+      await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+
+      const user = userEvent.setup();
+      await user.click(screen.getByRole("button", { name: /A-Z/ }));
+      await user.click(screen.getByRole("menuitemradio", { name: "Newest" }));
+
+      await waitFor(() => {
+        const params = new URLSearchParams(window.location.search);
+        expect(params.get("category_id")).toBe("cat-1");
+        expect(params.get("sort")).toBe("created_at_desc");
+      });
+    });
+
+    it("re-fetches services with the new sort params after the selection changes", async () => {
+      const fetchMock = mockFetch();
+
+      render(
+        <ServiceCatalogList
+          helpCenterPath={HELP_CENTER_PATH}
+          selectedCategoryId={null}
+          selectedCategoryName={null}
+        />
+      );
+
+      await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+      const user = userEvent.setup();
+      await user.click(screen.getByRole("button", { name: /A-Z/ }));
+      await user.click(screen.getByRole("menuitemradio", { name: "Newest" }));
+
+      await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+
+      expect(getSortParamsFromCall(fetchMock, 1)).toEqual({
+        sort_by: "created_at",
+        sort_order: "desc",
+      });
+    });
+  });
+
+  describe("popstate synchronization", () => {
+    it("updates the displayed sort option when the URL changes via browser navigation", async () => {
+      const fetchMock = mockFetch();
+
+      render(
+        <ServiceCatalogList
+          helpCenterPath={HELP_CENTER_PATH}
+          selectedCategoryId={null}
+          selectedCategoryName={null}
+        />
+      );
+
+      await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+
+      act(() => {
+        setUrl("sort=name_desc");
+        window.dispatchEvent(new PopStateEvent("popstate"));
+      });
+
+      expect(
+        await screen.findByRole("button", { name: /Z-A/ })
+      ).toBeInTheDocument();
+    });
+
+    it("triggers a fetch with the new sort when popstate changes the URL", async () => {
+      const fetchMock = mockFetch();
+
+      render(
+        <ServiceCatalogList
+          helpCenterPath={HELP_CENTER_PATH}
+          selectedCategoryId={null}
+          selectedCategoryName={null}
+        />
+      );
+
+      await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+      act(() => {
+        setUrl("sort=created_at_desc");
+        window.dispatchEvent(new PopStateEvent("popstate"));
+      });
+
+      await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+
+      expect(getSortParamsFromCall(fetchMock, 1)).toEqual({
+        sort_by: "created_at",
+        sort_order: "desc",
+      });
+    });
+  });
+});

--- a/src/modules/service-catalog/components/service-catalog-list/ServiceCatalogList.tsx
+++ b/src/modules/service-catalog/components/service-catalog-list/ServiceCatalogList.tsx
@@ -16,6 +16,14 @@ import {
   ALL_SERVICES_ID,
   UNCATEGORIZED_ID,
 } from "../service-catalog-categories-sidebar/constants";
+import {
+  SortMenu,
+  DEFAULT_SORT_OPTION,
+  SORT_URL_PARAM,
+  getSortFromUrl,
+  getSortParams,
+  type SortOption,
+} from "./SortMenu";
 
 const StyledCol = styled(Grid.Col)`
   margin-bottom: ${(props) => props.theme.space.md};
@@ -39,10 +47,32 @@ const CategoryHeading = styled(XL).attrs({ tag: "h2", isBold: true })`
   max-width: 600px;
 `;
 
+const CountAndSortRow = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: ${(props) => props.theme.space.sm};
+  flex-wrap: wrap;
+`;
+
 function getApiCategoryId(selectedCategoryId: string | null): string | null {
   if (!selectedCategoryId) return null;
   if (selectedCategoryId === ALL_SERVICES_ID) return null;
   return selectedCategoryId;
+}
+
+function updateSortUrlParam(sortOption: SortOption) {
+  const params = new URLSearchParams(window.location.search);
+  if (sortOption === DEFAULT_SORT_OPTION) {
+    params.delete(SORT_URL_PARAM);
+  } else {
+    params.set(SORT_URL_PARAM, sortOption);
+  }
+  const query = params.toString();
+  const newUrl = query
+    ? `${window.location.pathname}?${query}`
+    : window.location.pathname;
+  window.history.pushState({}, "", newUrl);
 }
 
 export function ServiceCatalogList({
@@ -57,6 +87,21 @@ export function ServiceCatalogList({
   const [searchInputValue, setSearchInputValue] = useState("");
   const searchInputValueRef = useRef(searchInputValue);
   searchInputValueRef.current = searchInputValue;
+
+  const [sortOption, setSortOption] = useState<SortOption>(getSortFromUrl);
+  const sortOptionRef = useRef(sortOption);
+  sortOptionRef.current = sortOption;
+
+  useEffect(() => {
+    const handlePopState = () => {
+      const nextSort = getSortFromUrl();
+      if (nextSort !== sortOptionRef.current) {
+        setSortOption(nextSort);
+      }
+    };
+    window.addEventListener("popstate", handlePopState);
+    return () => window.removeEventListener("popstate", handlePopState);
+  }, []);
 
   const { t } = useTranslation();
 
@@ -91,8 +136,18 @@ export function ServiceCatalogList({
   const debouncedUpdateServiceCatalogItems = useMemo(
     () =>
       debounce(
-        (value: string, cursor: string | null, categoryId: string | null) =>
-          fetchServiceCatalogItems(value, cursor, categoryId),
+        (
+          value: string,
+          cursor: string | null,
+          categoryId: string | null,
+          sort: SortOption
+        ) =>
+          fetchServiceCatalogItems(
+            value,
+            cursor,
+            categoryId,
+            getSortParams(sort)
+          ),
         300
       ),
     [fetchServiceCatalogItems]
@@ -102,10 +157,29 @@ export function ServiceCatalogList({
   const fetchedCategoryRef = useRef(apiCategoryId);
   const isCategoryChanging = fetchedCategoryRef.current !== apiCategoryId;
 
+  const previousItemsCountRef = useRef(0);
+  if (!isLoading) {
+    previousItemsCountRef.current = serviceCatalogItems.length;
+  }
+  const skeletonCount = isCategoryChanging
+    ? undefined
+    : previousItemsCountRef.current || undefined;
+
   useEffect(() => {
+    debouncedUpdateServiceCatalogItems.cancel();
     fetchedCategoryRef.current = apiCategoryId;
-    fetchServiceCatalogItems(searchInputValueRef.current, null, apiCategoryId);
-  }, [fetchServiceCatalogItems, apiCategoryId]);
+    fetchServiceCatalogItems(
+      searchInputValueRef.current,
+      null,
+      apiCategoryId,
+      getSortParams(sortOption)
+    );
+  }, [
+    fetchServiceCatalogItems,
+    apiCategoryId,
+    sortOption,
+    debouncedUpdateServiceCatalogItems,
+  ]);
 
   useEffect(() => {
     return () => debouncedUpdateServiceCatalogItems.cancel();
@@ -116,7 +190,8 @@ export function ServiceCatalogList({
       fetchServiceCatalogItems(
         searchInputValue,
         "page[after]=" + meta.after_cursor,
-        apiCategoryId
+        apiCategoryId,
+        getSortParams(sortOption)
       );
     }
   };
@@ -126,14 +201,21 @@ export function ServiceCatalogList({
       fetchServiceCatalogItems(
         searchInputValue,
         "page[before]=" + meta.before_cursor,
-        apiCategoryId
+        apiCategoryId,
+        getSortParams(sortOption)
       );
     }
   };
 
   const handleInputChange = (value: string) => {
     setSearchInputValue(value);
-    debouncedUpdateServiceCatalogItems(value, null, apiCategoryId);
+    debouncedUpdateServiceCatalogItems(value, null, apiCategoryId, sortOption);
+  };
+
+  const handleSortChange = (option: SortOption) => {
+    if (option === sortOption) return;
+    updateSortUrlParam(option);
+    setSortOption(option);
   };
 
   const categoryHeading =
@@ -152,15 +234,18 @@ export function ServiceCatalogList({
         onChange={handleInputChange}
       />
       {!isCategoryChanging && (
-        <span>
-          {t("service-catalog.service-count", "{{count}} services", {
-            "defaultValue.one": "{{count}} service",
-            count,
-          })}
-        </span>
+        <CountAndSortRow>
+          <span>
+            {t("service-catalog.service-count", "{{count}} services", {
+              "defaultValue.one": "{{count}} service",
+              count,
+            })}
+          </span>
+          <SortMenu selectedOption={sortOption} onChange={handleSortChange} />
+        </CountAndSortRow>
       )}
       {isLoading || isCategoryChanging ? (
-        <LoadingState />
+        <LoadingState count={skeletonCount} />
       ) : (
         <>
           <StyledGrid>

--- a/src/modules/service-catalog/components/service-catalog-list/ServiceCatalogListItemSkeleton.tsx
+++ b/src/modules/service-catalog/components/service-catalog-list/ServiceCatalogListItemSkeleton.tsx
@@ -1,0 +1,26 @@
+import { Skeleton } from "@zendeskgarden/react-loaders";
+import { getColor } from "@zendeskgarden/react-theming";
+import styled from "styled-components";
+
+const SkeletonCard = styled.div`
+  display: flex;
+  flex-direction: column;
+  background-color: ${({ theme }) =>
+    getColor({ theme, hue: "grey", shade: 300 })};
+  height: 100%;
+  border-radius: ${(props) => props.theme.borderRadii.md};
+  padding: ${(props) => props.theme.space.md};
+  border: ${(props) => props.theme.borders.sm}
+    ${({ theme }) => getColor({ theme, hue: "grey", shade: 300 })};
+`;
+
+export const ServiceCatalogListItemSkeleton = () => {
+  return (
+    <SkeletonCard
+      aria-hidden="true"
+      data-testid="service-catalog-list-item-skeleton"
+    >
+      <Skeleton width="100%" height="140px" />
+    </SkeletonCard>
+  );
+};

--- a/src/modules/service-catalog/components/service-catalog-list/SortMenu.spec.tsx
+++ b/src/modules/service-catalog/components/service-catalog-list/SortMenu.spec.tsx
@@ -1,0 +1,137 @@
+import { render } from "../../../test/render";
+import { screen } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import {
+  SortMenu,
+  DEFAULT_SORT_OPTION,
+  SORT_URL_PARAM,
+  getSortFromUrl,
+  getSortParams,
+  isValidSortOption,
+  type SortOption,
+} from "./SortMenu";
+
+describe("SortMenu helpers", () => {
+  describe("getSortParams", () => {
+    it("returns ascending name sort params for name_asc", () => {
+      expect(getSortParams("name_asc")).toEqual({
+        sort_by: "name",
+        sort_order: "asc",
+      });
+    });
+
+    it("returns descending name sort params for name_desc", () => {
+      expect(getSortParams("name_desc")).toEqual({
+        sort_by: "name",
+        sort_order: "desc",
+      });
+    });
+
+    it("returns descending created_at sort params for created_at_desc", () => {
+      expect(getSortParams("created_at_desc")).toEqual({
+        sort_by: "created_at",
+        sort_order: "desc",
+      });
+    });
+  });
+
+  describe("isValidSortOption", () => {
+    it("returns true for known sort options", () => {
+      expect(isValidSortOption("name_asc")).toBe(true);
+      expect(isValidSortOption("name_desc")).toBe(true);
+      expect(isValidSortOption("created_at_desc")).toBe(true);
+    });
+
+    it("returns false for unknown strings", () => {
+      expect(isValidSortOption("unknown_sort")).toBe(false);
+      expect(isValidSortOption("")).toBe(false);
+    });
+
+    it("returns false for non-string values", () => {
+      expect(isValidSortOption(null)).toBe(false);
+      expect(isValidSortOption(undefined)).toBe(false);
+      expect(isValidSortOption(42)).toBe(false);
+      expect(isValidSortOption({})).toBe(false);
+    });
+  });
+
+  describe("getSortFromUrl", () => {
+    it("returns the default sort option when sort param is missing", () => {
+      expect(getSortFromUrl("")).toBe(DEFAULT_SORT_OPTION);
+      expect(getSortFromUrl("?category_id=cat-1")).toBe(DEFAULT_SORT_OPTION);
+    });
+
+    it("returns the default sort option for unrecognized values", () => {
+      expect(getSortFromUrl(`?${SORT_URL_PARAM}=bogus`)).toBe(
+        DEFAULT_SORT_OPTION
+      );
+    });
+
+    it("returns the parsed sort option for valid values", () => {
+      expect(getSortFromUrl(`?${SORT_URL_PARAM}=name_desc`)).toBe("name_desc");
+      expect(getSortFromUrl(`?${SORT_URL_PARAM}=created_at_desc`)).toBe(
+        "created_at_desc"
+      );
+      expect(getSortFromUrl(`?${SORT_URL_PARAM}=name_asc`)).toBe("name_asc");
+    });
+
+    it("returns the parsed sort option when combined with other params", () => {
+      expect(
+        getSortFromUrl(`?category_id=cat-1&${SORT_URL_PARAM}=name_desc`)
+      ).toBe("name_desc");
+    });
+  });
+});
+
+describe("SortMenu", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders the currently selected option as the button label", () => {
+    render(<SortMenu selectedOption="name_desc" onChange={jest.fn()} />);
+
+    expect(screen.getByRole("button", { name: /Z-A/ })).toBeInTheDocument();
+  });
+
+  it("renders all sort options when the menu is opened", async () => {
+    render(<SortMenu selectedOption="name_asc" onChange={jest.fn()} />);
+
+    await userEvent.setup().click(screen.getByRole("button"));
+
+    expect(
+      screen.getByRole("menuitemradio", { name: "A-Z" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitemradio", { name: "Z-A" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitemradio", { name: "Newest" })
+    ).toBeInTheDocument();
+  });
+
+  it("marks the selected option as checked", async () => {
+    render(<SortMenu selectedOption="created_at_desc" onChange={jest.fn()} />);
+
+    await userEvent.setup().click(screen.getByRole("button"));
+
+    expect(
+      screen.getByRole("menuitemradio", { name: "Newest" })
+    ).toHaveAttribute("aria-checked", "true");
+    expect(screen.getByRole("menuitemradio", { name: "A-Z" })).toHaveAttribute(
+      "aria-checked",
+      "false"
+    );
+  });
+
+  it("calls onChange with the selected option when an item is clicked", async () => {
+    const onChange = jest.fn();
+    render(<SortMenu selectedOption="name_asc" onChange={onChange} />);
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button"));
+    await user.click(screen.getByRole("menuitemradio", { name: "Z-A" }));
+
+    expect(onChange).toHaveBeenCalledWith<[SortOption]>("name_desc");
+  });
+});

--- a/src/modules/service-catalog/components/service-catalog-list/SortMenu.tsx
+++ b/src/modules/service-catalog/components/service-catalog-list/SortMenu.tsx
@@ -1,0 +1,100 @@
+import { Menu, Item, ItemGroup } from "@zendeskgarden/react-dropdowns";
+import { Button } from "@zendeskgarden/react-buttons";
+import ChevronIcon from "@zendeskgarden/svg-icons/src/16/chevron-down-stroke.svg";
+import { useTranslation } from "react-i18next";
+import styled from "styled-components";
+
+export type SortOption = "name_asc" | "name_desc" | "created_at_desc";
+
+export const DEFAULT_SORT_OPTION: SortOption = "name_asc";
+
+export const SORT_URL_PARAM = "sort";
+
+const VALID_SORT_OPTIONS: ReadonlySet<SortOption> = new Set([
+  "name_asc",
+  "name_desc",
+  "created_at_desc",
+]);
+
+export function isValidSortOption(value: unknown): value is SortOption {
+  return (
+    typeof value === "string" && VALID_SORT_OPTIONS.has(value as SortOption)
+  );
+}
+
+export function getSortFromUrl(
+  search: string = window.location.search
+): SortOption {
+  const params = new URLSearchParams(search);
+  const value = params.get(SORT_URL_PARAM);
+  return isValidSortOption(value) ? value : DEFAULT_SORT_OPTION;
+}
+
+export function getSortParams(option: SortOption): {
+  sort_by: "name" | "created_at";
+  sort_order: "asc" | "desc";
+} {
+  switch (option) {
+    case "name_asc":
+      return { sort_by: "name", sort_order: "asc" };
+    case "name_desc":
+      return { sort_by: "name", sort_order: "desc" };
+    case "created_at_desc":
+      return { sort_by: "created_at", sort_order: "desc" };
+  }
+}
+
+const StyledButton = styled(Button)`
+  white-space: nowrap;
+`;
+
+interface SortMenuProps {
+  selectedOption: SortOption;
+  onChange: (option: SortOption) => void;
+}
+
+export function SortMenu({ selectedOption, onChange }: SortMenuProps) {
+  const { t } = useTranslation();
+
+  const optionLabels: Record<SortOption, string> = {
+    name_asc: t("service-catalog.sort.name-asc", "A-Z"),
+    name_desc: t("service-catalog.sort.name-desc", "Z-A"),
+    created_at_desc: t("service-catalog.sort.newest", "Newest"),
+  };
+
+  return (
+    <Menu
+      button={(props) => (
+        <StyledButton {...props} isBasic size="small">
+          {optionLabels[selectedOption]}
+          <Button.EndIcon>
+            <ChevronIcon />
+          </Button.EndIcon>
+        </StyledButton>
+      )}
+      onChange={({ value }) => {
+        if (value) {
+          onChange(value as SortOption);
+        }
+      }}
+    >
+      <ItemGroup
+        type="radio"
+        aria-label={t("service-catalog.sort.aria-label", "Sort services")}
+      >
+        <Item value="name_asc" isSelected={selectedOption === "name_asc"}>
+          {optionLabels.name_asc}
+        </Item>
+        <Item value="name_desc" isSelected={selectedOption === "name_desc"}>
+          {optionLabels.name_desc}
+        </Item>
+        <Item
+          value="created_at_desc"
+          isSelected={selectedOption === "created_at_desc"}
+        >
+          {optionLabels.created_at_desc}
+        </Item>
+      </ItemGroup>
+    </Menu>
+  );
+}

--- a/src/modules/service-catalog/hooks/useServiceCatalogItems.tsx
+++ b/src/modules/service-catalog/hooks/useServiceCatalogItems.tsx
@@ -4,6 +4,11 @@ import type { ServiceCatalogItem } from "../data-types/ServiceCatalogItem";
 
 const PAGE_SIZE = 16;
 
+export interface SortParams {
+  sort_by: "name" | "created_at";
+  sort_order: "asc" | "desc";
+}
+
 export function useServiceCatalogItems(): {
   serviceCatalogItems: ServiceCatalogItem[];
   meta: Meta | null;
@@ -13,7 +18,8 @@ export function useServiceCatalogItems(): {
   fetchServiceCatalogItems: (
     searchInputValue: string,
     currentCursor: string | null,
-    categoryId?: string | null
+    categoryId?: string | null,
+    sortParams?: SortParams | null
   ) => void;
 } {
   const [meta, setMeta] = useState<Meta | null>(null);
@@ -28,7 +34,8 @@ export function useServiceCatalogItems(): {
     async (
       searchInputValue: string,
       currentCursor: string | null,
-      categoryId?: string | null
+      categoryId?: string | null,
+      sortParams?: SortParams | null
     ) => {
       setIsLoading(true);
 
@@ -47,6 +54,11 @@ export function useServiceCatalogItems(): {
 
       if (categoryId) {
         searchParams.set("category_id", String(categoryId));
+      }
+
+      if (sortParams) {
+        searchParams.set("sort_by", sortParams.sort_by);
+        searchParams.set("sort_order", sortParams.sort_order);
       }
 
       try {

--- a/src/modules/service-catalog/translations/en-us.yml
+++ b/src/modules/service-catalog/translations/en-us.yml
@@ -283,3 +283,23 @@ parts:
       title: "Error message when email already exists in Add User form"
       screenshot: "https://drive.google.com/file/d/1Br5FvhlHzgUPl4FQlQnZcDA83pXKmHea/view?usp=share_link"
       value: "This email is already being used by a user."
+  - translation:
+      key: "service-catalog.sort.name-asc"
+      title: "Sort option in the service catalog list that orders services alphabetically from A to Z"
+      screenshot: ""
+      value: "A-Z"
+  - translation:
+      key: "service-catalog.sort.name-desc"
+      title: "Sort option in the service catalog list that orders services alphabetically from Z to A"
+      screenshot: ""
+      value: "Z-A"
+  - translation:
+      key: "service-catalog.sort.newest"
+      title: "Sort option in the service catalog list that orders services from newest to oldest"
+      screenshot: ""
+      value: "Newest"
+  - translation:
+      key: "service-catalog.sort.aria-label"
+      title: "[A11Y] Hidden label for screen readers describing the sort options group in the service catalog list"
+      screenshot: ""
+      value: "Sort services"


### PR DESCRIPTION
## Description

JIRA: https://zendesk.atlassian.net/jira/software/c/projects/PDSC/boards/9943

Sorting ability in end user service catalog for items

## DEMO


https://github.com/user-attachments/assets/a050b723-9c84-4f3d-a60b-4ce9ba282f6e


## Checklist

- [x] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [x] :arrow_left: changes are compatible with RTL direction
- [x] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [x] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [x] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->