### PR TITLE
Revert "feat: filter ticket fields by current brand form"

### DIFF
--- a/src/modules/request-list/data-types/TicketForm.ts
+++ b/src/modules/request-list/data-types/TicketForm.ts
@@ -1,5 +1,0 @@
-export interface TicketForm {
-  id: number;
-  active: boolean;
-  ticket_field_ids: number[];
-}

--- a/src/modules/request-list/data-types/index.ts
+++ b/src/modules/request-list/data-types/index.ts
@@ -6,4 +6,3 @@ export * from "./RequestUser";
 export * from "./TicketField";
 export * from "./FilterValue";
 export * from "./CustomStatus";
-export * from "./TicketForm";

--- a/src/modules/request-list/hooks/useTicketFields.test.ts
+++ b/src/modules/request-list/hooks/useTicketFields.test.ts
@@ -27,31 +27,17 @@ const inactiveTicketField: TicketField = {
   custom_field_options: [],
 };
 
-beforeEach(() => {
-  jest.resetAllMocks();
-});
-
-afterEach(() => {
-  jest.restoreAllMocks();
-});
-
 test("fetches all ticket fields via ticket_fields api call and returns the active ones", async () => {
-  fetchAllCursorPages
-    .mockResolvedValueOnce([activeTicketField, inactiveTicketField])
-    .mockResolvedValueOnce([
-      {
-        id: 1,
-        active: true,
-        ticket_field_ids: [10],
-      },
-    ]);
+  fetchAllCursorPages.mockReturnValueOnce([
+    activeTicketField,
+    inactiveTicketField,
+  ]);
 
   const { result, waitForNextUpdate } = renderHook(() => useTicketFields("dk"));
 
   await waitForNextUpdate();
 
   expect(fetchAllCursorPages.mock.calls[0][1]).toEqual("ticket_fields");
-  expect(fetchAllCursorPages.mock.calls[1][1]).toEqual("ticket_forms");
 
   expect(result.current).toEqual({
     ticketFields: [activeTicketField],
@@ -61,15 +47,17 @@ test("fetches all ticket fields via ticket_fields api call and returns the activ
 });
 
 test("handles exceptions", async () => {
-  fetchAllCursorPages.mockRejectedValueOnce(new Error("Network error"));
+  fetchAllCursorPages.mockRejectedValue("Network error");
 
   const { result, waitForNextUpdate } = renderHook(() => useTicketFields("dk"));
 
   await waitForNextUpdate();
 
-  expect(result.current.error).toEqual(new Error("Network error"));
-  expect(result.current.ticketFields).toEqual([]);
-  expect(result.current.isLoading).toBe(false);
+  expect(result.current).toEqual({
+    ticketFields: [],
+    error: "Network error",
+    isLoading: true,
+  });
 });
 
 test("filters out inactive subject field", async () => {
@@ -83,15 +71,10 @@ test("filters out inactive subject field", async () => {
     custom_field_options: [],
   };
 
-  fetchAllCursorPages
-    .mockResolvedValueOnce([activeTicketField, inactiveSubjectField])
-    .mockResolvedValueOnce([
-      {
-        id: 1,
-        active: true,
-        ticket_field_ids: [10, 30],
-      },
-    ]);
+  fetchAllCursorPages.mockReturnValueOnce([
+    activeTicketField,
+    inactiveSubjectField,
+  ]);
 
   const { result, waitForNextUpdate } = renderHook(() => useTicketFields("dk"));
 
@@ -99,36 +82,6 @@ test("filters out inactive subject field", async () => {
 
   expect(result.current).toEqual({
     ticketFields: [activeTicketField],
-    error: undefined,
-    isLoading: false,
-  });
-});
-
-test("only returns ticket fields present in active ticket forms", async () => {
-  const activeCustomField40: TicketField = {
-    ...inactiveTicketField,
-    id: 40,
-    active: true,
-    title: "Active field 40",
-    title_in_portal: "Active field 40",
-  };
-
-  fetchAllCursorPages
-    .mockResolvedValueOnce([
-      activeTicketField,
-      { ...inactiveTicketField, id: 30, active: true },
-      activeCustomField40,
-    ])
-    .mockResolvedValueOnce([
-      { id: 1, active: true, ticket_field_ids: [10, 40] },
-    ]);
-
-  const { result, waitForNextUpdate } = renderHook(() => useTicketFields("dk"));
-
-  await waitForNextUpdate();
-
-  expect(result.current).toEqual({
-    ticketFields: [activeTicketField, activeCustomField40],
     error: undefined,
     isLoading: false,
   });

--- a/src/modules/request-list/hooks/useTicketFields.ts
+++ b/src/modules/request-list/hooks/useTicketFields.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import type { CursorPaginatedResponse } from "../utils/pagination/CursorPaginatedResponse";
-import type { TicketField, TicketForm } from "../data-types";
+import type { TicketField } from "../data-types";
 import { fetchAllCursorPages } from "../utils/pagination/fetchAllCursorPages";
 
 interface UseTicketFields {
@@ -16,21 +16,6 @@ async function listTicketFields(
   const response = await fetch(
     `/api/v2/ticket_fields.json?locale=${locale}&page[size]=${pageSize}`
   );
-
-  if (!response.ok) {
-    throw new Error(response.statusText);
-  }
-  return await response.json();
-}
-
-async function listTicketForms(
-  locale: string,
-  pageSize = 100
-): Promise<CursorPaginatedResponse<"ticket_forms", TicketForm>> {
-  const response = await fetch(
-    `/api/v2/ticket_forms?locale=${locale}&associated_to_brand=true&active=true&form_type=all&page[size]=${pageSize}`
-  );
-
   if (!response.ok) {
     throw new Error(response.statusText);
   }
@@ -44,27 +29,15 @@ export function useTicketFields(locale: string): UseTicketFields {
 
   async function fetchTicketFields() {
     try {
-      const [ticketFields, ticketForms] = await Promise.all([
-        fetchAllCursorPages(() => listTicketFields(locale), "ticket_fields"),
-        fetchAllCursorPages(() => listTicketForms(locale), "ticket_forms"),
-      ]);
-
-      const activeTicketFieldIds = new Set<number>(
-        ticketForms.flatMap((ticketForm) => ticketForm.ticket_field_ids ?? [])
+      const response = await fetchAllCursorPages(
+        () => listTicketFields(locale),
+        "ticket_fields"
       );
-
-      setTicketFields(
-        ticketFields.filter(
-          (ticketField) =>
-            ticketField.active && activeTicketFieldIds.has(ticketField.id)
-        )
-      );
+      setTicketFields(response.filter((ticketField) => ticketField.active));
 
       setIsLoading(false);
     } catch (error) {
       setError(error as Error);
-    } finally {
-      setIsLoading(false);
     }
   }
 


### PR DESCRIPTION
Reverts zendesk/copenhagen_theme#806

- There are different layers of permissions built on top of unfiltered objects, this change makes it so the default fields do not show unless the custom object have been specifically assigned to the brand. 

Other options:
- Make this a setting instead of reverting, disabled by default
- Disable the setting if view requests across brands is enabled
