### PR TITLE
feat: add translation to attachments label in service catalog

### DIFF
--- a/src/modules/service-catalog/components/service-catalog-item/ItemRequestForm.tsx
+++ b/src/modules/service-catalog/components/service-catalog-item/ItemRequestForm.tsx
@@ -271,7 +271,7 @@ export function ItemRequestForm({
         key="attachments"
         field={{
           name: AttachmentsInputName,
-          label: attachmentsOption.name,
+          label: t("service-catalog.item.attachments-label", "Upload a file"),
           description:
             attachmentsOption.custom_object_fields["standard::description"] ??
             "",

--- a/src/modules/service-catalog/translations/en-us.yml
+++ b/src/modules/service-catalog/translations/en-us.yml
@@ -169,6 +169,11 @@ parts:
       screenshot: "https://drive.google.com/file/d/1H4Tsm7YHGdtFnSElJH6ZUIIU7VyySq2S/view?usp=sharing"
       value: "SN: {{serialNumber}}"
   - translation:
+      key: "service-catalog.item.attachments-label"
+      title: "Label for the attachment upload field in the service catalog item request form"
+      screenshot: "https://drive.google.com/file/d/1iixvKen00peKisWS4FkGLBhip1o8LGKT/view?usp=sharing"
+      value: "Upload a file"
+  - translation:
       key: "service-catalog.attachments-required-error"
       title: "Error message for attachments required field validation"
       screenshot: "https://drive.google.com/file/d/1pzBRSy9JYwExx8v2HsMPbh-aLlKvod57/view?usp=sharing"


### PR DESCRIPTION
## Description

The attachment field label in the Service Catalog item request form ("Upload a file") was not translated for any non-English locale 

## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->