### PR TITLE
fix(service-catalog): prevent stored XSS across storefront flows

### DIFF
--- a/src/modules/service-catalog/components/service-catalog-item/CollapsibleDescription.spec.tsx
+++ b/src/modules/service-catalog/components/service-catalog-item/CollapsibleDescription.spec.tsx
@@ -1,0 +1,57 @@
+import { render } from "../../../test/render";
+import { screen } from "@testing-library/react";
+import { CollapsibleDescription } from "./CollapsibleDescription";
+
+describe("CollapsibleDescription", () => {
+  const defaultProps = {
+    title: "Order a new laptop",
+    description: "<p>Request a brand new laptop.</p>",
+    thumbnailUrl: "",
+  };
+
+  it("renders the title", () => {
+    render(<CollapsibleDescription {...defaultProps} />);
+
+    expect(screen.getByText("Order a new laptop")).toBeInTheDocument();
+  });
+
+  it("renders safe description markup", () => {
+    render(<CollapsibleDescription {...defaultProps} />);
+
+    expect(screen.getByText("Request a brand new laptop.")).toBeInTheDocument();
+    expect(
+      document.querySelector(".service-catalog-description")
+    ).toBeInTheDocument();
+  });
+
+  it("does not execute XSS payloads in the description", () => {
+    const onError = jest.fn();
+    (window as unknown as { __xss?: () => void }).__xss = onError;
+
+    render(
+      <CollapsibleDescription
+        {...defaultProps}
+        description={'<img src=x onerror="window.__xss()">Safe content'}
+      />
+    );
+
+    expect(onError).not.toHaveBeenCalled();
+    expect(document.querySelector("img[onerror]")).toBeNull();
+    expect(screen.getByText("Safe content")).toBeInTheDocument();
+
+    delete (window as unknown as { __xss?: () => void }).__xss;
+  });
+
+  it("does not render the description container when the sanitized description is empty", () => {
+    render(
+      <CollapsibleDescription
+        {...defaultProps}
+        description={"<script>alert(1)</script>"}
+      />
+    );
+
+    expect(
+      document.querySelector(".service-catalog-description")
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/modules/service-catalog/components/service-catalog-item/CollapsibleDescription.tsx
+++ b/src/modules/service-catalog/components/service-catalog-item/CollapsibleDescription.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useRef } from "react";
+import { useEffect, useMemo, useState, useRef } from "react";
 import styled from "styled-components";
 import { Button } from "@zendeskgarden/react-buttons";
 import ChevronUp from "@zendeskgarden/svg-icons/src/16/chevron-up-fill.svg";
@@ -7,6 +7,7 @@ import { useTranslation } from "react-i18next";
 import { getColor } from "@zendeskgarden/react-theming";
 import { XXXL } from "@zendeskgarden/react-typography";
 import { ItemThumbnail } from "../item-thumbnail/ItemThumbnail";
+import { sanitizeHtml } from "../../utils/sanitize";
 
 const DescriptionWrapper = styled.div`
   border-bottom: ${(props) => props.theme.borders.sm}
@@ -72,6 +73,11 @@ export const CollapsibleDescription = ({
   const { t } = useTranslation();
   const contentRef = useRef<HTMLDivElement>(null);
 
+  const sanitizedDescription = useMemo(
+    () => sanitizeHtml(description ?? ""),
+    [description]
+  );
+
   useEffect(() => {
     const el = contentRef.current;
     if (el) {
@@ -86,7 +92,7 @@ export const CollapsibleDescription = ({
       };
       requestAnimationFrame(checkClamped);
     }
-  }, [description]);
+  }, [sanitizedDescription]);
 
   const toggleDescription = () => {
     setIsCollapsed(!isCollapsed);
@@ -98,12 +104,12 @@ export const CollapsibleDescription = ({
         <ItemThumbnail size="large" url={thumbnailUrl} />
         <ItemTitle tag="h1">{title}</ItemTitle>
       </HeaderContainer>
-      {description && (
+      {sanitizedDescription && (
         <CollapsibleText
           ref={contentRef}
           className="service-catalog-description"
           isCollapsed={isCollapsed}
-          dangerouslySetInnerHTML={{ __html: description }}
+          dangerouslySetInnerHTML={{ __html: sanitizedDescription }}
         ></CollapsibleText>
       )}
       {isClamped && (

--- a/src/modules/service-catalog/components/service-catalog-item/ServiceCatalogItem.spec.tsx
+++ b/src/modules/service-catalog/components/service-catalog-item/ServiceCatalogItem.spec.tsx
@@ -575,7 +575,7 @@ describe("ServiceCatalogItem", () => {
       });
 
       const callArgs = mockSubmitServiceItemRequest.mock.calls[0]!;
-      // requesterId is the 8th positional arg, onBehalfNoteHtml the 9th.
+      // requesterId is the 8th positional arg, onBehalfNote the 9th.
       expect(callArgs[7]).toBeNull();
       expect(callArgs[8]).toBeNull();
     });
@@ -595,8 +595,10 @@ describe("ServiceCatalogItem", () => {
 
       const callArgs = mockSubmitServiceItemRequest.mock.calls[0]!;
       expect(callArgs[7]).toBe(789);
-      expect(callArgs[8]).toContain("Submitter: {{name}}");
-      expect(callArgs[8]).toContain("Requester: {{name}}");
+      expect(callArgs[8]).toEqual({
+        submitterLabel: expect.stringContaining("Submitter: {{name}}"),
+        requesterLabel: expect.stringContaining("Requester: {{name}}"),
+      });
     });
   });
 });

--- a/src/modules/service-catalog/components/service-catalog-item/ServiceCatalogItem.tsx
+++ b/src/modules/service-catalog/components/service-catalog-item/ServiceCatalogItem.tsx
@@ -371,17 +371,20 @@ export function ServiceCatalogItem({
         selectedUser != null && Number(selectedUser.id) !== userId;
       const requesterId = isRequestingOnBehalf ? Number(selectedUser.id) : null;
 
-      const onBehalfNoteHtml =
+      const onBehalfNote =
         isRequestingOnBehalf && selectedUser
-          ? `<p style="margin:0;padding:0">${t(
-              "service-catalog.item.submitter-label",
-              "Submitter: {{name}}",
-              { name: userName }
-            )}</p><p style="margin:0;padding:0">${t(
-              "service-catalog.item.requester-label",
-              "Requester: {{name}}",
-              { name: selectedUser.name }
-            )}</p>`
+          ? {
+              submitterLabel: t(
+                "service-catalog.item.submitter-label",
+                "Submitter: {{name}}",
+                { name: userName }
+              ),
+              requesterLabel: t(
+                "service-catalog.item.requester-label",
+                "Requester: {{name}}",
+                { name: selectedUser.name }
+              ),
+            }
           : null;
 
       const response = await submitServiceItemRequest(
@@ -393,7 +396,7 @@ export function ServiceCatalogItem({
         categoryLookupField,
         selectedCategoryId,
         requesterId,
-        onBehalfNoteHtml
+        onBehalfNote
       );
 
       if (response?.ok) {

--- a/src/modules/service-catalog/components/service-catalog-item/submitServiceItemRequest.spec.tsx
+++ b/src/modules/service-catalog/components/service-catalog-item/submitServiceItemRequest.spec.tsx
@@ -101,13 +101,68 @@ describe("submitServiceItemRequest", () => {
     );
 
     const request = getSubmittedRequest(fetchMock);
+    const parsedDocument = new DOMParser().parseFromString(
+      request.comment.html_body,
+      "text/html"
+    );
+    const link = parsedDocument.querySelector("a");
+
     expect(request.item_id).toBe(mockItem.id);
     expect(request.subject).toBe(mockItem.name);
     expect(request.comment.uploads).toEqual(["token-1"]);
+    expect(link?.getAttribute("href")).toBe(
+      `${window.location.origin}${helpCenterPath}/services/${mockItem.id}`
+    );
+    expect(link?.getAttribute("target")).toBe("_blank");
+    expect(link?.getAttribute("rel")).toBe("noopener noreferrer");
+    expect(link?.getAttribute("style")).toBe("text-decoration: underline");
+    expect(link?.textContent).toBe(mockItem.name);
+    expect(parsedDocument.querySelector("p")).toBeNull();
     expect(request.custom_fields).toEqual([
       { id: 1, value: "value-1" },
       { id: associatedLookupField.id, value: mockItem.id },
     ]);
+  });
+
+  it("encodes all user-controlled comment values as text", async () => {
+    const fetchMock = mockFetch();
+    const unsafeName = '<img src=x onerror="alert(1)"> & Service';
+    const unsafeSubmitterLabel =
+      'Submitter: <img src=x onerror="alert(2)"> Agent';
+    const unsafeRequesterLabel =
+      "Requester: <script>alert(3)</script> Employee";
+
+    await submitServiceItemRequest(
+      { ...mockItem, name: unsafeName },
+      [],
+      associatedLookupField,
+      attachments,
+      helpCenterPath,
+      null,
+      null,
+      null,
+      {
+        submitterLabel: unsafeSubmitterLabel,
+        requesterLabel: unsafeRequesterLabel,
+      }
+    );
+
+    const request = getSubmittedRequest(fetchMock);
+    const htmlBody = request.comment.html_body;
+    const parsedDocument = new DOMParser().parseFromString(
+      htmlBody,
+      "text/html"
+    );
+    const link = parsedDocument.querySelector("a");
+    const paragraphs = parsedDocument.querySelectorAll("p");
+
+    expect(request.subject).toBe(unsafeName);
+    expect(link?.textContent).toBe(unsafeName);
+    expect(link?.children).toHaveLength(0);
+    expect(paragraphs[0]?.textContent).toBe(unsafeSubmitterLabel);
+    expect(paragraphs[0]?.children).toHaveLength(0);
+    expect(paragraphs[1]?.textContent).toBe(unsafeRequesterLabel);
+    expect(paragraphs[1]?.children).toHaveLength(0);
   });
 
   it("does not send requester_id or collaborators for a self request", async () => {
@@ -162,15 +217,26 @@ describe("submitServiceItemRequest", () => {
       null,
       null,
       beneficiaryId,
-      "<p>Submitter: Agent</p><p>User: Beneficiary</p>"
+      {
+        submitterLabel: "Submitter: Agent",
+        requesterLabel: "Requester: Beneficiary",
+      }
     );
 
     const request = getSubmittedRequest(fetchMock);
+    const parsedDocument = new DOMParser().parseFromString(
+      request.comment.html_body,
+      "text/html"
+    );
+    const paragraphs = parsedDocument.querySelectorAll("p");
+
     expect(request.requester_id).toBe(beneficiaryId);
     expect(request.collaborators).toEqual([SUBMITTER_ID]);
-    expect(request.comment.html_body).toContain(
-      "<p>Submitter: Agent</p><p>User: Beneficiary</p>"
-    );
+    expect(paragraphs).toHaveLength(2);
+    expect(paragraphs[0]?.textContent).toBe("Submitter: Agent");
+    expect(paragraphs[0]?.getAttribute("style")).toBe("margin:0;padding:0");
+    expect(paragraphs[1]?.textContent).toBe("Requester: Beneficiary");
+    expect(paragraphs[1]?.getAttribute("style")).toBe("margin:0;padding:0");
   });
 
   it("appends the category lookup field when a category is provided", async () => {

--- a/src/modules/service-catalog/components/service-catalog-item/submitServiceItemRequest.tsx
+++ b/src/modules/service-catalog/components/service-catalog-item/submitServiceItemRequest.tsx
@@ -2,6 +2,11 @@ import type { TicketFieldObject } from "../../../ticket-fields/data-types/Ticket
 import type { ServiceCatalogItem } from "../../data-types/ServiceCatalogItem";
 import type { Attachment } from "../../../ticket-fields/data-types/AttachmentsField";
 
+interface OnBehalfNote {
+  submitterLabel: string;
+  requesterLabel: string;
+}
+
 const getCurrentUser = async () => {
   try {
     const currentUserRequest = await fetch("/api/v2/users/me.json");
@@ -15,6 +20,36 @@ const getCurrentUser = async () => {
   }
 };
 
+const buildCommentHtml = (
+  serviceCatalogItem: ServiceCatalogItem,
+  helpCenterPath: string,
+  onBehalfNote?: OnBehalfNote | null
+) => {
+  const link = document.createElement("a");
+  link.setAttribute(
+    "href",
+    `${window.location.origin}${helpCenterPath}/services/${serviceCatalogItem.id}`
+  );
+  link.setAttribute("style", "text-decoration: underline");
+  link.setAttribute("target", "_blank");
+  link.setAttribute("rel", "noopener noreferrer");
+  link.textContent = serviceCatalogItem.name;
+
+  if (!onBehalfNote) {
+    return link.outerHTML;
+  }
+
+  const submitter = document.createElement("p");
+  submitter.setAttribute("style", "margin:0;padding:0");
+  submitter.textContent = onBehalfNote.submitterLabel;
+
+  const requester = document.createElement("p");
+  requester.setAttribute("style", "margin:0;padding:0");
+  requester.textContent = onBehalfNote.requesterLabel;
+
+  return `${link.outerHTML}${submitter.outerHTML}${requester.outerHTML}`;
+};
+
 export async function submitServiceItemRequest(
   serviceCatalogItem: ServiceCatalogItem,
   requestFields: TicketFieldObject[],
@@ -24,7 +59,7 @@ export async function submitServiceItemRequest(
   categoryLookupField?: TicketFieldObject | null,
   categoryId?: string | null,
   requesterId?: number | null,
-  onBehalfNoteHtml?: string | null
+  onBehalfNote?: OnBehalfNote | null
 ) {
   try {
     const currentUser = await getCurrentUser();
@@ -61,13 +96,11 @@ export async function submitServiceItemRequest(
           item_id: serviceCatalogItem.id,
           subject: `${serviceCatalogItem.name}`,
           comment: {
-            html_body: `<a href="${
-              window.location.origin
-            }${helpCenterPath}/services/${
-              serviceCatalogItem.id
-            }" style="text-decoration: underline" target="_blank" rel="noopener noreferrer">${
-              serviceCatalogItem.name
-            }</a>${onBehalfNoteHtml ?? ""}`,
+            html_body: buildCommentHtml(
+              serviceCatalogItem,
+              helpCenterPath,
+              onBehalfNote
+            ),
             uploads: uploadTokens,
           },
           custom_fields: [...customFields, ...lookupFields],

--- a/src/modules/service-catalog/components/service-catalog-list/ServiceCatalogListItem.spec.tsx
+++ b/src/modules/service-catalog/components/service-catalog-list/ServiceCatalogListItem.spec.tsx
@@ -81,6 +81,30 @@ describe("ServiceCatalogListItem", () => {
       );
     });
 
+    it("should render name and description as text without executing HTML payloads", () => {
+      const onError = jest.fn();
+      (window as unknown as { __xss?: () => void }).__xss = onError;
+
+      render(
+        <ServiceCatalogListItem
+          serviceItem={{
+            ...mockServiceItem,
+            name: '<img src=x onerror="window.__xss()">Order a laptop',
+            description:
+              '<img src=x onerror="window.__xss()">Malicious description',
+          }}
+          helpCenterPath={mockHelpCenterPath}
+        />
+      );
+
+      expect(onError).not.toHaveBeenCalled();
+      expect(screen.getByText("Order a laptop")).toBeInTheDocument();
+      expect(screen.getByText("Malicious description")).toBeInTheDocument();
+      expect(document.querySelector("img[onerror]")).toBeNull();
+
+      delete (window as unknown as { __xss?: () => void }).__xss;
+    });
+
     it("should use primaryHue as card border color on hover", async () => {
       render(
         <ServiceCatalogListItem

--- a/src/modules/service-catalog/components/service-catalog-list/ServiceCatalogListItem.tsx
+++ b/src/modules/service-catalog/components/service-catalog-list/ServiceCatalogListItem.tsx
@@ -3,6 +3,7 @@ import styled from "styled-components";
 import { getColor } from "@zendeskgarden/react-theming";
 import { ItemThumbnail } from "../item-thumbnail/ItemThumbnail";
 import { useMemo } from "react";
+import { htmlToText } from "../../utils/sanitize";
 
 const ItemContainer = styled.div`
   height: 100%;
@@ -69,19 +70,13 @@ const ServiceCatalogListItem = ({
     ? `${helpCenterPath}/services/${serviceItem.id}?category_id=${selectedCategoryId}`
     : `${helpCenterPath}/services/${serviceItem.id}`;
 
-  const decodeToText = (htmlString: string) => {
-    const tempDiv = document.createElement("div");
-    tempDiv.innerHTML = htmlString;
-    return tempDiv.textContent || tempDiv.innerText || "";
-  };
-
   const titleText = useMemo(
-    () => decodeToText(serviceItem.name || ""),
+    () => htmlToText(serviceItem.name || ""),
     [serviceItem.name]
   );
 
   const cleanText = useMemo(
-    () => decodeToText(serviceItem.description || ""),
+    () => htmlToText(serviceItem.description || ""),
     [serviceItem.description]
   );
 

--- a/src/modules/service-catalog/hooks/useItemFormFields.spec.ts
+++ b/src/modules/service-catalog/hooks/useItemFormFields.spec.ts
@@ -543,4 +543,97 @@ describe("useItemFormFields", () => {
       expect.objectContaining({ id: 2, type: "lookup" })
     );
   });
+
+  it("sanitizes asset option descriptions before exposing request fields", async () => {
+    const itemWithAssetOptions: ServiceCatalogItem = {
+      ...serviceCatalogItem,
+      custom_object_fields: {
+        ...serviceCatalogItem.custom_object_fields,
+        "standard::asset_option": "asset-option-id",
+        "standard::asset_type_option": "asset-type-option-id",
+      },
+    };
+    const assetTypeField = {
+      ...textField,
+      id: 3,
+      type: "lookup",
+      relationship_target_type: "zen:custom_object:standard::itam_asset_type",
+    };
+    const assetField = {
+      ...textField,
+      id: 4,
+      type: "lookup",
+      relationship_target_type: "zen:custom_object:standard::itam_asset",
+    };
+    const formResponse = {
+      ticket_form: {
+        id: 1,
+        ticket_field_ids: [1, 2, 3, 4],
+        active: true,
+      },
+    };
+    const ticketFieldResponse = {
+      ticket_fields: [textField, lookupField, assetTypeField, assetField],
+    };
+
+    (globalThis.fetch as jest.Mock) = jest.fn((url: string) => {
+      const responses: Record<string, unknown> = {
+        "/api/v2/ticket_forms/1": formResponse,
+        "/api/v2/ticket_fields?locale=en-us": ticketFieldResponse,
+        "/api/v2/custom_objects/standard::service_catalog_asset_type_option/records/asset-type-option-id":
+          {
+            custom_object_record: {
+              name: "Asset type",
+              custom_object_fields: {
+                "standard::asset_type_ids": "type-1",
+                "standard::description":
+                  '<strong>Choose a type</strong><img src=x onerror="alert(1)">',
+              },
+            },
+          },
+        "/api/v2/custom_objects/standard::service_catalog_asset_option/records/asset-option-id":
+          {
+            custom_object_record: {
+              name: "Asset",
+              custom_object_fields: {
+                "standard::asset_filter_ids": "asset-1",
+                "standard::description":
+                  '<a href="javascript:alert(2)">Choose an asset</a><iframe src="https://example.com"></iframe>',
+              },
+            },
+          },
+      };
+
+      return Promise.resolve({
+        json: () => Promise.resolve(responses[url]),
+        status: 200,
+        ok: true,
+      });
+    });
+
+    const { result, waitFor } = renderHook(() =>
+      useItemFormFields(itemWithAssetOptions, baseLocale)
+    );
+
+    await waitFor(() => {
+      expect(result.current.requestFields).toHaveLength(3);
+    });
+
+    const renderedAssetTypeField = result.current.requestFields.find(
+      (field) => field.id === assetTypeField.id
+    );
+    const renderedAssetField = result.current.requestFields.find(
+      (field) => field.id === assetField.id
+    );
+
+    expect(renderedAssetTypeField?.description).toContain(
+      "<strong>Choose a type</strong>"
+    );
+    expect(renderedAssetTypeField?.description).not.toContain("onerror");
+    expect(renderedAssetTypeField?.description).not.toContain("alert");
+    expect(renderedAssetField?.description).toContain("Choose an asset");
+    expect(renderedAssetField?.description).not.toContain("javascript:");
+    expect(renderedAssetField?.description).not.toContain("<iframe");
+    expect(renderedAssetField?.description).not.toContain("alert");
+  });
 });

--- a/src/modules/service-catalog/hooks/useItemFormFields.tsx
+++ b/src/modules/service-catalog/hooks/useItemFormFields.tsx
@@ -12,6 +12,7 @@ import type {
   AssetOptionData,
   AssetConfig,
 } from "../data-types/Assets";
+import { sanitizeFieldDescription } from "../utils/sanitize";
 
 const ASSET_TYPE_KEY = "zen:custom_object:standard::itam_asset_type";
 const ASSET_KEY = "zen:custom_object:standard::itam_asset";
@@ -80,7 +81,9 @@ const formatField = (field: TicketField): TicketFieldObject => {
     relationship_filter,
   } = field;
 
-  const sanitizedDescription = linkifyStr(description);
+  const sanitizedDescription = sanitizeFieldDescription(
+    linkifyStr(description)
+  );
 
   return {
     id,
@@ -132,7 +135,9 @@ const enrichFieldsWithAssetConfig = (
       return {
         ...field,
         label: assetConfig.assetTypeLabel || field.label,
-        description: assetConfig.assetTypeDescription || field.description,
+        description: sanitizeFieldDescription(
+          assetConfig.assetTypeDescription || field.description
+        ),
         required: assetConfig.assetTypeIsRequired || field.required,
       };
     }
@@ -140,7 +145,9 @@ const enrichFieldsWithAssetConfig = (
       return {
         ...field,
         label: assetConfig.assetLabel || field.label,
-        description: assetConfig.assetDescription || field.description,
+        description: sanitizeFieldDescription(
+          assetConfig.assetDescription || field.description
+        ),
         required: assetConfig.assetIsRequired || field.required,
       };
     }

--- a/src/modules/service-catalog/utils/sanitize.spec.ts
+++ b/src/modules/service-catalog/utils/sanitize.spec.ts
@@ -59,12 +59,14 @@ describe("sanitize utils", () => {
 
     it("preserves safe formatting markup", () => {
       const input =
-        '<p><strong>Bold</strong> and <a href="https://example.com">link</a></p>';
+        '<p><strong>Bold</strong> and <a href="https://example.com" target="_blank" rel="noopener noreferrer">link</a></p>';
 
       const result = sanitizeHtml(input);
 
       expect(result).toContain("<strong>Bold</strong>");
       expect(result).toContain('href="https://example.com"');
+      expect(result).toContain('target="_blank"');
+      expect(result).toContain('rel="noopener noreferrer"');
     });
 
     it("preserves video iframes", () => {
@@ -96,11 +98,13 @@ describe("sanitize utils", () => {
   describe("sanitizeFieldDescription", () => {
     it("preserves safe links and formatting", () => {
       const result = sanitizeFieldDescription(
-        '<strong>Choose carefully</strong> or visit <a href="https://example.com">docs</a>'
+        '<strong>Choose carefully</strong> or visit <a href="https://example.com" target="_blank" rel="noopener noreferrer">docs</a>'
       );
 
       expect(result).toContain("<strong>Choose carefully</strong>");
       expect(result).toContain('href="https://example.com"');
+      expect(result).toContain('target="_blank"');
+      expect(result).toContain('rel="noopener noreferrer"');
     });
 
     it("removes executable content and iframes", () => {

--- a/src/modules/service-catalog/utils/sanitize.spec.ts
+++ b/src/modules/service-catalog/utils/sanitize.spec.ts
@@ -1,4 +1,4 @@
-import { htmlToText, sanitizeHtml } from "./sanitize";
+import { htmlToText, sanitizeFieldDescription, sanitizeHtml } from "./sanitize";
 
 describe("sanitize utils", () => {
   describe("htmlToText", () => {
@@ -90,6 +90,28 @@ describe("sanitize utils", () => {
       const result = sanitizeHtml('<a href="javascript:alert(1)">x</a>');
 
       expect(result).not.toContain("javascript:");
+    });
+  });
+
+  describe("sanitizeFieldDescription", () => {
+    it("preserves safe links and formatting", () => {
+      const result = sanitizeFieldDescription(
+        '<strong>Choose carefully</strong> or visit <a href="https://example.com">docs</a>'
+      );
+
+      expect(result).toContain("<strong>Choose carefully</strong>");
+      expect(result).toContain('href="https://example.com"');
+    });
+
+    it("removes executable content and iframes", () => {
+      const result = sanitizeFieldDescription(
+        '<img src="x" onerror="alert(1)"><script>alert(2)</script><iframe src="https://example.com"></iframe>'
+      );
+
+      expect(result).not.toContain("onerror");
+      expect(result).not.toContain("<script");
+      expect(result).not.toContain("<iframe");
+      expect(result).not.toContain("alert");
     });
   });
 });

--- a/src/modules/service-catalog/utils/sanitize.spec.ts
+++ b/src/modules/service-catalog/utils/sanitize.spec.ts
@@ -41,6 +41,19 @@ describe("sanitize utils", () => {
       expect(spy).not.toHaveBeenCalled();
       delete (window as unknown as { __xss?: () => void }).__xss;
     });
+
+    it("does not execute SVG event-handler payloads", () => {
+      const onload = jest.fn();
+      (window as unknown as { __xss?: () => void }).__xss = onload;
+
+      const result = htmlToText(
+        '<svg onload="window.__xss()">safe svg text</svg>'
+      );
+
+      expect(onload).not.toHaveBeenCalled();
+      expect(result).toBe("safe svg text");
+      delete (window as unknown as { __xss?: () => void }).__xss;
+    });
   });
 
   describe("sanitizeHtml", () => {
@@ -55,6 +68,16 @@ describe("sanitize utils", () => {
 
       expect(result).toContain("<img");
       expect(result).not.toContain("onerror");
+    });
+
+    it("removes SVG event-handler attributes", () => {
+      const result = sanitizeHtml(
+        '<svg onload="alert(1)"><circle cx="10" cy="10" r="5"></circle></svg>'
+      );
+
+      expect(result).toContain("<svg");
+      expect(result).not.toContain("onload");
+      expect(result).not.toContain("alert(1)");
     });
 
     it("preserves safe formatting markup", () => {

--- a/src/modules/service-catalog/utils/sanitize.spec.ts
+++ b/src/modules/service-catalog/utils/sanitize.spec.ts
@@ -1,0 +1,95 @@
+import { htmlToText, sanitizeHtml } from "./sanitize";
+
+describe("sanitize utils", () => {
+  describe("htmlToText", () => {
+    it("returns an empty string for empty input", () => {
+      expect(htmlToText("")).toBe("");
+    });
+
+    it("decodes HTML entities to plain text", () => {
+      expect(
+        htmlToText("This is a keyboard &quot;from&quot; Atl Nacional")
+      ).toBe('This is a keyboard "from" Atl Nacional');
+    });
+
+    it("strips HTML tags and keeps the text content", () => {
+      expect(htmlToText("<strong>Order</strong> a new <em>laptop</em>")).toBe(
+        "Order a new laptop"
+      );
+    });
+
+    it("does not execute event-handler payloads and returns no text for them", () => {
+      const onerror = jest.fn();
+      (window as unknown as { __xss?: () => void }).__xss = onerror;
+
+      const result = htmlToText(
+        '<img src=x onerror="window.__xss()">safe text'
+      );
+
+      expect(onerror).not.toHaveBeenCalled();
+      expect(result).toBe("safe text");
+
+      delete (window as unknown as { __xss?: () => void }).__xss;
+    });
+
+    it("does not execute script payloads", () => {
+      const spy = jest.fn();
+      (window as unknown as { __xss?: () => void }).__xss = spy;
+
+      htmlToText("<script>window.__xss()</script>");
+
+      expect(spy).not.toHaveBeenCalled();
+      delete (window as unknown as { __xss?: () => void }).__xss;
+    });
+  });
+
+  describe("sanitizeHtml", () => {
+    it("removes script tags", () => {
+      expect(sanitizeHtml("<p>hi</p><script>alert(1)</script>")).toBe(
+        "<p>hi</p>"
+      );
+    });
+
+    it("removes event-handler attributes but keeps the element", () => {
+      const result = sanitizeHtml('<img src="x" onerror="alert(1)">');
+
+      expect(result).toContain("<img");
+      expect(result).not.toContain("onerror");
+    });
+
+    it("preserves safe formatting markup", () => {
+      const input =
+        '<p><strong>Bold</strong> and <a href="https://example.com">link</a></p>';
+
+      const result = sanitizeHtml(input);
+
+      expect(result).toContain("<strong>Bold</strong>");
+      expect(result).toContain('href="https://example.com"');
+    });
+
+    it("preserves video iframes", () => {
+      const input =
+        '<iframe src="https://www.youtube.com/embed/abc123" allowfullscreen></iframe>';
+
+      const result = sanitizeHtml(input);
+
+      expect(result).toContain("<iframe");
+      expect(result).toContain('src="https://www.youtube.com/embed/abc123"');
+    });
+
+    it("strips iframe srcdoc payloads", () => {
+      const result = sanitizeHtml(
+        '<iframe srcdoc="<script>alert(1)</script>"></iframe>'
+      );
+
+      expect(result).not.toContain("srcdoc");
+      expect(result).not.toContain("alert(1)");
+    });
+
+    it("removes javascript: urls", () => {
+      const result = sanitizeHtml('<a href="javascript:alert(1)">x</a>');
+
+      expect(result).not.toContain("javascript:");
+    });
+  });
+});

--- a/src/modules/service-catalog/utils/sanitize.ts
+++ b/src/modules/service-catalog/utils/sanitize.ts
@@ -1,0 +1,27 @@
+import DOMPurify from "dompurify";
+
+/**
+ * Sanitizes rich-text HTML for safe rendering via `dangerouslySetInnerHTML`.
+ * `iframe` is kept (descriptions can embed videos) but DOMPurify still blocks
+ * `javascript:`/`data:` sources, `srcdoc` and event-handler attributes.
+ */
+export function sanitizeHtml(html: string): string {
+  return DOMPurify.sanitize(html, {
+    ADD_TAGS: ["iframe"],
+    ADD_ATTR: ["allow", "allowfullscreen", "frameborder", "scrolling", "title"],
+  });
+}
+
+/**
+ * Converts a possibly-HTML string to plain text using an inert `DOMParser`
+ * document, so resources are never fetched and handlers like `onerror` never
+ * fire (unlike assigning to `innerHTML`).
+ */
+export function htmlToText(html: string): string {
+  if (!html) {
+    return "";
+  }
+
+  const doc = new DOMParser().parseFromString(html, "text/html");
+  return doc.body.textContent ?? "";
+}

--- a/src/modules/service-catalog/utils/sanitize.ts
+++ b/src/modules/service-catalog/utils/sanitize.ts
@@ -8,12 +8,21 @@ import DOMPurify from "dompurify";
 export function sanitizeHtml(html: string): string {
   return DOMPurify.sanitize(html, {
     ADD_TAGS: ["iframe"],
-    ADD_ATTR: ["allow", "allowfullscreen", "frameborder", "scrolling", "title"],
+    ADD_ATTR: [
+      "allow",
+      "allowfullscreen",
+      "frameborder",
+      "scrolling",
+      "target",
+      "title",
+    ],
   });
 }
 
 export function sanitizeFieldDescription(html: string): string {
-  return DOMPurify.sanitize(html);
+  return DOMPurify.sanitize(html, {
+    ADD_ATTR: ["target"],
+  });
 }
 
 /**

--- a/src/modules/service-catalog/utils/sanitize.ts
+++ b/src/modules/service-catalog/utils/sanitize.ts
@@ -12,6 +12,10 @@ export function sanitizeHtml(html: string): string {
   });
 }
 
+export function sanitizeFieldDescription(html: string): string {
+  return DOMPurify.sanitize(html);
+}
+
 /**
  * Converts a possibly-HTML string to plain text using an inert `DOMParser`
  * document, so resources are never fetched and handlers like `onerror` never


### PR DESCRIPTION
## Description

Prevent stored XSS across Service Catalog storefront flows by treating all API and user-controlled content as untrusted:

- replace the list card's `innerHTML` decoder with inert `DOMParser` text extraction for item names and descriptions
- sanitize rich item descriptions before rendering with `dangerouslySetInnerHTML`, while preserving supported formatting, video iframes, and safe link attributes
- sanitize ticket-field, Asset, and Asset Type descriptions before they reach shared field components
- build request-comment HTML from DOM nodes and `textContent` so item, submitter, and requester names cannot become executable markup

## Jira

- https://zendesk.atlassian.net/browse/PDSC-943
- https://zendesk.atlassian.net/browse/PDSC-944
- https://zendesk.atlassian.net/browse/PDSC-949

## Test plan

Automated coverage includes:

- `img`/`onerror`, SVG/`onload`, script, unsafe URL, and iframe `srcdoc` payloads
- safe rich-text formatting, video iframe, and `target=\"_blank\"` compatibility
- Asset and Asset Type description sanitization
- safe serialization of item, submitter, and requester names into ticket `html_body`
- full Service Catalog Jest suite

Manual staging validation completed:

- [x] storefront list and detail with combined safe formatting and XSS payloads
- [x] Asset and Asset Type descriptions with safe and malicious markup
- [x] safe links retain `target=\"_blank\"` and `rel=\"noopener noreferrer\"`
- [ ] submit a request with a malicious item name and verify the Agent Workspace comment
- [ ] submit a request on behalf of a test user with a malicious display name

## Screenshots

https://github.com/user-attachments/assets/bfb54b71-c33d-4b40-829f-71046e4787ed

## Checklist

- [x] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [x] :arrow_left: changes do not introduce direction-dependent layout
- [ ] :wheelchair: changes are tested for accessibility and compliant with WCAG 2.1
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings