### PR TITLE
fix(ticket-fields): show selected label for nested dropdown values

### DIFF
--- a/src/modules/ticket-fields/fields/MultiSelect.test.tsx
+++ b/src/modules/ticket-fields/fields/MultiSelect.test.tsx
@@ -1,0 +1,68 @@
+import { screen, fireEvent, within } from "@testing-library/react";
+import { MultiSelect } from "./MultiSelect";
+import type { TicketFieldObject } from "../data-types/TicketFieldObject";
+import { render } from "../../test/render";
+
+const baseField: TicketFieldObject = {
+  id: 123,
+  name: "test_multiselect",
+  value: [],
+  error: null,
+  label: "Test MultiSelect",
+  required: false,
+  description: "",
+  type: "multiselect",
+  options: [
+    { name: "Bass::Fender::Precision", value: "bass__fender__precision" },
+    { name: "Bass::Fender::Jazz", value: "bass__fender__jazz" },
+    { name: "Drums", value: "drums" },
+  ],
+};
+
+function renderMultiSelect(overrides: Partial<TicketFieldObject> = {}) {
+  const onChange = jest.fn();
+  render(
+    <MultiSelect field={{ ...baseField, ...overrides }} onChange={onChange} />
+  );
+  return { onChange, combobox: screen.getByLabelText("Test MultiSelect") };
+}
+
+describe("MultiSelect", () => {
+  describe("selected value tags", () => {
+    it("displays a tag with the label of a selected root-level value", () => {
+      const { combobox } = renderMultiSelect({ value: ["drums"] });
+      expect(combobox).toHaveTextContent("Drums");
+    });
+
+    it("displays a tag with the full label of a selected nested value", () => {
+      const { combobox } = renderMultiSelect({
+        value: ["bass__fender__precision"],
+      });
+      expect(combobox).toHaveTextContent("Bass > Fender > Precision");
+    });
+
+    it("renders hidden options for selected values without polluting the menu", () => {
+      renderMultiSelect({ value: ["bass__fender__precision"] });
+      const combobox = screen.getByLabelText("Test MultiSelect");
+      fireEvent.click(combobox);
+
+      const listbox = screen.getByRole("listbox");
+      // Root level navigation is shown, not the hidden nested option.
+      expect(within(listbox).getByText("Bass")).toBeInTheDocument();
+      expect(within(listbox).getByText("Drums")).toBeInTheDocument();
+    });
+  });
+
+  describe("navigation", () => {
+    it("navigates into a subgroup and selects a nested value", () => {
+      const { onChange, combobox } = renderMultiSelect();
+      fireEvent.click(combobox);
+
+      fireEvent.click(screen.getByText("Bass"));
+      fireEvent.click(screen.getByText("Fender"));
+      fireEvent.click(screen.getByText("Precision"));
+
+      expect(onChange).toHaveBeenCalledWith(["bass__fender__precision"]);
+    });
+  });
+});

--- a/src/modules/ticket-fields/fields/MultiSelect.tsx
+++ b/src/modules/ticket-fields/fields/MultiSelect.tsx
@@ -20,11 +20,15 @@ export function MultiSelect({
   onChange,
 }: MultiSelectProps): JSX.Element {
   const { label, options, error, value, name, required, description } = field;
-  const { currentGroup, isGroupIdentifier, setCurrentGroupByIdentifier } =
-    useNestedOptions({
-      options,
-      hasEmptyOption: false,
-    });
+  const {
+    currentGroup,
+    isGroupIdentifier,
+    setCurrentGroupByIdentifier,
+    getOptionLabel,
+  } = useNestedOptions({
+    options,
+    hasEmptyOption: false,
+  });
 
   const [selectedValues, setSelectValues] = useState<string[]>(
     (value as string[]) || []
@@ -78,6 +82,27 @@ export function MultiSelect({
         selectionValue={selectedValues}
         maxHeight="auto"
       >
+        {/*
+         * The Combobox derives each selected tag's label from a matching option
+         * child. Since only the current group's options are rendered, selected
+         * values that live in other groups are rendered as hidden options so
+         * their labels resolve without affecting menu navigation.
+         */}
+        {selectedValues
+          .filter(
+            (selectedValue) =>
+              !currentGroup.options.some(
+                (option) => option.value === selectedValue
+              )
+          )
+          .map((selectedValue) => (
+            <Option
+              key={`selected-${selectedValue}`}
+              value={selectedValue}
+              label={getOptionLabel(selectedValue) ?? selectedValue}
+              isHidden
+            />
+          ))}
         {currentGroup.type === "SubGroup" && (
           <Option {...currentGroup.backOption} />
         )}

--- a/src/modules/ticket-fields/fields/Tagger.test.tsx
+++ b/src/modules/ticket-fields/fields/Tagger.test.tsx
@@ -1,0 +1,68 @@
+import { screen, fireEvent, within } from "@testing-library/react";
+import { Tagger } from "./Tagger";
+import type { TicketFieldObject } from "../data-types/TicketFieldObject";
+import { render } from "../../test/render";
+
+const baseField: TicketFieldObject = {
+  id: 123,
+  name: "test_tagger",
+  value: "",
+  error: null,
+  label: "Test Tagger",
+  required: false,
+  description: "",
+  type: "tagger",
+  options: [
+    { name: "Bass::Fender::Precision", value: "bass__fender__precision" },
+    { name: "Bass::Fender::Jazz", value: "bass__fender__jazz" },
+    { name: "Drums", value: "drums" },
+  ],
+};
+
+function renderTagger(overrides: Partial<TicketFieldObject> = {}) {
+  const onChange = jest.fn();
+  render(<Tagger field={{ ...baseField, ...overrides }} onChange={onChange} />);
+  return { onChange, combobox: screen.getByLabelText("Test Tagger") };
+}
+
+describe("Tagger", () => {
+  describe("selected value label", () => {
+    it("displays the label of a selected root-level value", () => {
+      const { combobox } = renderTagger({ value: "drums" });
+      expect(combobox).toHaveTextContent("Drums");
+    });
+
+    it("displays the full label of a selected nested value", () => {
+      const { combobox } = renderTagger({ value: "bass__fender__precision" });
+      expect(combobox).toHaveTextContent("Bass > Fender > Precision");
+    });
+
+    it("displays the empty value placeholder when no value is selected", () => {
+      const { combobox } = renderTagger({ value: "" });
+      expect(combobox).toHaveTextContent("-");
+    });
+  });
+
+  describe("navigation", () => {
+    it("opens at the group containing the selected nested value", () => {
+      const { combobox } = renderTagger({ value: "bass__fender__precision" });
+      fireEvent.click(combobox);
+
+      const listbox = screen.getByRole("listbox");
+      // Sibling leaf options of the selected value are shown.
+      expect(within(listbox).getByText("Precision")).toBeInTheDocument();
+      expect(within(listbox).getByText("Jazz")).toBeInTheDocument();
+    });
+
+    it("navigates from the root into a subgroup and selects a nested value", () => {
+      const { onChange, combobox } = renderTagger();
+      fireEvent.click(combobox);
+
+      fireEvent.click(screen.getByText("Bass"));
+      fireEvent.click(screen.getByText("Fender"));
+      fireEvent.click(screen.getByText("Precision"));
+
+      expect(onChange).toHaveBeenCalledWith("bass__fender__precision");
+    });
+  });
+});

--- a/src/modules/ticket-fields/fields/Tagger.tsx
+++ b/src/modules/ticket-fields/fields/Tagger.tsx
@@ -1,7 +1,4 @@
-import type {
-  IComboboxProps,
-  ISelectedOption,
-} from "@zendeskgarden/react-dropdowns";
+import type { IComboboxProps } from "@zendeskgarden/react-dropdowns";
 import {
   Field,
   Combobox,
@@ -21,11 +18,16 @@ interface TaggerProps {
 
 export function Tagger({ field, onChange }: TaggerProps): JSX.Element {
   const { label, options, error, value, name, required, description } = field;
-  const { currentGroup, isGroupIdentifier, setCurrentGroupByIdentifier } =
-    useNestedOptions({
-      options,
-      hasEmptyOption: true,
-    });
+  const {
+    currentGroup,
+    isGroupIdentifier,
+    setCurrentGroupByIdentifier,
+    getOptionLabel,
+  } = useNestedOptions({
+    options,
+    hasEmptyOption: true,
+    selectedValue: (value as string | undefined) ?? "",
+  });
 
   const selectionValue = (value as string | undefined) ?? "";
   const [isExpanded, setIsExpanded] = useState(false);
@@ -73,9 +75,10 @@ export function Tagger({ field, onChange }: TaggerProps): JSX.Element {
         onChange={handleChange}
         selectionValue={selectionValue}
         inputValue={selectionValue}
-        renderValue={({ selection }) =>
-          (selection as ISelectedOption | null)?.label ?? <EmptyValueOption />
-        }
+        renderValue={() => {
+          const selectedLabel = getOptionLabel(selectionValue);
+          return selectedLabel ? <>{selectedLabel}</> : <EmptyValueOption />;
+        }}
         isExpanded={isExpanded}
       >
         {currentGroup.type === "SubGroup" && (

--- a/src/modules/ticket-fields/fields/useNestedOptions.tsx
+++ b/src/modules/ticket-fields/fields/useNestedOptions.tsx
@@ -190,39 +190,64 @@ function buildNestedOptions(
 }
 
 /**
- * When one or more options are selected, the Combobox component renders the label
- * for an option in the input, searching for an option passed as a child with the
- * same value as the selected option.
+ * Builds a map from each selectable option value to the label that should be
+ * displayed for it once selected (e.g. `"Bass > Fender > Precision"`).
  *
- * In the first render we are passing only the root group options as children,
- * and if we already have some selected values from a SubGroup, the component is not
- * able to find the label for the selected option.
- *
- * We therefore need to pass all the non-navigation options as children in the first render.
- * The passed options are cached by the Combobox component, so we can safely remove them
- * after the first render and pass only the root group options.
+ * The Combobox only renders the options for the currently displayed group, so a
+ * selected value that lives in a different group has no matching option child to
+ * derive its label from. Consumers use this map to resolve the label of a
+ * selected value regardless of which group is currently displayed.
  */
-function getInitialGroup(nestedOptions: NestedOptions): RootGroup {
-  const result: RootGroup = {
-    type: "RootGroup",
-    options: [],
-  };
+function buildOptionLabels(
+  nestedOptions: NestedOptions
+): Record<string, string> {
+  const result: Record<string, string> = {};
 
   Object.values(nestedOptions).forEach(({ options }) => {
-    result.options.push(...options.filter(({ type }) => type === undefined));
+    options.forEach((option) => {
+      // Skip navigation options (next/previous) and the empty option.
+      if (option.type === undefined && option.value !== "") {
+        result[option.value] = option.label;
+      }
+    });
   });
 
   return result;
 }
 
+/**
+ * Finds the group that directly contains the given selectable value, so the menu
+ * can open on the level the value belongs to instead of always starting at the root.
+ */
+function findGroupForValue(
+  nestedOptions: NestedOptions,
+  value: string | undefined
+): OptionGroup | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  return Object.values(nestedOptions).find(({ options }) =>
+    options.some(
+      (option) => option.type === undefined && option.value === value
+    )
+  );
+}
+
 interface UseNestedOptionsProps {
   options: TicketFieldOptionObject[];
   hasEmptyOption: boolean;
+  /**
+   * When provided, the menu opens on the group that contains this value
+   * instead of the root group.
+   */
+  selectedValue?: string;
 }
 
 export function useNestedOptions({
   options,
   hasEmptyOption,
+  selectedValue,
 }: UseNestedOptionsProps) {
   const { t } = useTranslation();
   const nestedOptions: NestedOptions = useMemo(
@@ -235,13 +260,23 @@ export function useNestedOptions({
     [options, hasEmptyOption, t]
   );
 
-  const [currentGroup, setCurrentGroup] = useState<OptionGroup>(
-    getInitialGroup(nestedOptions)
+  const optionLabels = useMemo(
+    () => buildOptionLabels(nestedOptions),
+    [nestedOptions]
   );
 
+  const initialGroup = useMemo(
+    () =>
+      findGroupForValue(nestedOptions, selectedValue) ??
+      nestedOptions[ROOT_GROUP_IDENTIFIER],
+    [nestedOptions, selectedValue]
+  );
+
+  const [currentGroup, setCurrentGroup] = useState<OptionGroup>(initialGroup);
+
   useEffect(() => {
-    setCurrentGroup(nestedOptions[ROOT_GROUP_IDENTIFIER]);
-  }, [nestedOptions]);
+    setCurrentGroup(initialGroup);
+  }, [initialGroup]);
 
   const setCurrentGroupByIdentifier = (identifier: GroupIdentifier) => {
     const group = nestedOptions[identifier];
@@ -250,9 +285,13 @@ export function useNestedOptions({
     }
   };
 
+  const getOptionLabel = (value: string): string | undefined =>
+    optionLabels[value];
+
   return {
     currentGroup,
     isGroupIdentifier,
     setCurrentGroupByIdentifier,
+    getOptionLabel,
   };
 }


### PR DESCRIPTION
## Description

Nested dropdown fields (single-select `Tagger` and `MultiSelect`) stopped displaying the label of an already-selected value after the Garden v9 upgrade (Copenhagen theme v4.18). The value was correctly selected and submitted, but the closed combobox showed the empty placeholder instead of the selected option's label. This was most visible when values are set externally, e.g. via prefilled URL parameters.

The previous implementation relied on rendering every option on the first render and trusting the Combobox to cache their labels so it could resolve a selected value that lives in a non-visible group. Garden v9 rebuilds that label cache from the currently rendered options on every render, so once the options were removed the selected label was lost.

Instead of depending on that internal caching, resolve the label from the full option list directly: Tagger computes the displayed label via `renderValue`, and `MultiSelect` renders hidden options for selected values so their tags resolve, without affecting menu navigation. Tagger now also opens on the group that contains the selected value, which is both clearer for the user and no longer required for correctness.

Adds component-level tests covering selected-value labels (root, nested and empty) and the existing navigation/selection behavior to guard against regressions.

## Screenshots

Before:
- when a nested dropdown has a value selected (either by submitting a form with errors or by prefilling via URL), the value is not shown
- when a nested multiselect has a value selected (either by submitting a form with errors or by prefilling via URL), the selected tags show the raw value instead of the label
- when navigating around in a nested multiselect, the selected tags show the raw value instead of the label for all the selected items that are not in the current selected level


https://github.com/user-attachments/assets/a394bb48-cda1-4c9e-abdf-2e21d547da12

After:
- when a nested dropdown has a value selected (either by submitting a form with errors or by prefilling via URL), the value is shown correctly
- when a nested multiselect has a value selected (either by submitting a form with errors or by prefilling via URL), the selected tags show the label of the selected items
- when navigating around in a nested multiselect, the selected tags show the label of the selected items


https://github.com/user-attachments/assets/73bcc8b6-b4a5-44b9-b5f4-88b7ef92580c



## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->