### PR TITLE
[PDSC-914] fix: double autocomplete call

### DIFF
--- a/src/modules/service-catalog/components/change-user-modal/ChangeUserForm.tsx
+++ b/src/modules/service-catalog/components/change-user-modal/ChangeUserForm.tsx
@@ -121,7 +121,7 @@ export const ChangeUserForm: React.FC<ChangeUserFormProps> = ({
   };
 
   const handleChange = useCallback<NonNullable<IComboboxProps["onChange"]>>(
-    ({ inputValue, selectionValue }) => {
+    ({ type, inputValue, selectionValue }) => {
       if (selectionValue !== undefined) {
         const selectedOption = options.find((opt) => opt.id === selectionValue);
 
@@ -137,7 +137,8 @@ export const ChangeUserForm: React.FC<ChangeUserFormProps> = ({
         }
       }
 
-      if (inputValue !== undefined) {
+      // Without this guard that would fire a redundant search for the just-selected user.
+      if (type === "input:change" && inputValue !== undefined) {
         setInputValue(inputValue);
         isTyping.current = true; // Mark as typing
 


### PR DESCRIPTION
## Description

This PR fixes a duplicate autocomplete request in the change-requester modal. Selecting a user from the dropdown was firing a second, redundant search for the user just picked.

Gate the search branch on `type === "input:change"`, so only real typing triggers a search — selection no longer does.


## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->