### PR TITLE
[PDSC-919] feat(i18n): replace user-label with requester-label in request note

### DIFF
--- a/src/modules/service-catalog/components/service-catalog-item/ServiceCatalogItem.spec.tsx
+++ b/src/modules/service-catalog/components/service-catalog-item/ServiceCatalogItem.spec.tsx
@@ -596,7 +596,7 @@ describe("ServiceCatalogItem", () => {
       const callArgs = mockSubmitServiceItemRequest.mock.calls[0]!;
       expect(callArgs[7]).toBe(789);
       expect(callArgs[8]).toContain("Submitter: {{name}}");
-      expect(callArgs[8]).toContain("User: {{name}}");
+      expect(callArgs[8]).toContain("Requester: {{name}}");
     });
   });
 });

--- a/src/modules/service-catalog/components/service-catalog-item/ServiceCatalogItem.tsx
+++ b/src/modules/service-catalog/components/service-catalog-item/ServiceCatalogItem.tsx
@@ -378,8 +378,8 @@ export function ServiceCatalogItem({
               "Submitter: {{name}}",
               { name: userName }
             )}</p><p style="margin:0;padding:0">${t(
-              "service-catalog.item.user-label",
-              "User: {{name}}",
+              "service-catalog.item.requester-label",
+              "Requester: {{name}}",
               { name: selectedUser.name }
             )}</p>`
           : null;

--- a/src/modules/service-catalog/translations/en-us.yml
+++ b/src/modules/service-catalog/translations/en-us.yml
@@ -323,3 +323,9 @@ parts:
       title: "Line in the request comment naming the user the request was submitted on behalf of. {{name}} is that user's name."
       screenshot: "https://drive.google.com/file/d/1kkyjrLu9UZWVPFowlqwZ-D-qE0zwcUyV/view?usp=sharing"
       value: "User: {{name}}"
+      obsolete: "2026-10-10"
+  - translation:
+      key: "service-catalog.item.requester-label"
+      title: "Line in the request comment naming the requester. {{name}} is that requester's name."
+      screenshot: "https://drive.google.com/file/d/1DsOq3atb9velOovcY-abPqa41S4NNp9v/view?usp=sharing"
+      value: "Requester: {{name}}"


### PR DESCRIPTION
## Description

This PR renames the request-on-behalf comment note label from "User" to "Requester" for consistency with existing product wording (request-list, approval-requests both use "Requester").

## Jira
- https://zendesk.atlassian.net/browse/PDSC-919

## Screenshots

<img width="1382" height="675" alt="Screenshot 2026-07-10 at 00 17 16" src="https://github.com/user-attachments/assets/d4ea0873-9265-4501-bf08-2f2d0231d690" />

## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->