### PR TITLE
chore: update Slovenian localization keys for Help Center

### DIFF
--- a/src/modules/ticket-fields/translations/locales/sl.json
+++ b/src/modules/ticket-fields/translations/locales/sl.json
@@ -1,5 +1,5 @@
 {
-  "cph-theme-ticket-fields.attachments.choose-file-label": "Choose a file or drag and drop here",
+  "cph-theme-ticket-fields.attachments.choose-file-label": "Izberite datoteko ali jo povlecite in spustite sem",
   "cph-theme-ticket-fields.attachments.drop-files-label": "Drop files here",
   "cph-theme-ticket-fields.attachments.error-separator": "; ",
   "cph-theme-ticket-fields.attachments.file": "File: {{fileName}}, press delete to remove",


### PR DESCRIPTION
Populated missing sl-SI translations for key cph-theme-ticket-fields.attachments.choose-file-label as per customer request in ticket (https://support.zendesk.com/agent/tickets/14901186).

## Description

<!-- a summary of the changes introduced by this PR and the motivation behind them -->

## Screenshots

<!-- (optional) when applicable, please include some screenshots or gifs that illustrate the changes -->

## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->