### PR TITLE
Feat: Requester instead of User in Service Catalog pages

### DIFF
--- a/src/modules/service-catalog/components/change-user-modal/ChangeUserForm.tsx
+++ b/src/modules/service-catalog/components/change-user-modal/ChangeUserForm.tsx
@@ -221,7 +221,10 @@ export const ChangeUserForm: React.FC<ChangeUserFormProps> = ({
   return (
     <>
       <StyledHeader tag="h2">
-        {t("service-catalog.change-user-modal.title", "Change user")}
+        {t(
+          "service-catalog.change-user-modal.requester-title",
+          "Change requester"
+        )}
       </StyledHeader>
 
       <StyledModalBody>
@@ -230,8 +233,8 @@ export const ChangeUserForm: React.FC<ChangeUserFormProps> = ({
             <Field>
               <Field.Label>
                 {t(
-                  "service-catalog.change-user-modal.select-user-label",
-                  "Select user* (required)"
+                  "service-catalog.change-user-modal.select-requester-label",
+                  "Select requester* (required)"
                 )}
               </Field.Label>
               <Combobox
@@ -243,8 +246,8 @@ export const ChangeUserForm: React.FC<ChangeUserFormProps> = ({
                 data-test-id="user-autocomplete-input"
                 isAutocomplete
                 placeholder={t(
-                  "service-catalog.change-user-modal.search-placeholder",
-                  "Search users..."
+                  "service-catalog.change-user-modal.requester-search-placeholder",
+                  "Search requesters..."
                 )}
                 renderValue={() => selectedUser?.name || ""}
                 inputProps={{
@@ -292,8 +295,8 @@ export const ChangeUserForm: React.FC<ChangeUserFormProps> = ({
                   )}
                 >
                   {t(
-                    "service-catalog.change-user-modal.user-required",
-                    "Select a user"
+                    "service-catalog.change-user-modal.requester-required",
+                    "Select a requester"
                   )}
                 </Field.Message>
               )}

--- a/src/modules/service-catalog/components/service-catalog-item/ItemRequestForm.tsx
+++ b/src/modules/service-catalog/components/service-catalog-item/ItemRequestForm.tsx
@@ -384,7 +384,9 @@ export function ItemRequestForm({
           <ButtonWrapper>
             <ButtonContainer>
               <UserNameWrapper>
-                <Span isBold>{t("service-catalog.item.user", "User")}</Span>
+                <Span isBold>
+                  {t("service-catalog.item.requester", "Requester")}
+                </Span>
                 <Span>{displayedUserName}</Span>
               </UserNameWrapper>
               {requestOnBehalfEnabled && (

--- a/src/modules/service-catalog/translations/en-us.yml
+++ b/src/modules/service-catalog/translations/en-us.yml
@@ -222,7 +222,7 @@ parts:
   - translation:
       key: "service-catalog.change-user-modal.requester-title"
       title: "Modal title for changing the requester"
-      screenshot: "https://drive.google.com/file/d/1J9wEdvh_WC0j2aoRbQUA6nEHPFDv2NVd/view?usp=share_link"
+      screenshot: "https://drive.google.com/file/d/1gXqafXjYZ0EVO8_p3yRop53LQajUS2P7/view?usp=sharing"
       value: "Change requester"
   - translation:
       key: "service-catalog.change-user-modal.select-user-label"
@@ -233,7 +233,7 @@ parts:
   - translation:
       key: "service-catalog.change-user-modal.select-requester-label"
       title: "Label for requester selection dropdown in Change Requester modal"
-      screenshot: "https://drive.google.com/file/d/1J9wEdvh_WC0j2aoRbQUA6nEHPFDv2NVd/view?usp=share_link"
+      screenshot: "https://drive.google.com/file/d/1o1omjXbAqzGTvOJvKS9wkGvbOfbKuDbF/view?usp=sharing"
       value: "Select requester* (required)"
   - translation:
       key: "service-catalog.change-user-modal.search-placeholder"
@@ -244,7 +244,7 @@ parts:
   - translation:
       key: "service-catalog.change-user-modal.requester-search-placeholder"
       title: "Placeholder text for requester search input in Change Requester modal"
-      screenshot: "https://drive.google.com/file/d/1J9wEdvh_WC0j2aoRbQUA6nEHPFDv2NVd/view?usp=share_link"
+      screenshot: "https://drive.google.com/file/d/1o1omjXbAqzGTvOJvKS9wkGvbOfbKuDbF/view?usp=sharing"
       value: "Search requesters..."
   - translation:
       key: "service-catalog.change-user-modal.loading-users"
@@ -275,7 +275,7 @@ parts:
   - translation:
       key: "service-catalog.change-user-modal.requester-required"
       title: "Error message when the agent tries to save without selecting a requester"
-      screenshot: "https://drive.google.com/file/d/1NzYBWHmHQZPPia0ud3uLWy41haGPQwUn/view?usp=share_link"
+      screenshot: "https://drive.google.com/file/d/1o1omjXbAqzGTvOJvKS9wkGvbOfbKuDbF/view?usp=sharing"
       value: "Select a requester"
   - translation:
       key: "service-catalog.change-user-modal.cancel"
@@ -341,7 +341,7 @@ parts:
   - translation:
       key: "service-catalog.item.requester"
       title: "Label above the requester's name in the service request form"
-      screenshot: "https://drive.google.com/file/d/1k5um4vxeW-SV1vQlblYJFU4uHzdejvju/view?usp=share_link"
+      screenshot: "https://drive.google.com/file/d/1o1omjXbAqzGTvOJvKS9wkGvbOfbKuDbF/view?usp=sharing"
       value: "Requester"
   - translation:
       key: "service-catalog.item.submitter-label"

--- a/src/modules/service-catalog/translations/en-us.yml
+++ b/src/modules/service-catalog/translations/en-us.yml
@@ -218,16 +218,34 @@ parts:
       title: "Modal title for changing the requester user"
       screenshot: "https://drive.google.com/file/d/1J9wEdvh_WC0j2aoRbQUA6nEHPFDv2NVd/view?usp=share_link"
       value: "Change user"
+      obsolete: "2026-10-10"
+  - translation:
+      key: "service-catalog.change-user-modal.requester-title"
+      title: "Modal title for changing the requester"
+      screenshot: "https://drive.google.com/file/d/1J9wEdvh_WC0j2aoRbQUA6nEHPFDv2NVd/view?usp=share_link"
+      value: "Change requester"
   - translation:
       key: "service-catalog.change-user-modal.select-user-label"
       title: "Label for user selection dropdown in Change User modal"
       screenshot: "https://drive.google.com/file/d/1J9wEdvh_WC0j2aoRbQUA6nEHPFDv2NVd/view?usp=share_link"
       value: "Select user* (required)"
+      obsolete: "2026-10-10"
+  - translation:
+      key: "service-catalog.change-user-modal.select-requester-label"
+      title: "Label for requester selection dropdown in Change Requester modal"
+      screenshot: "https://drive.google.com/file/d/1J9wEdvh_WC0j2aoRbQUA6nEHPFDv2NVd/view?usp=share_link"
+      value: "Select requester* (required)"
   - translation:
       key: "service-catalog.change-user-modal.search-placeholder"
       title: "Placeholder text for user search input in Change User modal"
       screenshot: "https://drive.google.com/file/d/1J9wEdvh_WC0j2aoRbQUA6nEHPFDv2NVd/view?usp=share_link"
       value: "Search users..."
+      obsolete: "2026-10-10"
+  - translation:
+      key: "service-catalog.change-user-modal.requester-search-placeholder"
+      title: "Placeholder text for requester search input in Change Requester modal"
+      screenshot: "https://drive.google.com/file/d/1J9wEdvh_WC0j2aoRbQUA6nEHPFDv2NVd/view?usp=share_link"
+      value: "Search requesters..."
   - translation:
       key: "service-catalog.change-user-modal.loading-users"
       title: "Loading state message while fetching users in Change User modal"
@@ -253,6 +271,12 @@ parts:
       title: "Error message when user tries to save without selecting a user"
       screenshot: "https://drive.google.com/file/d/1NzYBWHmHQZPPia0ud3uLWy41haGPQwUn/view?usp=share_link"
       value: "Select a user"
+      obsolete: "2026-10-10"
+  - translation:
+      key: "service-catalog.change-user-modal.requester-required"
+      title: "Error message when the agent tries to save without selecting a requester"
+      screenshot: "https://drive.google.com/file/d/1NzYBWHmHQZPPia0ud3uLWy41haGPQwUn/view?usp=share_link"
+      value: "Select a requester"
   - translation:
       key: "service-catalog.change-user-modal.cancel"
       title: "Cancel button text in Change User modal"
@@ -313,6 +337,12 @@ parts:
       title: "Label above the requester's name in the service request form"
       screenshot: "https://drive.google.com/file/d/1k5um4vxeW-SV1vQlblYJFU4uHzdejvju/view?usp=share_link"
       value: "User"
+      obsolete: "2026-10-10"
+  - translation:
+      key: "service-catalog.item.requester"
+      title: "Label above the requester's name in the service request form"
+      screenshot: "https://drive.google.com/file/d/1k5um4vxeW-SV1vQlblYJFU4uHzdejvju/view?usp=share_link"
+      value: "Requester"
   - translation:
       key: "service-catalog.item.submitter-label"
       title: "Line in the request comment naming who submitted the request on behalf of another user. {{name}} is the submitter's name."


### PR DESCRIPTION
## Description

<!-- a summary of the changes introduced by this PR and the motivation behind them -->
Updated design for Service Catalog Request page involving Request on Behalf. 
## Screenshots
<img width="447" height="234" alt="image" src="https://github.com/user-attachments/assets/3bcdb163-feac-4dcc-a509-f68eecb32d58" />
<img width="616" height="215" alt="image" src="https://github.com/user-attachments/assets/a9ea2964-d5af-451b-81d7-fc71a2cb1482" />

<!-- (optional) when applicable, please include some screenshots or gifs that illustrate the changes -->

## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->