### PR TITLE
add counting to category

### DIFF
--- a/src/modules/service-catalog/components/service-catalog-categories-sidebar/CategoryItem.tsx
+++ b/src/modules/service-catalog/components/service-catalog-categories-sidebar/CategoryItem.tsx
@@ -194,7 +194,9 @@ export const CategoryItem: React.FC<CategoryItemProps> = ({
             )}
             <ItemContent>
               <SidebarItemName>{displayName}</SidebarItemName>
-              <ItemCount>{category.itemsCount}</ItemCount>
+              {typeof category.items_count === "number" && (
+                <ItemCount>{category.items_count}</ItemCount>
+              )}
             </ItemContent>
           </CategoryItemContainer>
         </StyledSidebarItem>

--- a/src/modules/service-catalog/data-types/Categories.ts
+++ b/src/modules/service-catalog/data-types/Categories.ts
@@ -1,7 +1,7 @@
 export interface Category {
   id: string;
   name: string;
-  itemsCount: number;
+  items_count: number;
   updated_at: string;
   children?: Category[];
 }

--- a/src/modules/service-catalog/renderServiceCatalogPage.tsx
+++ b/src/modules/service-catalog/renderServiceCatalogPage.tsx
@@ -13,11 +13,31 @@ import type { Settings } from "../shared";
 import { ErrorBoundary } from "../shared/error-boundary/ErrorBoundary";
 import { ErrorScreen } from "../shared/error-boundary/ErrorScreen";
 import type { Category } from "./data-types/Categories";
+import {
+  PREVIEW_MODE_QUERY_PARAM,
+  PREVIEW_MODE_QUERY_PARAM_VALUE,
+} from "./constants";
 
-async function fetchCategoryTree(): Promise<Category[]> {
+function isPreviewMode(): boolean {
+  if (typeof window === "undefined") return false;
+  return (
+    new URLSearchParams(window.location.search).get(
+      PREVIEW_MODE_QUERY_PARAM
+    ) === PREVIEW_MODE_QUERY_PARAM_VALUE
+  );
+}
+
+async function fetchCategoryTree({
+  publishedOnly,
+}: {
+  publishedOnly: boolean;
+}): Promise<Category[]> {
   try {
+    const params = new URLSearchParams({
+      published_only: String(publishedOnly),
+    });
     const response = await fetch(
-      "/api/v2/help_center/service_catalog/categories"
+      `/api/v2/help_center/service_catalog/categories?${params.toString()}`
     );
     if (response.ok) {
       const data = await response.json();
@@ -55,7 +75,7 @@ export async function renderServiceCatalogPage(
     ]).catch((error) => {
       console.error("Failed to load translations:", error);
     }),
-    fetchCategoryTree(),
+    fetchCategoryTree({ publishedOnly: !isPreviewMode() }),
   ]);
 
   render(


### PR DESCRIPTION
## Description

Display ItemsCount in the CategoryTree structure for EndUser the same way as for Admin. Use the published_only parameter in the EndUser


## Screenshots

<img width="354" height="242" alt="Screenshot 2026-05-12 at 16 02 07" src="https://github.com/user-attachments/assets/c43989c3-bd5f-4a74-9ebe-34a0adbfeb55" />

## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->