### PR TITLE
chore(i18n): add submitter/user translation keys

### DIFF
--- a/src/modules/service-catalog/translations/en-us.yml
+++ b/src/modules/service-catalog/translations/en-us.yml
@@ -308,3 +308,18 @@ parts:
       title: "[A11Y] Hidden label for screen readers describing the sort options group in the service catalog list"
       screenshot: ""
       value: "Sort services"
+  - translation:
+      key: "service-catalog.item.user"
+      title: "Label above the requester's name in the service request form"
+      screenshot: "https://drive.google.com/file/d/1k5um4vxeW-SV1vQlblYJFU4uHzdejvju/view?usp=share_link"
+      value: "User"
+  - translation:
+      key: "service-catalog.item.submitter-label"
+      title: "Line in the request comment naming who submitted the request on behalf of another user. {{name}} is the submitter's name."
+      screenshot: "https://drive.google.com/file/d/1kkyjrLu9UZWVPFowlqwZ-D-qE0zwcUyV/view?usp=sharing"
+      value: "Submitter: {{name}}"
+  - translation:
+      key: "service-catalog.item.user-label"
+      title: "Line in the request comment naming the user the request was submitted on behalf of. {{name}} is that user's name."
+      screenshot: "https://drive.google.com/file/d/1kkyjrLu9UZWVPFowlqwZ-D-qE0zwcUyV/view?usp=sharing"
+      value: "User: {{name}}"


### PR DESCRIPTION
## Description

This PR adds 3 strings to the Service Catalog en-us.yml

## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->