### PR TITLE
Update Croatian localization keys for Help Center

### DIFF
--- a/src/modules/ticket-fields/translations/locales/hr.json
+++ b/src/modules/ticket-fields/translations/locales/hr.json
@@ -1,5 +1,5 @@
 {
-  "cph-theme-ticket-fields.attachments.choose-file-label": "Choose a file or drag and drop here",
+  "cph-theme-ticket-fields.attachments.choose-file-label": "Odaberite datoteku ili je povucite i ispustite ovdje",
   "cph-theme-ticket-fields.attachments.drop-files-label": "Drop files here",
   "cph-theme-ticket-fields.attachments.error-separator": "; ",
   "cph-theme-ticket-fields.attachments.file": "File: {{fileName}}, press delete to remove",
@@ -18,5 +18,7 @@
   "cph-theme-ticket-fields.lookup-field.placeholder": "Search {{label}}",
   "cph-theme-ticket-fields.search-field.no-matches-found": "No matches found",
   "cph-theme-ticket-fields.search-field.placeholder": "Search {{label}}",
-  "cph-theme-ticket-fields.upload-failed-title": "{{fileName}} upload failed"
+  "cph-theme-ticket-fields.upload-failed-title": "{{fileName}} upload failed",
+  "new-request-form.submit": "Pošalji",
+  "new-request-form.required-fields-info": "Polja označena zvjezdicom (*) obavezna su."
 }


### PR DESCRIPTION
## Description

Proactively added 3 missing Croatian (`hr`) localization keys to `hr.json` as requested by the customer support team in Zendesk [Ticket](https://support.zendesk.com/agent/tickets/14864626). 

This PR includes:
- Updating 1 pre-existing attachment label key.
- Appending 2 new request form validation and submit keys.

Adding these ensures standard Help Center interface elements render completely in Croatian.

## Screenshots

<!-- (optional) when applicable, please include some screenshots or gifs that illustrate the changes -->

## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->