### PR TITLE
feat: remove filter when requests across brands on

### DIFF
--- a/src/modules/request-list/components/requests-list/RequestsList.test.tsx
+++ b/src/modules/request-list/components/requests-list/RequestsList.test.tsx
@@ -46,7 +46,13 @@ const renderComponent = async (params?: Partial<RequestListParams>) => {
     push,
   });
 
-  render(<RequestsList locale="en-us" customStatusesEnabled={false} />);
+  render(
+    <RequestsList
+      locale="en-us"
+      customStatusesEnabled={false}
+      viewRequestsAcrossBrandsEnabled={false}
+    />
+  );
 
   // This is needed because of a “bug” with the Jest fake timers
   // See: https://github.com/facebook/jest/issues/10221
@@ -94,6 +100,27 @@ describe("Rendering", () => {
     expect(screen.getAllByText("Mar 3, 2019")[0]).toBeInTheDocument();
     expect(screen.getAllByText("Jun 3, 2020")[0]).toBeInTheDocument();
     expect(screen.getAllByText("Open")[0]).toBeInTheDocument();
+  }, 10000);
+
+  test("renders default columns when ticketFields is empty", async () => {
+    (useTicketFields as jest.Mock).mockReturnValue({
+      ticketFields: [],
+    });
+
+    await renderComponent();
+
+    expect(screen.getByRole("button", { name: /id/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /created date/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /updated date/i })
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /status/i })).toBeInTheDocument();
+
+    expect(
+      screen.getByRole("link", { name: "My request" })
+    ).toBeInTheDocument();
   }, 10000);
 
   test("applies a default sort of updated at and descending", async () => {

--- a/src/modules/request-list/components/requests-list/RequestsList.tsx
+++ b/src/modules/request-list/components/requests-list/RequestsList.tsx
@@ -28,11 +28,13 @@ import { useShowManyUsers } from "../../hooks/useShowManyUsers";
 export interface RequestsListProps {
   locale: string;
   customStatusesEnabled: boolean;
+  viewRequestsAcrossBrandsEnabled: boolean;
 }
 
 export function RequestsList({
   locale,
   customStatusesEnabled,
+  viewRequestsAcrossBrandsEnabled,
 }: RequestsListProps): JSX.Element {
   const { t } = useTranslation();
 
@@ -67,7 +69,7 @@ export function RequestsList({
     ticketFields,
     isLoading: isLoadingTicketFields,
     error: ticketFieldsError,
-  } = useTicketFields(locale);
+  } = useTicketFields(locale, viewRequestsAcrossBrandsEnabled);
 
   const loadingError = requestsError || ticketFieldsError || userError;
 

--- a/src/modules/request-list/components/requests-table/RequestsTable.tsx
+++ b/src/modules/request-list/components/requests-table/RequestsTable.tsx
@@ -88,8 +88,11 @@ export function RequestsTable({
   const SELECTABLE_COLUMNS = [...DEFAULT_DESKTOP_COLUMNS, "requester"];
 
   const requestAttributes: RequestAttribute[] = useMemo(() => {
-    if (ticketFields.length === 0) {
-      return [];
+    if (!ticketFields || ticketFields.length === 0) {
+      return DEFAULT_DESKTOP_COLUMNS.map((identifier) => {
+        const label = requestAttributesLabels[identifier] ?? identifier;
+        return { identifier, label };
+      });
     }
 
     return [

--- a/src/modules/request-list/hooks/useTicketFields.test.ts
+++ b/src/modules/request-list/hooks/useTicketFields.test.ts
@@ -46,7 +46,9 @@ test("fetches all ticket fields via ticket_fields api call and returns the activ
       },
     ]);
 
-  const { result, waitForNextUpdate } = renderHook(() => useTicketFields("dk"));
+  const { result, waitForNextUpdate } = renderHook(() =>
+    useTicketFields("dk", false)
+  );
 
   await waitForNextUpdate();
 
@@ -63,7 +65,9 @@ test("fetches all ticket fields via ticket_fields api call and returns the activ
 test("handles exceptions", async () => {
   fetchAllCursorPages.mockRejectedValueOnce(new Error("Network error"));
 
-  const { result, waitForNextUpdate } = renderHook(() => useTicketFields("dk"));
+  const { result, waitForNextUpdate } = renderHook(() =>
+    useTicketFields("dk", false)
+  );
 
   await waitForNextUpdate();
 
@@ -93,7 +97,9 @@ test("filters out inactive subject field", async () => {
       },
     ]);
 
-  const { result, waitForNextUpdate } = renderHook(() => useTicketFields("dk"));
+  const { result, waitForNextUpdate } = renderHook(() =>
+    useTicketFields("dk", false)
+  );
 
   await waitForNextUpdate();
 
@@ -123,12 +129,32 @@ test("only returns ticket fields present in active ticket forms", async () => {
       { id: 1, active: true, ticket_field_ids: [10, 40] },
     ]);
 
-  const { result, waitForNextUpdate } = renderHook(() => useTicketFields("dk"));
+  const { result, waitForNextUpdate } = renderHook(() =>
+    useTicketFields("dk", false)
+  );
 
   await waitForNextUpdate();
 
   expect(result.current).toEqual({
     ticketFields: [activeTicketField, activeCustomField40],
+    error: undefined,
+    isLoading: false,
+  });
+});
+
+test("when viewRequestsAcrossBrandsEnabled=true, returns all active fields when ticket forms is empty", async () => {
+  fetchAllCursorPages
+    .mockResolvedValueOnce([activeTicketField, inactiveTicketField])
+    .mockResolvedValueOnce([]);
+
+  const { result, waitForNextUpdate } = renderHook(() =>
+    useTicketFields("dk", true)
+  );
+
+  await waitForNextUpdate();
+
+  expect(result.current).toEqual({
+    ticketFields: [activeTicketField],
     error: undefined,
     isLoading: false,
   });

--- a/src/modules/request-list/hooks/useTicketFields.ts
+++ b/src/modules/request-list/hooks/useTicketFields.ts
@@ -37,28 +37,42 @@ async function listTicketForms(
   return await response.json();
 }
 
-export function useTicketFields(locale: string): UseTicketFields {
+export function useTicketFields(
+  locale: string,
+  viewRequestsAcrossBrandsEnabled: boolean
+): UseTicketFields {
   const [ticketFields, setTicketFields] = useState<TicketField[]>([]);
   const [error, setError] = useState<Error | undefined>();
   const [isLoading, setIsLoading] = useState(true);
 
   async function fetchTicketFields() {
     try {
-      const [ticketFields, ticketForms] = await Promise.all([
-        fetchAllCursorPages(() => listTicketFields(locale), "ticket_fields"),
-        fetchAllCursorPages(() => listTicketForms(locale), "ticket_forms"),
-      ]);
+      if (viewRequestsAcrossBrandsEnabled) {
+        const ticketFields = await fetchAllCursorPages(
+          () => listTicketFields(locale),
+          "ticket_fields"
+        );
 
-      const activeTicketFieldIds = new Set<number>(
-        ticketForms.flatMap((ticketForm) => ticketForm.ticket_field_ids ?? [])
-      );
+        setTicketFields(
+          ticketFields.filter((ticketField) => ticketField.active)
+        );
+      } else {
+        const [ticketFields, ticketForms] = await Promise.all([
+          fetchAllCursorPages(() => listTicketFields(locale), "ticket_fields"),
+          fetchAllCursorPages(() => listTicketForms(locale), "ticket_forms"),
+        ]);
 
-      setTicketFields(
-        ticketFields.filter(
-          (ticketField) =>
-            ticketField.active && activeTicketFieldIds.has(ticketField.id)
-        )
-      );
+        const activeTicketFieldIds = new Set<number>(
+          ticketForms.flatMap((ticketForm) => ticketForm.ticket_field_ids ?? [])
+        );
+
+        setTicketFields(
+          ticketFields.filter(
+            (ticketField) =>
+              ticketField.active && activeTicketFieldIds.has(ticketField.id)
+          )
+        );
+      }
 
       setIsLoading(false);
     } catch (error) {

--- a/src/modules/request-list/renderRequestList.tsx
+++ b/src/modules/request-list/renderRequestList.tsx
@@ -12,8 +12,8 @@ export async function renderRequestList(
   props: RequestsListProps,
   container: Element
 ): Promise<void> {
-  const { locale } = props;
-  const { customStatusesEnabled } = props;
+  const { locale, customStatusesEnabled, viewRequestsAcrossBrandsEnabled } =
+    props;
 
   initI18next(locale);
 
@@ -30,6 +30,7 @@ export async function renderRequestList(
         <RequestsList
           locale={locale}
           customStatusesEnabled={customStatusesEnabled}
+          viewRequestsAcrossBrandsEnabled={viewRequestsAcrossBrandsEnabled}
         />
       </ErrorBoundary>
     </ThemeProviders>,

--- a/templates/requests_page.hbs
+++ b/templates/requests_page.hbs
@@ -13,9 +13,11 @@
   const container = document.getElementById("main-content"); 
   const settings = {{json settings}}; 
 
+
   const props = {   
     locale: {{json help_center.base_locale}},
-    customStatusesEnabled: {{json help_center.custom_statuses_enabled}}
+    customStatusesEnabled: {{json help_center.custom_statuses_enabled}},
+    viewRequestsAcrossBrandsEnabled: {{json help_center.view_requests_across_brands_enabled}},
   }; 
   
   renderRequestList(settings, props, container);


### PR DESCRIPTION
## Description
- ensure custom objects are not filtered per brand when viewing requests for all the brands

- also add default columns when the response for ticket forms is empty, to ensure we always show
the columns present in the default form



## Screenshots

with view requests across brands on:
<img width="1199" height="1014" alt="image" src="https://github.com/user-attachments/assets/5e13f02b-1e2b-4658-81ed-0259473997b4" />


with view requests across brands off:

<img width="1156" height="1013" alt="image" src="https://github.com/user-attachments/assets/5e5d69de-bf79-491a-b295-a2590b03bd04" />


## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->