### PR TITLE
fix: add styling to wrap long names in request page

### DIFF
--- a/style.css
+++ b/style.css
@@ -3556,6 +3556,7 @@ ul {
   line-break: strict;
   color: lighten($text_color, 20%);
   width: 40%;
+  overflow-wrap: break-word;
 }
 .request-details .request-collaborators {
   display: inline-block;

--- a/styles/_request.scss
+++ b/styles/_request.scss
@@ -157,6 +157,7 @@
       line-break: strict;
       color: $secondary-text-color;
       width: 40%;
+      overflow-wrap: break-word;
     }
 
     .request-collaborators {


### PR DESCRIPTION
## Description

We have received reports referencing a visual bug in the request page: when the field name is too long, the text does not wrap and covers the value field.

The purpose of this task is to fix styling so that long names do not obstruct the remaining column values.

## Screenshots

### Before

<img width="1728" height="860" alt="Screenshot 2026-07-03 at 11 46 23" src="https://github.com/user-attachments/assets/77fc8bf8-f6de-4a2c-b023-8d8ac935c141" />

### After

<img width="1728" height="853" alt="Screenshot 2026-07-03 at 11 48 02" src="https://github.com/user-attachments/assets/b87906e5-a106-4e88-bd26-c4f76d7b01a8" />


## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->