### PR TITLE
fix: truncate requester name properly

### DIFF
--- a/src/modules/service-catalog/components/service-catalog-item/ItemRequestForm.tsx
+++ b/src/modules/service-catalog/components/service-catalog-item/ItemRequestForm.tsx
@@ -54,6 +54,7 @@ const ButtonWrapper = styled.div`
   border: ${(props) => props.theme.borders.sm}
     ${({ theme }) => getColor({ theme, hue: "grey", shade: 300 })};
   height: fit-content;
+  max-width: 360px;
 
   @media (max-width: ${(props) => props.theme.breakpoints.md}) {
     position: sticky;
@@ -106,6 +107,8 @@ const ButtonSkeleton = styled(Skeleton)`
 const UserNameWrapper = styled.div`
   margin-bottom: 16px;
   display: flex;
+  flex: 1;
+  min-width: 0;
   flex-direction: column;
   gap: ${(props) => props.theme.space.xxs};
 `;
@@ -114,6 +117,12 @@ const ButtonContainer = styled.div`
   display: flex;
   align-items: center;
   justify-content: space-between;
+`;
+
+const RequesterName = styled.span`
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 `;
 
 const isAssetField = (f: TicketFieldObject) =>
@@ -387,7 +396,7 @@ export function ItemRequestForm({
                 <Span isBold>
                   {t("service-catalog.item.requester", "Requester")}
                 </Span>
-                <Span>{displayedUserName}</Span>
+                <RequesterName>{displayedUserName}</RequesterName>
               </UserNameWrapper>
               {requestOnBehalfEnabled && (
                 <>


### PR DESCRIPTION
## Description

This PR limits the requester wrapper width to 360px to match the design and ensure long requester names are truncated with an ellipsis instead of overflowing toward the Change link.

## Before 
<img width="1081" height="722" alt="Screenshot 2026-07-17 at 11 07 06" src="https://github.com/user-attachments/assets/503ca53d-140d-48f1-81c6-30597f250d0f" />

## After 
<img width="1070" height="700" alt="Screenshot 2026-07-17 at 11 06 44" src="https://github.com/user-attachments/assets/9e6ede4c-b331-4935-a43c-a4dd6d2db0d4" />

## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->