### PR TITLE
PDSC-841: Hide Uncategorized category entirely from end-user service catalog

### DIFF
--- a/src/modules/service-catalog/components/ServiceCatalogPage.spec.tsx
+++ b/src/modules/service-catalog/components/ServiceCatalogPage.spec.tsx
@@ -1,5 +1,5 @@
 import { render } from "../../test/render";
-import { waitFor } from "@testing-library/react";
+import { waitFor, fireEvent, within } from "@testing-library/react";
 import { ServiceCatalogPage } from "./ServiceCatalogPage";
 import type { Category } from "../data-types/Categories";
 import {
@@ -100,7 +100,7 @@ describe("ServiceCatalogPage uncategorized filtering", () => {
       });
     });
 
-    it("does not render the uncategorized category in nested children", async () => {
+    it("does not render the uncategorized category in nested children after expanding parent", async () => {
       mockFetch();
 
       render(
@@ -110,14 +110,29 @@ describe("ServiceCatalogPage uncategorized filtering", () => {
         />
       );
 
-      // Expand the parent category to reveal children
+      // Expand the parent category "Hardware" by clicking its expand button
+      const parentCategory = document.querySelector(
+        '[data-test-id="sidebar-category-cat-1"]'
+      ) as HTMLElement;
+      expect(parentCategory).toBeInTheDocument();
+      const expandButton = within(parentCategory).getByLabelText(
+        "Expand category"
+      );
+      fireEvent.click(expandButton);
+
+      // After expanding, the valid child "Laptops" should appear but not UNCATEGORIZED_ID
       await waitFor(() => {
         expect(
           document.querySelector(
-            `[data-test-id="sidebar-category-${UNCATEGORIZED_ID}"]`
+            '[data-test-id="sidebar-category-cat-1-1"]'
           )
-        ).toBeNull();
+        ).toBeInTheDocument();
       });
+      expect(
+        document.querySelector(
+          `[data-test-id="sidebar-category-${UNCATEGORIZED_ID}"]`
+        )
+      ).toBeNull();
     });
 
     it("still renders valid categories", async () => {

--- a/src/modules/service-catalog/components/ServiceCatalogPage.spec.tsx
+++ b/src/modules/service-catalog/components/ServiceCatalogPage.spec.tsx
@@ -115,17 +115,14 @@ describe("ServiceCatalogPage uncategorized filtering", () => {
         '[data-test-id="sidebar-category-cat-1"]'
       ) as HTMLElement;
       expect(parentCategory).toBeInTheDocument();
-      const expandButton = within(parentCategory).getByLabelText(
-        "Expand category"
-      );
+      const expandButton =
+        within(parentCategory).getByLabelText("Expand category");
       fireEvent.click(expandButton);
 
       // After expanding, the valid child "Laptops" should appear but not UNCATEGORIZED_ID
       await waitFor(() => {
         expect(
-          document.querySelector(
-            '[data-test-id="sidebar-category-cat-1-1"]'
-          )
+          document.querySelector('[data-test-id="sidebar-category-cat-1-1"]')
         ).toBeInTheDocument();
       });
       expect(

--- a/src/modules/service-catalog/components/ServiceCatalogPage.spec.tsx
+++ b/src/modules/service-catalog/components/ServiceCatalogPage.spec.tsx
@@ -1,0 +1,191 @@
+import { render } from "../../test/render";
+import { waitFor } from "@testing-library/react";
+import { ServiceCatalogPage } from "./ServiceCatalogPage";
+import type { Category } from "../data-types/Categories";
+import {
+  ALL_SERVICES_ID,
+  UNCATEGORIZED_ID,
+} from "./service-catalog-categories-sidebar/constants";
+
+const HELP_CENTER_PATH = "/hc/en-us";
+
+const emptyResponse = {
+  service_catalog_items: [],
+  meta: { before_cursor: null, after_cursor: null, has_more: false },
+  count: 0,
+};
+
+function mockFetch() {
+  const fetchMock = jest.fn(() =>
+    Promise.resolve({
+      json: () => Promise.resolve(emptyResponse),
+      status: 200,
+      ok: true,
+    })
+  ) as jest.Mock;
+  global.fetch = fetchMock;
+  return fetchMock;
+}
+
+function setUrl(search: string) {
+  window.history.replaceState(
+    {},
+    "",
+    `${window.location.pathname}${search ? `?${search}` : ""}`
+  );
+}
+
+const categoryTree: Category[] = [
+  {
+    id: ALL_SERVICES_ID,
+    name: "All services",
+    items_count: 10,
+    updated_at: "2024-01-01",
+  },
+  {
+    id: "cat-1",
+    name: "Hardware",
+    items_count: 5,
+    updated_at: "2024-01-01",
+    children: [
+      {
+        id: "cat-1-1",
+        name: "Laptops",
+        items_count: 3,
+        updated_at: "2024-01-01",
+      },
+      {
+        id: UNCATEGORIZED_ID,
+        name: "Uncategorized",
+        items_count: 2,
+        updated_at: "2024-01-01",
+      },
+    ],
+  },
+  {
+    id: UNCATEGORIZED_ID,
+    name: "Uncategorized",
+    items_count: 4,
+    updated_at: "2024-01-01",
+  },
+];
+
+describe("ServiceCatalogPage uncategorized filtering", () => {
+  beforeEach(() => {
+    setUrl("");
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    setUrl("");
+  });
+
+  describe("sidebar filtering", () => {
+    it("does not render the uncategorized category in the sidebar at the top level", async () => {
+      mockFetch();
+
+      render(
+        <ServiceCatalogPage
+          helpCenterPath={HELP_CENTER_PATH}
+          categoryTree={categoryTree}
+        />
+      );
+
+      await waitFor(() => {
+        expect(
+          document.querySelector(
+            `[data-test-id="sidebar-category-${UNCATEGORIZED_ID}"]`
+          )
+        ).toBeNull();
+      });
+    });
+
+    it("does not render the uncategorized category in nested children", async () => {
+      mockFetch();
+
+      render(
+        <ServiceCatalogPage
+          helpCenterPath={HELP_CENTER_PATH}
+          categoryTree={categoryTree}
+        />
+      );
+
+      // Expand the parent category to reveal children
+      await waitFor(() => {
+        expect(
+          document.querySelector(
+            `[data-test-id="sidebar-category-${UNCATEGORIZED_ID}"]`
+          )
+        ).toBeNull();
+      });
+    });
+
+    it("still renders valid categories", async () => {
+      mockFetch();
+
+      render(
+        <ServiceCatalogPage
+          helpCenterPath={HELP_CENTER_PATH}
+          categoryTree={categoryTree}
+        />
+      );
+
+      await waitFor(() => {
+        expect(
+          document.querySelector('[data-test-id="sidebar-category-cat-1"]')
+        ).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("URL param rejection", () => {
+    it("does not use uncategorized-virtual-id from URL as selectedCategoryId", async () => {
+      setUrl(`category_id=${UNCATEGORIZED_ID}`);
+      const fetchMock = mockFetch();
+
+      render(
+        <ServiceCatalogPage
+          helpCenterPath={HELP_CENTER_PATH}
+          categoryTree={categoryTree}
+        />
+      );
+
+      await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+
+      // No API call should contain uncategorized-virtual-id as category_id
+      const allUrls = fetchMock.mock.calls.map((call) => call[0] as string);
+      for (const url of allUrls) {
+        const params = new URLSearchParams(url.split("?")[1] ?? "");
+        expect(params.get("category_id")).not.toBe(UNCATEGORIZED_ID);
+      }
+    });
+
+    it("rejects uncategorized-virtual-id from popstate navigation", async () => {
+      setUrl("category_id=cat-1");
+      const fetchMock = mockFetch();
+
+      render(
+        <ServiceCatalogPage
+          helpCenterPath={HELP_CENTER_PATH}
+          categoryTree={categoryTree}
+        />
+      );
+
+      await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+
+      // Simulate navigation to uncategorized URL
+      setUrl(`category_id=${UNCATEGORIZED_ID}`);
+      window.dispatchEvent(new PopStateEvent("popstate"));
+
+      // Wait for any potential refetch to settle
+      await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+
+      // No API call should contain uncategorized-virtual-id as category_id
+      const allUrls = fetchMock.mock.calls.map((call) => call[0] as string);
+      for (const url of allUrls) {
+        const params = new URLSearchParams(url.split("?")[1] ?? "");
+        expect(params.get("category_id")).not.toBe(UNCATEGORIZED_ID);
+      }
+    });
+  });
+});

--- a/src/modules/service-catalog/components/ServiceCatalogPage.tsx
+++ b/src/modules/service-catalog/components/ServiceCatalogPage.tsx
@@ -10,7 +10,18 @@ import {
 } from "./service-catalog-categories-sidebar/constants";
 
 function filterUncategorized(categories: Category[]): Category[] {
-  return categories.filter((cat) => cat.id !== UNCATEGORIZED_ID);
+  return categories
+    .filter((cat) => cat.id !== UNCATEGORIZED_ID)
+    .map((cat) =>
+      cat.children
+        ? { ...cat, children: filterUncategorized(cat.children) }
+        : cat
+    );
+}
+
+function sanitizeCategoryId(categoryId: string | null): string | null {
+  if (categoryId === UNCATEGORIZED_ID) return null;
+  return categoryId;
 }
 
 function getCategoryIdFromUrl(): string | null {
@@ -29,12 +40,12 @@ export const ServiceCatalogPage: React.FC<ServiceCatalogPageProps> = ({
 }) => {
   const hasCategories = categoryTree.length > 0;
   const [selectedCategoryId, setSelectedCategoryId] = useState<string | null>(
-    getCategoryIdFromUrl
+    () => sanitizeCategoryId(getCategoryIdFromUrl())
   );
 
   useEffect(() => {
     const handlePopState = () => {
-      setSelectedCategoryId(getCategoryIdFromUrl());
+      setSelectedCategoryId(sanitizeCategoryId(getCategoryIdFromUrl()));
     };
     window.addEventListener("popstate", handlePopState);
     return () => window.removeEventListener("popstate", handlePopState);
@@ -43,7 +54,6 @@ export const ServiceCatalogPage: React.FC<ServiceCatalogPageProps> = ({
   const selectedCategoryName = useMemo(() => {
     if (!selectedCategoryId || !hasCategories) return null;
     if (selectedCategoryId === ALL_SERVICES_ID) return ALL_SERVICES_ID;
-    if (selectedCategoryId === UNCATEGORIZED_ID) return UNCATEGORIZED_ID;
     const category = findCategoryById(categoryTree, selectedCategoryId);
     return category?.name ?? null;
   }, [selectedCategoryId, categoryTree, hasCategories]);

--- a/src/modules/service-catalog/components/ServiceCatalogPage.tsx
+++ b/src/modules/service-catalog/components/ServiceCatalogPage.tsx
@@ -59,7 +59,7 @@ export const ServiceCatalogPage: React.FC<ServiceCatalogPageProps> = ({
   }, [selectedCategoryId, categoryTree, hasCategories]);
 
   const handleCategorySelect = useCallback((categoryId: string) => {
-    setSelectedCategoryId(categoryId);
+    setSelectedCategoryId(sanitizeCategoryId(categoryId));
   }, []);
 
   return (

--- a/src/modules/service-catalog/components/service-catalog-categories-sidebar/CategoryItem.tsx
+++ b/src/modules/service-catalog/components/service-catalog-categories-sidebar/CategoryItem.tsx
@@ -5,7 +5,7 @@ import ChevronDownIcon from "@zendeskgarden/svg-icons/src/12/chevron-down-fill.s
 import ChevronUpIcon from "@zendeskgarden/svg-icons/src/12/chevron-up-fill.svg";
 import { useTranslation } from "react-i18next";
 import type { Category } from "../../data-types/Categories";
-import { ALL_SERVICES_ID, UNCATEGORIZED_ID } from "./constants";
+import { ALL_SERVICES_ID } from "./constants";
 
 const MAX_NESTING_LEVEL = 6;
 const INDENT_PER_LEVEL = 20;
@@ -134,15 +134,12 @@ export const CategoryItem: React.FC<CategoryItemProps> = ({
   const hasChildren = (category.children?.length ?? 0) > 0;
   const isExpanded = expandedCategories.has(category.id);
   const isAllServices = category.id === ALL_SERVICES_ID;
-  const isUncategorized = category.id === UNCATEGORIZED_ID;
   const isSelected = selectedCategoryId === category.id;
 
   const { t } = useTranslation();
 
   const displayName = isAllServices
     ? t("service-catalog-sidebar.all-services", "All services")
-    : isUncategorized
-    ? t("service-catalog-sidebar.uncategorized", "Uncategorized")
     : category.name;
 
   const handleExpandClick = (e: React.MouseEvent) => {

--- a/src/modules/service-catalog/components/service-catalog-list/ServiceCatalogList.spec.tsx
+++ b/src/modules/service-catalog/components/service-catalog-list/ServiceCatalogList.spec.tsx
@@ -3,6 +3,10 @@ import { render } from "../../../test/render";
 import { screen, waitFor } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
 import { ServiceCatalogList } from "./ServiceCatalogList";
+import {
+  ALL_SERVICES_ID,
+  UNCATEGORIZED_ID,
+} from "../service-catalog-categories-sidebar/constants";
 
 const HELP_CENTER_PATH = "/hc/en-us";
 
@@ -276,6 +280,87 @@ describe("ServiceCatalogList sorting", () => {
         sort_by: "created_at",
         sort_order: "desc",
       });
+    });
+  });
+});
+
+describe("ServiceCatalogList category filtering", () => {
+  beforeEach(() => {
+    setUrl("");
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    setUrl("");
+  });
+
+  it("does not pass UNCATEGORIZED_ID as category_id to the API", async () => {
+    const fetchMock = mockFetch();
+
+    render(
+      <ServiceCatalogList
+        helpCenterPath={HELP_CENTER_PATH}
+        selectedCategoryId={UNCATEGORIZED_ID}
+        selectedCategoryName={null}
+      />
+    );
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+
+    const url = fetchMock.mock.calls[0]?.[0] as string;
+    const params = new URLSearchParams(url.split("?")[1] ?? "");
+    expect(params.get("category_id")).toBeNull();
+  });
+
+  it("does not pass ALL_SERVICES_ID as category_id to the API", async () => {
+    const fetchMock = mockFetch();
+
+    render(
+      <ServiceCatalogList
+        helpCenterPath={HELP_CENTER_PATH}
+        selectedCategoryId={ALL_SERVICES_ID}
+        selectedCategoryName={ALL_SERVICES_ID}
+      />
+    );
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+
+    const url = fetchMock.mock.calls[0]?.[0] as string;
+    const params = new URLSearchParams(url.split("?")[1] ?? "");
+    expect(params.get("category_id")).toBeNull();
+  });
+
+  it("passes a real category_id to the API", async () => {
+    const fetchMock = mockFetch();
+
+    render(
+      <ServiceCatalogList
+        helpCenterPath={HELP_CENTER_PATH}
+        selectedCategoryId="real-cat-id"
+        selectedCategoryName="Hardware"
+      />
+    );
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+
+    const url = fetchMock.mock.calls[0]?.[0] as string;
+    const params = new URLSearchParams(url.split("?")[1] ?? "");
+    expect(params.get("category_id")).toBe("real-cat-id");
+  });
+
+  it("does not render 'Uncategorized' heading when selectedCategoryName is UNCATEGORIZED_ID", async () => {
+    mockFetch();
+
+    render(
+      <ServiceCatalogList
+        helpCenterPath={HELP_CENTER_PATH}
+        selectedCategoryId={UNCATEGORIZED_ID}
+        selectedCategoryName={null}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByText("Uncategorized")).not.toBeInTheDocument();
     });
   });
 });

--- a/src/modules/service-catalog/components/service-catalog-list/ServiceCatalogList.tsx
+++ b/src/modules/service-catalog/components/service-catalog-list/ServiceCatalogList.tsx
@@ -58,6 +58,7 @@ const CountAndSortRow = styled.div`
 function getApiCategoryId(selectedCategoryId: string | null): string | null {
   if (!selectedCategoryId) return null;
   if (selectedCategoryId === ALL_SERVICES_ID) return null;
+  if (selectedCategoryId === UNCATEGORIZED_ID) return null;
   return selectedCategoryId;
 }
 
@@ -221,8 +222,6 @@ export function ServiceCatalogList({
   const categoryHeading =
     selectedCategoryName === ALL_SERVICES_ID
       ? t("service-catalog-sidebar.all-services", "All services")
-      : selectedCategoryName === UNCATEGORIZED_ID
-      ? t("service-catalog-sidebar.uncategorized", "Uncategorized")
       : selectedCategoryName;
 
   return (


### PR DESCRIPTION
## PDSC-841: Hide Uncategorized category entirely from end-user service catalog
**Jira:** https://zendesk.atlassian.net/browse/PDSC-841
### Implementation
Done. Here's a summary of what was implemented:

## Summary of Changes (PDSC-841)

**Branch:** `pdsc-841-agent-fix` (off `master`)

### Problem
The "Uncategorized" virtual category (`uncategorized-virtual-id`) was partially hidden from end users but still accessible via direct URL, renderable with an "Uncategorized" heading, and had dead code in the sidebar component.

### Changes Made

1. **`ServiceCatalogPage.tsx`** — Three fixes:
   - Made `filterUncategorized()` **recursive** — it now strips uncategorized from `category.children` at all nesting levels, not just the top-level array
   - Added `sanitizeCategoryId()` guard that maps `UNCATEGORIZED_ID` → `null`, applied to both the initial state (from URL params) and the `popstate` handler — this blocks `?category_id=uncategorized-virtual-id` from being used
   - Removed the `UNCATEGORIZED_ID` branch from `selectedCategoryName` memo (now unreachable)

2. **`ServiceCatalogList.tsx`** — Two fixes:
   - Added `UNCATEGORIZED_ID` check to `getApiCategoryId()` to return `null` (prevents API calls filtered to uncategorized)
   - Removed the "Uncategorized" heading branch from `categoryHeading`

3. **`CategoryItem.tsx`** — Dead code removal:
   - Removed `isUncategorized` variable and its use in `displayName` ternary
   - Removed unused `UNCATEGORIZED_ID` import

4. **Tests** — New test coverage:
   - `ServiceCatalogPage.spec.tsx` (new file): Tests sidebar filtering at top-level and nested, URL param rejection on initial load and popstate
   - `ServiceCatalogList.spec.tsx` (extended): Tests that `getApiCategoryId` returns null for `UNCATEGORIZED_ID` and `ALL_SERVICES_ID`, passes real IDs through, and doesn't render "Uncategorized" heading

**All 100 tests pass across 11 test suites.**

### Review
The implementation correctly addresses all acceptance criteria from PDSC-841. The changes properly: (1) make `filterUncategorized` recursive to strip uncategorized from nested children, (2) add `sanitizeCategoryId` to reject UNCATEGORIZED_ID from URL params and popstate navigation, (3) add UNCATEGORIZED_ID → null mapping in `getApiCategoryId`, (4) remove dead `isUncategorized` logic from CategoryItem.tsx, and (5) add comprehensive tests. I made two minor review fixes: (a) added `sanitizeCategoryId` to the `handleCategorySelect` callback for defense-in-depth — while the UI path is blocked by the sidebar filter, this guards against any future programmatic caller, and (b) improved the nested-children test to actually expand the parent category and verify the child 'Laptops' appears while UNCATEGORIZED_ID does not, rather than just checking initial render state (which was functionally identical to the top-level test). All 100 service-catalog tests pass.

_This PR was created automatically by ZenForge._