### PR TITLE
[PDSC-713] feat: migrate to the new endpoint and add submitter/user logic

### DIFF
--- a/src/modules/service-catalog/components/service-catalog-item/ItemRequestForm.tsx
+++ b/src/modules/service-catalog/components/service-catalog-item/ItemRequestForm.tsx
@@ -130,6 +130,8 @@ interface ItemRequestFormProps {
   userId: number;
   requestOnBehalfEnabled: boolean | undefined;
   userName: string;
+  selectedUser: UserOption | null;
+  setSelectedUser: (user: UserOption | null) => void;
   brandId: number;
   defaultOrganizationId: string | null;
   handleChange: (
@@ -162,6 +164,8 @@ export function ItemRequestForm({
   userId,
   requestOnBehalfEnabled,
   userName,
+  selectedUser,
+  setSelectedUser,
   brandId,
   defaultOrganizationId,
   handleChange,
@@ -183,7 +187,6 @@ export function ItemRequestForm({
 }: ItemRequestFormProps) {
   const { t } = useTranslation();
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const [selectedUser, setSelectedUser] = useState<UserOption | null>(null);
   const [displayedUserName, setDisplayedUserName] = useState(userName);
 
   const handleOpenModal = () => {

--- a/src/modules/service-catalog/components/service-catalog-item/ServiceCatalogItem.spec.tsx
+++ b/src/modules/service-catalog/components/service-catalog-item/ServiceCatalogItem.spec.tsx
@@ -40,20 +40,38 @@ jest.mock("../../hooks/useAttachmentsOption", () => ({
   useAttachmentsOption: jest.fn(),
 }));
 
-// Mock ItemRequestForm to simplify testing
 jest.mock("./ItemRequestForm", () => ({
   ItemRequestForm: ({
     onSubmit,
     isPreviewMode,
+    setSelectedUser,
   }: {
     onSubmit: (e: React.FormEvent<HTMLFormElement>) => void;
     isPreviewMode?: boolean;
+    setSelectedUser: (user: {
+      id: string;
+      name: string;
+      email: string;
+    }) => void;
   }) => (
     <form
       data-testid="item-request-form"
       data-preview-mode={isPreviewMode ? "true" : "false"}
       onSubmit={onSubmit}
     >
+      <button
+        type="button"
+        data-testid="select-beneficiary"
+        onClick={() =>
+          setSelectedUser({
+            id: "789",
+            name: "Beneficiary",
+            email: "beneficiary@example.com",
+          })
+        }
+      >
+        Select beneficiary
+      </button>
       <button type="submit" disabled={isPreviewMode}>
         Submit
       </button>
@@ -535,6 +553,50 @@ describe("ServiceCatalogItem", () => {
           })
         );
       });
+    });
+  });
+
+  describe("request on behalf", () => {
+    // defaultProps.userId is 123; the mocked beneficiary has id "789".
+    const successResponse = {
+      ok: true,
+      json: () => Promise.resolve({ request: { id: 555 } }),
+    } as unknown as Response;
+
+    it("does not pass requesterId or note for a self request", async () => {
+      mockSubmitServiceItemRequest.mockResolvedValue(successResponse);
+
+      renderWithTheme(<ServiceCatalogItem {...defaultProps} />);
+
+      fireEvent.submit(screen.getByTestId("item-request-form"));
+
+      await waitFor(() => {
+        expect(mockSubmitServiceItemRequest).toHaveBeenCalled();
+      });
+
+      const callArgs = mockSubmitServiceItemRequest.mock.calls[0]!;
+      // requesterId is the 8th positional arg, onBehalfNoteHtml the 9th.
+      expect(callArgs[7]).toBeNull();
+      expect(callArgs[8]).toBeNull();
+    });
+
+    it("passes the beneficiary id and a submitter/user note when on behalf", async () => {
+      mockSubmitServiceItemRequest.mockResolvedValue(successResponse);
+
+      renderWithTheme(<ServiceCatalogItem {...defaultProps} />);
+
+      // Pick a beneficiary (id 789) different from the current user (123).
+      fireEvent.click(screen.getByTestId("select-beneficiary"));
+      fireEvent.submit(screen.getByTestId("item-request-form"));
+
+      await waitFor(() => {
+        expect(mockSubmitServiceItemRequest).toHaveBeenCalled();
+      });
+
+      const callArgs = mockSubmitServiceItemRequest.mock.calls[0]!;
+      expect(callArgs[7]).toBe(789);
+      expect(callArgs[8]).toContain("Submitter: {{name}}");
+      expect(callArgs[8]).toContain("User: {{name}}");
     });
   });
 });

--- a/src/modules/service-catalog/components/service-catalog-item/ServiceCatalogItem.tsx
+++ b/src/modules/service-catalog/components/service-catalog-item/ServiceCatalogItem.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useState } from "react";
 import { createPortal } from "react-dom";
 import { useItemFormFields } from "../../hooks/useItemFormFields";
 import { ItemRequestForm } from "./ItemRequestForm";
+import type { UserOption } from "../../data-types/UserOption";
 import { CategorySelector } from "./CategorySelector";
 import { PreviewModeBanner } from "./PreviewModeBanner";
 import type { Organization } from "../../../ticket-fields/data-types/Organization";
@@ -91,6 +92,8 @@ export function ServiceCatalogItem({
   const [selectedCategoryId, setSelectedCategoryId] = useState<string | null>(
     null
   );
+
+  const [selectedUser, setSelectedUser] = useState<UserOption | null>(null);
 
   useEffect(() => {
     if (!serviceCatalogItem?.categories?.length) return;
@@ -364,15 +367,33 @@ export function ServiceCatalogItem({
     setIsSubmitting(true);
 
     try {
+      const isRequestingOnBehalf =
+        selectedUser != null && Number(selectedUser.id) !== userId;
+      const requesterId = isRequestingOnBehalf ? Number(selectedUser.id) : null;
+
+      const onBehalfNoteHtml =
+        isRequestingOnBehalf && selectedUser
+          ? `<p style="margin:0;padding:0">${t(
+              "service-catalog.item.submitter-label",
+              "Submitter: {{name}}",
+              { name: userName }
+            )}</p><p style="margin:0;padding:0">${t(
+              "service-catalog.item.user-label",
+              "User: {{name}}",
+              { name: selectedUser.name }
+            )}</p>`
+          : null;
+
       const response = await submitServiceItemRequest(
         serviceCatalogItem,
         requestFieldsWithFormData,
         associatedLookupField,
-        baseLocale,
         attachments,
         helpCenterPath,
         categoryLookupField,
-        selectedCategoryId
+        selectedCategoryId,
+        requesterId,
+        onBehalfNoteHtml
       );
 
       if (response?.ok) {
@@ -434,6 +455,8 @@ export function ServiceCatalogItem({
           userId={userId}
           requestOnBehalfEnabled={requestOnBehalfEnabled}
           userName={userName}
+          selectedUser={selectedUser}
+          setSelectedUser={setSelectedUser}
           brandId={brandId}
           defaultOrganizationId={defaultOrganizationId}
           handleChange={handleFieldChange}

--- a/src/modules/service-catalog/components/service-catalog-item/submitServiceItemRequest.spec.tsx
+++ b/src/modules/service-catalog/components/service-catalog-item/submitServiceItemRequest.spec.tsx
@@ -1,0 +1,217 @@
+import { submitServiceItemRequest } from "./submitServiceItemRequest";
+import type { ServiceCatalogItem } from "../../data-types/ServiceCatalogItem";
+import type { TicketFieldObject } from "../../../ticket-fields/data-types/TicketFieldObject";
+import type { Attachment } from "../../../ticket-fields/data-types/AttachmentsField";
+
+const SUBMITTER_ID = 123;
+const SUBMIT_URL = "/hc/api/v2/service_catalog/requests";
+const ME_URL = "/api/v2/users/me.json";
+
+const mockItem: ServiceCatalogItem = {
+  id: 1,
+  name: "Test Service",
+  description: "Test Description",
+  form_id: 100,
+  thumbnail_url: "",
+  categories: [],
+  is_request_on_behalf: true,
+  published_at: "2025-01-01T00:00:00Z",
+  custom_object_fields: {
+    "standard::asset_option": "",
+    "standard::asset_type_option": "",
+    "standard::attachment_option": "",
+  },
+};
+
+const makeField = (id: number, value: string): TicketFieldObject => ({
+  id,
+  name: `custom_fields_${id}`,
+  type: "text",
+  description: "",
+  label: `Field ${id}`,
+  required: false,
+  options: [],
+  value,
+  error: null,
+});
+
+const associatedLookupField = makeField(900, "");
+const attachments: Attachment[] = [
+  { id: "token-1", file_name: "a.txt", url: "https://x/a.txt" },
+];
+const helpCenterPath = "/hc/en-us";
+
+/**
+ * Mocks the two fetches submitServiceItemRequest makes: the current-user
+ * lookup and the request submission. Returns the submit-fetch mock so tests
+ * can assert on the request body.
+ */
+function mockFetch() {
+  const submitResponse = {
+    ok: true,
+    json: () => Promise.resolve({ request: { id: 555 } }),
+  };
+  const meResponse = {
+    ok: true,
+    json: () =>
+      Promise.resolve({
+        user: { id: SUBMITTER_ID, authenticity_token: "csrf-token" },
+      }),
+  };
+
+  const fetchMock = jest.fn((url: string) =>
+    Promise.resolve(url === ME_URL ? meResponse : submitResponse)
+  ) as unknown as jest.Mock;
+
+  global.fetch = fetchMock;
+  return fetchMock;
+}
+
+/** Extracts the parsed `request` object from the submit fetch call. */
+function getSubmittedRequest(fetchMock: jest.Mock) {
+  const submitCall = fetchMock.mock.calls.find(([url]) => url === SUBMIT_URL);
+  expect(submitCall).toBeDefined();
+  return JSON.parse(submitCall![1].body).request;
+}
+
+describe("submitServiceItemRequest", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("posts to the service catalog requests proxy with item_id and lookup fields", async () => {
+    const fetchMock = mockFetch();
+
+    await submitServiceItemRequest(
+      mockItem,
+      [makeField(1, "value-1")],
+      associatedLookupField,
+      attachments,
+      helpCenterPath
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      SUBMIT_URL,
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          "X-CSRF-Token": "csrf-token",
+        }),
+      })
+    );
+
+    const request = getSubmittedRequest(fetchMock);
+    expect(request.item_id).toBe(mockItem.id);
+    expect(request.subject).toBe(mockItem.name);
+    expect(request.comment.uploads).toEqual(["token-1"]);
+    expect(request.custom_fields).toEqual([
+      { id: 1, value: "value-1" },
+      { id: associatedLookupField.id, value: mockItem.id },
+    ]);
+  });
+
+  it("does not send requester_id or collaborators for a self request", async () => {
+    const fetchMock = mockFetch();
+
+    await submitServiceItemRequest(
+      mockItem,
+      [],
+      associatedLookupField,
+      attachments,
+      helpCenterPath,
+      null,
+      null,
+      // requesterId omitted - self request
+      null
+    );
+
+    const request = getSubmittedRequest(fetchMock);
+    expect(request).not.toHaveProperty("requester_id");
+    expect(request).not.toHaveProperty("collaborators");
+  });
+
+  it("does not send requester_id when the requester is the submitter", async () => {
+    const fetchMock = mockFetch();
+
+    await submitServiceItemRequest(
+      mockItem,
+      [],
+      associatedLookupField,
+      attachments,
+      helpCenterPath,
+      null,
+      null,
+      SUBMITTER_ID // same as current user - not on behalf
+    );
+
+    const request = getSubmittedRequest(fetchMock);
+    expect(request).not.toHaveProperty("requester_id");
+    expect(request).not.toHaveProperty("collaborators");
+  });
+
+  it("sends requester_id and the submitter as a collaborator for a request on behalf", async () => {
+    const fetchMock = mockFetch();
+    const beneficiaryId = 789;
+
+    await submitServiceItemRequest(
+      mockItem,
+      [],
+      associatedLookupField,
+      attachments,
+      helpCenterPath,
+      null,
+      null,
+      beneficiaryId,
+      "<p>Submitter: Agent</p><p>User: Beneficiary</p>"
+    );
+
+    const request = getSubmittedRequest(fetchMock);
+    expect(request.requester_id).toBe(beneficiaryId);
+    expect(request.collaborators).toEqual([SUBMITTER_ID]);
+    expect(request.comment.html_body).toContain(
+      "<p>Submitter: Agent</p><p>User: Beneficiary</p>"
+    );
+  });
+
+  it("appends the category lookup field when a category is provided", async () => {
+    const fetchMock = mockFetch();
+    const categoryLookupField = makeField(901, "");
+
+    await submitServiceItemRequest(
+      mockItem,
+      [],
+      associatedLookupField,
+      attachments,
+      helpCenterPath,
+      categoryLookupField,
+      "cat-42"
+    );
+
+    const request = getSubmittedRequest(fetchMock);
+    expect(request.custom_fields).toEqual([
+      { id: associatedLookupField.id, value: mockItem.id },
+      { id: categoryLookupField.id, value: "cat-42" },
+    ]);
+  });
+
+  it("returns undefined and logs when the request throws", async () => {
+    global.fetch = jest.fn(() =>
+      Promise.reject(new Error("network"))
+    ) as jest.Mock;
+    const consoleError = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    const result = await submitServiceItemRequest(
+      mockItem,
+      [],
+      associatedLookupField,
+      attachments,
+      helpCenterPath
+    );
+
+    expect(result).toBeUndefined();
+    expect(consoleError).toHaveBeenCalled();
+    consoleError.mockRestore();
+  });
+});

--- a/src/modules/service-catalog/components/service-catalog-item/submitServiceItemRequest.tsx
+++ b/src/modules/service-catalog/components/service-catalog-item/submitServiceItemRequest.tsx
@@ -19,11 +19,12 @@ export async function submitServiceItemRequest(
   serviceCatalogItem: ServiceCatalogItem,
   requestFields: TicketFieldObject[],
   associatedLookupField: TicketFieldObject,
-  baseLocale: string,
   attachments: Attachment[],
   helpCenterPath: string,
   categoryLookupField?: TicketFieldObject | null,
-  categoryId?: string | null
+  categoryId?: string | null,
+  requesterId?: number | null,
+  onBehalfNoteHtml?: string | null
 ) {
   try {
     const currentUser = await getCurrentUser();
@@ -44,7 +45,12 @@ export async function submitServiceItemRequest(
       lookupFields.push({ id: categoryLookupField.id, value: categoryId });
     }
 
-    const response = await fetch(`/api/v2/requests?locale=${baseLocale}`, {
+    const submitterId = currentUser.user.id;
+
+    const isRequestingOnBehalf =
+      requesterId != null && requesterId !== submitterId;
+
+    const response = await fetch("/hc/api/v2/service_catalog/requests", {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -52,17 +58,22 @@ export async function submitServiceItemRequest(
       },
       body: JSON.stringify({
         request: {
+          item_id: serviceCatalogItem.id,
           subject: `${serviceCatalogItem.name}`,
           comment: {
-            html_body: `<a href="${window.location.origin}${helpCenterPath}/services/${serviceCatalogItem.id}" style="text-decoration: underline" target="_blank" rel="noopener noreferrer">${serviceCatalogItem.name}</a>`,
+            html_body: `<a href="${
+              window.location.origin
+            }${helpCenterPath}/services/${
+              serviceCatalogItem.id
+            }" style="text-decoration: underline" target="_blank" rel="noopener noreferrer">${
+              serviceCatalogItem.name
+            }</a>${onBehalfNoteHtml ?? ""}`,
             uploads: uploadTokens,
           },
-          ticket_form_id: serviceCatalogItem.form_id,
           custom_fields: [...customFields, ...lookupFields],
-          via: {
-            channel: "web form",
-            source: 50,
-          },
+          ...(isRequestingOnBehalf
+            ? { requester_id: requesterId, collaborators: [submitterId] }
+            : {}),
         },
       }),
     });


### PR DESCRIPTION
## Description

This PR adds request-on-behalf support to the Service Catalog request form, and migrates submission to the new `/hc/api/v2/service_catalog/requests` proxy.

When a different requester is selected via the change-user modal, the request is submitted with `requester_id` (the beneficiary) and collaborators:` [submitterId]` (so the submitter stays notified).
The comment body gets a note identifying both parties - Submitter: <name> / User: <name> — since the backend can't override the comment author (consistent with normal ROB tickets).

Self-requests are unchanged: no requester_id, no note.

## Jira

- https://zendesk.atlassian.net/browse/PDSC-712
- https://zendesk.atlassian.net/browse/PDSC-713 

<img width="1180" height="739" alt="Screenshot 2026-06-30 at 14 14 23" src="https://github.com/user-attachments/assets/71481598-6709-4ada-add5-06f8339f97c6" />

## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->