### PR TITLE
feat(service-catalog): support query-string prefill for item forms (P…

### DIFF
--- a/src/modules/service-catalog/constants/index.ts
+++ b/src/modules/service-catalog/constants/index.ts
@@ -14,3 +14,35 @@ export const PREVIEW_MODE_HTML_CLASS = "is-service-catalog-preview";
 // <html> synchronously, before first paint, eliminating the chrome flicker.
 export const PREVIEW_MODE_QUERY_PARAM = "preview";
 export const PREVIEW_MODE_QUERY_PARAM_VALUE = "true";
+
+// Query-string prefill (PDSC-954): /services/123?tf_456=value prefills fields.
+export const PREFILL_FIELD_PREFIX = "tf_";
+
+// URLs longer than this skip prefill entirely (same limit as Help Center).
+export const MAX_PREFILL_URL_LENGTH = 2048;
+
+export const PREFILL_ALLOWED_BOOLEAN_VALUES = ["true", "false"] as const;
+
+// Kept identical to the Help Center prefill whitelist.
+export const PREFILL_ALLOWED_HTML_TAGS = [
+  "pre",
+  "strong",
+  "b",
+  "p",
+  "blockquote",
+  "ul",
+  "ol",
+  "li",
+  "h2",
+  "h3",
+  "h4",
+  "i",
+  "em",
+  "br",
+];
+
+// Fields targetable by name (tf_priority, tf_type) instead of numeric id.
+export const PREFILL_SYSTEM_FIELD_ALIASES: Record<string, string[]> = {
+  priority: ["priority", "basic_priority"],
+  type: ["tickettype"],
+};

--- a/src/modules/service-catalog/hooks/useItemFormFields.prefill.spec.ts
+++ b/src/modules/service-catalog/hooks/useItemFormFields.prefill.spec.ts
@@ -1,0 +1,226 @@
+import { renderHook } from "@testing-library/react-hooks";
+import type { ServiceCatalogItem } from "../data-types/ServiceCatalogItem";
+import { useItemFormFields } from "./useItemFormFields";
+
+describe("useItemFormFields — query-string prefill integration", () => {
+  const baseLocale = "en-us";
+
+  const serviceCatalogItem: ServiceCatalogItem = {
+    id: 1,
+    name: "Test Item",
+    description: "Test Description",
+    form_id: 1,
+    thumbnail_url: "",
+    categories: [],
+    is_request_on_behalf: false,
+    published_at: "2025-01-01T00:00:00Z",
+    custom_object_fields: {
+      "standard::asset_option": "",
+      "standard::asset_type_option": "",
+      "standard::attachment_option": "",
+    },
+  };
+
+  // Associated service-catalog-item lookup is mandatory: the hook throws
+  // "Associated lookup field not found" without it. It is removed from
+  // requestFields, so it never interferes with assertions below.
+  const associatedLookup = {
+    id: 2,
+    type: "lookup",
+    description: "Service",
+    title_in_portal: "Service",
+    editable_in_portal: true,
+    relationship_target_type: "standard::service_catalog_item",
+    required_in_portal: true,
+    active: true,
+  };
+
+  const basicText = {
+    id: 1,
+    type: "text",
+    description: "A field",
+    title_in_portal: "Basic text",
+    editable_in_portal: true,
+    required_in_portal: false,
+    active: true,
+  };
+
+  // Conditional parent: when its value is "reveal", child field 4 is shown.
+  const parentDropdown = {
+    id: 3,
+    type: "tagger",
+    description: "",
+    title_in_portal: "Reason",
+    editable_in_portal: true,
+    required_in_portal: false,
+    active: true,
+    custom_field_options: [
+      { name: "Reveal", value: "reveal" },
+      { name: "Hide", value: "hide" },
+    ],
+  };
+
+  // Conditional child of `parentDropdown`.
+  const conditionalChild = {
+    id: 4,
+    type: "text",
+    description: "",
+    title_in_portal: "Details",
+    editable_in_portal: true,
+    required_in_portal: false,
+    active: true,
+  };
+
+  const revealChildCondition = {
+    parent_field_id: 3,
+    parent_field_type: "tagger",
+    value: "reveal",
+    child_fields: [{ id: 4, is_required: true }],
+  };
+
+  const setUrl = (search: string) => {
+    window.history.pushState({}, "", search);
+  };
+
+  const mockFetch = (
+    ticketFieldIds: number[],
+    ticketFields: unknown[],
+    endUserConditions: unknown[] = []
+  ) => {
+    const formResponse = {
+      ticket_form: {
+        id: 1,
+        ticket_field_ids: ticketFieldIds,
+        active: true,
+        end_user_conditions: endUserConditions,
+      },
+    };
+    const ticketFieldResponse = { ticket_fields: ticketFields };
+
+    (globalThis.fetch as jest.Mock) = jest.fn((url: string) =>
+      Promise.resolve({
+        status: 200,
+        ok: true,
+        json: () =>
+          Promise.resolve(
+            url.includes("/api/v2/ticket_forms/1")
+              ? formResponse
+              : url.includes(`/api/v2/ticket_fields?locale=${baseLocale}`)
+              ? ticketFieldResponse
+              : {}
+          ),
+      })
+    );
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    // Reset the URL so prefill state never leaks between tests.
+    window.history.pushState({}, "", "/");
+  });
+
+  it("applies a prefill value from the URL onto a plain field", async () => {
+    setUrl("/?tf_1=Hello%20World");
+    mockFetch([1, 2], [basicText, associatedLookup]);
+
+    const { result, waitFor } = renderHook(() =>
+      useItemFormFields(serviceCatalogItem, baseLocale)
+    );
+
+    await waitFor(() => {
+      expect(result.current.requestFields).toHaveLength(1);
+    });
+
+    const field = result.current.requestFields.find((f) => f.id === 1);
+    expect(field?.value).toBe("Hello World");
+    expect(result.current.error).toBeNull();
+  });
+
+  it("ignores prefill keys that do not match a field on the form", async () => {
+    setUrl("/?tf_9999=ignored&subject=nope");
+    mockFetch([1, 2], [basicText, associatedLookup]);
+
+    const { result, waitFor } = renderHook(() =>
+      useItemFormFields(serviceCatalogItem, baseLocale)
+    );
+
+    await waitFor(() => {
+      expect(result.current.requestFields).toHaveLength(1);
+    });
+
+    expect(
+      result.current.requestFields.find((f) => f.id === 1)?.value
+    ).toBeNull();
+  });
+
+  it("reveals a conditional child when its parent is prefilled with the triggering value", async () => {
+    setUrl("/?tf_3=reveal&tf_4=Child%20details");
+    mockFetch(
+      [1, 2, 3, 4],
+      [basicText, associatedLookup, parentDropdown, conditionalChild],
+      [revealChildCondition]
+    );
+
+    const { result, waitFor } = renderHook(() =>
+      useItemFormFields(serviceCatalogItem, baseLocale)
+    );
+
+    await waitFor(() => {
+      expect(result.current.requestFields.some((f) => f.id === 3)).toBe(true);
+    });
+
+    const visibleIds = result.current.requestFields.map((f) => f.id);
+    // Parent (3) and child (4) are both visible; basic (1) too.
+    expect(visibleIds).toEqual(expect.arrayContaining([1, 3, 4]));
+
+    const parent = result.current.requestFields.find((f) => f.id === 3);
+    const child = result.current.requestFields.find((f) => f.id === 4);
+    expect(parent?.value).toBe("reveal");
+    expect(child?.value).toBe("Child details");
+    // The condition marks the child required while visible.
+    expect(child?.required).toBe(true);
+  });
+
+  it("keeps a conditional child hidden (and its prefill unused) when the parent value does not match", async () => {
+    // Child is prefilled but the parent is not, so the condition is not met.
+    setUrl("/?tf_4=Child%20details");
+    mockFetch(
+      [1, 2, 3, 4],
+      [basicText, associatedLookup, parentDropdown, conditionalChild],
+      [revealChildCondition]
+    );
+
+    const { result, waitFor } = renderHook(() =>
+      useItemFormFields(serviceCatalogItem, baseLocale)
+    );
+
+    await waitFor(() => {
+      expect(result.current.requestFields.some((f) => f.id === 3)).toBe(true);
+    });
+
+    const visibleIds = result.current.requestFields.map((f) => f.id);
+    // Child (4) stays hidden; parent (3) and basic (1) remain visible.
+    expect(visibleIds).toEqual(expect.arrayContaining([1, 3]));
+    expect(visibleIds).not.toContain(4);
+  });
+
+  it("does not prefill anything when the URL has no tf_ parameters", async () => {
+    setUrl("/?category_id=42");
+    mockFetch([1, 2], [basicText, associatedLookup]);
+
+    const { result, waitFor } = renderHook(() =>
+      useItemFormFields(serviceCatalogItem, baseLocale)
+    );
+
+    await waitFor(() => {
+      expect(result.current.requestFields).toHaveLength(1);
+    });
+
+    expect(
+      result.current.requestFields.find((f) => f.id === 1)?.value
+    ).toBeNull();
+  });
+});

--- a/src/modules/service-catalog/hooks/useItemFormFields.tsx
+++ b/src/modules/service-catalog/hooks/useItemFormFields.tsx
@@ -13,6 +13,8 @@ import type {
   AssetConfig,
 } from "../data-types/Assets";
 import { sanitizeFieldDescription } from "../utils/sanitize";
+import { applyPrefillToFields } from "../utils/applyPrefillToFields";
+import { useQueryStringPrefill } from "./useQueryStringPrefill";
 
 const ASSET_TYPE_KEY = "zen:custom_object:standard::itam_asset_type";
 const ASSET_KEY = "zen:custom_object:standard::itam_asset";
@@ -270,6 +272,10 @@ export function useItemFormFields(
     assetTypeOptionId ?? ""
   );
 
+  // Prefill (PDSC-954) is applied to the full field set before visibility is
+  // computed, so a prefilled parent reveals its conditional children.
+  const prefill = useQueryStringPrefill();
+
   useEffect(() => {
     if (!serviceCatalogItem?.form_id) return;
 
@@ -309,7 +315,8 @@ export function useItemFormFields(
           requestFields,
           processedAssetConfig
         );
-        setAllRequestFields(enrichedFields);
+        const prefilledFields = applyPrefillToFields(enrichedFields, prefill);
+        setAllRequestFields(prefilledFields);
       } catch (error) {
         if (alive) {
           setError(error);
@@ -326,7 +333,13 @@ export function useItemFormFields(
     return () => {
       alive = false;
     };
-  }, [baseLocale, serviceCatalogItem?.form_id, fetchAssets, fetchAssetTypes]);
+  }, [
+    baseLocale,
+    serviceCatalogItem?.form_id,
+    fetchAssets,
+    fetchAssetTypes,
+    prefill,
+  ]);
 
   const handleChange = useCallback(
     (field: TicketFieldObject, value: TicketFieldObject["value"]) => {

--- a/src/modules/service-catalog/hooks/useQueryStringPrefill.tsx
+++ b/src/modules/service-catalog/hooks/useQueryStringPrefill.tsx
@@ -1,0 +1,15 @@
+import { useMemo } from "react";
+import { parseQueryStringPrefill } from "../utils/parseQueryStringPrefill";
+
+export function useQueryStringPrefill(): Map<string, string> {
+  return useMemo(() => {
+    if (typeof window === "undefined") {
+      return new Map<string, string>();
+    }
+
+    return parseQueryStringPrefill(
+      window.location.search,
+      window.location.href.length
+    );
+  }, []);
+}

--- a/src/modules/service-catalog/utils/applyPrefillToFields.spec.ts
+++ b/src/modules/service-catalog/utils/applyPrefillToFields.spec.ts
@@ -1,0 +1,296 @@
+import { applyPrefillToFields } from "./applyPrefillToFields";
+import type { TicketFieldObject } from "../../ticket-fields/data-types/TicketFieldObject";
+import { ASSET_KEY, ASSET_TYPE_KEY } from "../constants";
+
+const createField = (
+  overrides: Partial<TicketFieldObject> = {}
+): TicketFieldObject => ({
+  id: 1,
+  name: "custom_fields_1",
+  label: "Test Field",
+  type: "text",
+  description: "",
+  value: null,
+  error: null,
+  required: false,
+  options: [],
+  ...overrides,
+});
+
+const prefillMap = (entries: Record<string, string>): Map<string, string> =>
+  new Map(Object.entries(entries));
+
+describe("applyPrefillToFields", () => {
+  it("returns the same array when there is nothing to prefill", () => {
+    const fields = [createField()];
+    expect(applyPrefillToFields(fields, new Map())).toBe(fields);
+  });
+
+  it("does not mutate the input fields", () => {
+    const fields = [createField({ id: 5, value: null })];
+    const result = applyPrefillToFields(fields, prefillMap({ "5": "hello" }));
+
+    expect(fields[0]?.value).toBeNull();
+    expect(result[0]?.value).toBe("hello");
+    expect(result).not.toBe(fields);
+  });
+
+  describe("basic fields (PDSC-955)", () => {
+    it.each(["text", "integer", "decimal", "regexp"])(
+      "prefills %s fields by numeric id",
+      (type) => {
+        const fields = [createField({ id: 42, type })];
+        const result = applyPrefillToFields(
+          fields,
+          prefillMap({ "42": "100" })
+        );
+        expect(result[0]?.value).toBe("100");
+      }
+    );
+
+    it("prefills valid YYYY-MM-DD date values", () => {
+      const fields = [createField({ id: 7, type: "date" })];
+      const result = applyPrefillToFields(
+        fields,
+        prefillMap({ "7": "2026-12-25" })
+      );
+      expect(result[0]?.value).toBe("2026-12-25");
+    });
+
+    it("ignores invalid date values", () => {
+      const fields = [createField({ id: 7, type: "date", value: null })];
+      expect(
+        applyPrefillToFields(fields, prefillMap({ "7": "25-12-2026" }))[0]
+          ?.value
+      ).toBeNull();
+      expect(
+        applyPrefillToFields(fields, prefillMap({ "7": "2026-13-40" }))[0]
+          ?.value
+      ).toBeNull();
+    });
+  });
+
+  describe("selection fields (PDSC-956)", () => {
+    it("prefills a dropdown (tagger) by value", () => {
+      const fields = [
+        createField({
+          id: 3,
+          type: "tagger",
+          options: [
+            { name: "High", value: "high" },
+            { name: "Low", value: "low" },
+          ],
+        }),
+      ];
+      const result = applyPrefillToFields(fields, prefillMap({ "3": "high" }));
+      expect(result[0]?.value).toBe("high");
+    });
+
+    it("prefills a system priority field by alias", () => {
+      const fields = [
+        createField({ id: 99, type: "priority", name: "custom_fields_99" }),
+      ];
+      const result = applyPrefillToFields(
+        fields,
+        prefillMap({ priority: "high" })
+      );
+      expect(result[0]?.value).toBe("high");
+    });
+
+    it("prefills a system type field by alias", () => {
+      const fields = [createField({ id: 98, type: "tickettype" })];
+      const result = applyPrefillToFields(
+        fields,
+        prefillMap({ type: "incident" })
+      );
+      expect(result[0]?.value).toBe("incident");
+    });
+
+    it("splits multiselect on commas and keeps only known options", () => {
+      const fields = [
+        createField({
+          id: 4,
+          type: "multiselect",
+          options: [
+            { name: "A", value: "a" },
+            { name: "B", value: "b" },
+          ],
+        }),
+      ];
+      const result = applyPrefillToFields(
+        fields,
+        prefillMap({ "4": "a,b,unknown" })
+      );
+      expect(result[0]?.value).toEqual(["a", "b"]);
+    });
+
+    it("prefills checkbox with a boolean (not on/off) for true", () => {
+      const fields = [createField({ id: 6, type: "checkbox" })];
+      const result = applyPrefillToFields(fields, prefillMap({ "6": "true" }));
+      expect(result[0]?.value).toBe(true);
+    });
+
+    it("prefills checkbox with false", () => {
+      const fields = [createField({ id: 6, type: "checkbox", value: true })];
+      const result = applyPrefillToFields(fields, prefillMap({ "6": "false" }));
+      expect(result[0]?.value).toBe(false);
+    });
+
+    it("ignores non-boolean checkbox values", () => {
+      const fields = [createField({ id: 6, type: "checkbox", value: null })];
+      const result = applyPrefillToFields(fields, prefillMap({ "6": "yes" }));
+      expect(result[0]?.value).toBeNull();
+    });
+  });
+
+  describe("lookup fields (PDSC-957)", () => {
+    it("prefills a regular lookup with a valid ULID record id", () => {
+      const fields = [
+        createField({
+          id: 8,
+          type: "lookup",
+          relationship_target_type:
+            "zen:custom_object:standard::service_catalog_item",
+        }),
+      ];
+      const result = applyPrefillToFields(
+        fields,
+        prefillMap({ "8": "01KY4M9HVGWG9QMK31S4TZMNNN" })
+      );
+      expect(result[0]?.value).toBe("01KY4M9HVGWG9QMK31S4TZMNNN");
+    });
+
+    it("skips lookup ids that are not valid ULIDs (avoids a doomed request)", () => {
+      const fields = [
+        createField({
+          id: 8,
+          type: "lookup",
+          relationship_target_type:
+            "zen:custom_object:standard::service_catalog_item",
+          value: null,
+        }),
+      ];
+      // wrong length, and contains ULID-invalid chars (I, O, L)
+      expect(
+        applyPrefillToFields(fields, prefillMap({ "8": "record_123" }))[0]
+          ?.value
+      ).toBeNull();
+      expect(
+        applyPrefillToFields(
+          fields,
+          prefillMap({ "8": "01INVALIDRECORDIDXXXXXXXXX" })
+        )[0]?.value
+      ).toBeNull();
+    });
+
+    it("does not prefill asset lookups (out of scope for v1)", () => {
+      const fields = [
+        createField({
+          id: 9,
+          type: "lookup",
+          relationship_target_type: ASSET_KEY,
+          value: null,
+        }),
+        createField({
+          id: 10,
+          type: "lookup",
+          relationship_target_type: ASSET_TYPE_KEY,
+          value: null,
+        }),
+      ];
+      const result = applyPrefillToFields(
+        fields,
+        prefillMap({ "9": "abc", "10": "def" })
+      );
+      expect(result[0]?.value).toBeNull();
+      expect(result[1]?.value).toBeNull();
+    });
+  });
+
+  describe("credit card", () => {
+    it("prefills the last 4 digits of a credit card, stripping non-digits", () => {
+      const fields = [
+        createField({ id: 11, type: "partialcreditcard", value: null }),
+      ];
+      const result = applyPrefillToFields(
+        fields,
+        prefillMap({ "11": "4111 1111 1111 1234" })
+      );
+      expect(result[0]?.value).toBe("1234");
+    });
+
+    it("ignores a credit card value with no digits", () => {
+      const fields = [
+        createField({ id: 11, type: "partialcreditcard", value: null }),
+      ];
+      const result = applyPrefillToFields(fields, prefillMap({ "11": "abc" }));
+      expect(result[0]?.value).toBeNull();
+    });
+  });
+
+  describe("security (PDSC-958)", () => {
+    it("strips script tags / disallowed html from values", () => {
+      const fields = [createField({ id: 12, type: "text" })];
+      const result = applyPrefillToFields(
+        fields,
+        prefillMap({ "12": "<script>alert('xss')</script>hello" })
+      );
+      expect(result[0]?.value).not.toContain("<script>");
+      expect(result[0]?.value).toContain("hello");
+    });
+
+    it("keeps whitelisted html tags", () => {
+      const fields = [createField({ id: 13, type: "textarea" })];
+      const result = applyPrefillToFields(
+        fields,
+        prefillMap({ "13": "<strong>bold</strong>" })
+      );
+      expect(result[0]?.value).toBe("<strong>bold</strong>");
+    });
+  });
+
+  describe("field resolution", () => {
+    it("ignores unknown numeric field ids", () => {
+      const fields = [createField({ id: 1, value: null })];
+      const result = applyPrefillToFields(
+        fields,
+        prefillMap({ "9999": "value" })
+      );
+      expect(result[0]?.value).toBeNull();
+    });
+
+    it("ignores keys with no matching field (e.g. subject)", () => {
+      const fields = [createField({ id: 1, type: "text", value: null })];
+      const result = applyPrefillToFields(
+        fields,
+        prefillMap({ subject: "Laptop", description: "text" })
+      );
+      expect(result[0]?.value).toBeNull();
+    });
+
+    it("prefills multiple fields at once", () => {
+      const fields = [
+        createField({ id: 1, type: "text" }),
+        createField({ id: 2, type: "text", name: "custom_fields_2" }),
+      ];
+      const result = applyPrefillToFields(
+        fields,
+        prefillMap({ "1": "one", "2": "two" })
+      );
+      expect(result[0]?.value).toBe("one");
+      expect(result[1]?.value).toBe("two");
+    });
+
+    it("does not clobber a field already prefilled by another key", () => {
+      const fields = [
+        createField({ id: 50, type: "priority", name: "custom_fields_50" }),
+      ];
+      // both the numeric id and the alias target the same field; first wins
+      const result = applyPrefillToFields(
+        fields,
+        prefillMap({ "50": "high", priority: "low" })
+      );
+      expect(result[0]?.value).toBe("high");
+    });
+  });
+});

--- a/src/modules/service-catalog/utils/applyPrefillToFields.ts
+++ b/src/modules/service-catalog/utils/applyPrefillToFields.ts
@@ -1,0 +1,138 @@
+import DOMPurify from "dompurify";
+import type { TicketFieldObject } from "../../ticket-fields/data-types/TicketFieldObject";
+import {
+  ASSET_KEY,
+  ASSET_TYPE_KEY,
+  PREFILL_ALLOWED_BOOLEAN_VALUES,
+  PREFILL_ALLOWED_HTML_TAGS,
+  PREFILL_SYSTEM_FIELD_ALIASES,
+} from "../constants";
+
+const DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
+
+// Record ids are ULIDs (26 chars, Crockford base32). Validating the format
+// lets us skip a doomed `/records/:id` request (400 "id must be a ULID").
+const ULID_REGEX = /^[0-9A-HJKMNP-TV-Z]{26}$/i;
+
+function isValidDate(dateString: string): boolean {
+  if (!DATE_REGEX.test(dateString)) {
+    return false;
+  }
+
+  const date = new Date(dateString);
+  const [year, month, day] = dateString.split("-").map(Number);
+  return (
+    date.getUTCFullYear() === year &&
+    date.getUTCMonth() + 1 === month &&
+    date.getUTCDate() === day
+  );
+}
+
+function isAssetLookup(field: TicketFieldObject): boolean {
+  return (
+    field.relationship_target_type === ASSET_KEY ||
+    field.relationship_target_type === ASSET_TYPE_KEY
+  );
+}
+
+function findTargetField(
+  key: string,
+  fields: TicketFieldObject[]
+): TicketFieldObject | undefined {
+  const trimmedKey = key.trim();
+  const isNumericId = trimmedKey !== "" && !Number.isNaN(Number(trimmedKey));
+
+  if (isNumericId) {
+    const id = Number(trimmedKey);
+    return fields.find((field) => field.id === id);
+  }
+
+  const aliasedTypes = PREFILL_SYSTEM_FIELD_ALIASES[trimmedKey];
+  if (aliasedTypes) {
+    return fields.find((field) => aliasedTypes.includes(field.type));
+  }
+
+  return undefined;
+}
+
+function coercePrefillValue(
+  field: TicketFieldObject,
+  rawValue: string
+): TicketFieldObject["value"] | undefined {
+  const sanitizedValue = DOMPurify.sanitize(rawValue, {
+    ALLOWED_TAGS: PREFILL_ALLOWED_HTML_TAGS,
+  });
+
+  switch (field.type) {
+    // Enabled on explicit product decision (overrides PDSC-958): only the last
+    // 4 digits are ever captured, so a full card number is never stored/shown.
+    case "partialcreditcard": {
+      const digits = sanitizedValue.replace(/\D/g, "");
+      return digits ? digits.slice(-4) : undefined;
+    }
+
+    case "multiselect":
+      return sanitizedValue
+        .split(",")
+        .filter((value) =>
+          field.options.some((option) => option.value === value)
+        );
+
+    // SC's Checkbox expects a boolean (unlike Help Center's "on"/"off"), which
+    // is also what conditional-field visibility compares against.
+    case "checkbox":
+      if (!PREFILL_ALLOWED_BOOLEAN_VALUES.includes(sanitizedValue as never)) {
+        return undefined;
+      }
+      return sanitizedValue === "true";
+
+    case "date":
+      return isValidDate(sanitizedValue) ? sanitizedValue : undefined;
+
+    case "lookup":
+      // Asset / asset-type lookups are out of scope for v1.
+      if (isAssetLookup(field)) {
+        return undefined;
+      }
+      if (!ULID_REGEX.test(sanitizedValue)) {
+        return undefined;
+      }
+      return sanitizedValue;
+
+    default:
+      return sanitizedValue;
+  }
+}
+
+export function applyPrefillToFields(
+  fields: TicketFieldObject[],
+  prefill: Map<string, string>
+): TicketFieldObject[] {
+  if (prefill.size === 0) {
+    return fields;
+  }
+
+  // A numeric id and a system alias can target the same field; the first
+  // applied value wins and later ones don't clobber it.
+  const prefilledFieldIds = new Set<number>();
+  let nextFields = fields;
+
+  for (const [key, rawValue] of prefill) {
+    const targetField = findTargetField(key, nextFields);
+    if (!targetField || prefilledFieldIds.has(targetField.id)) {
+      continue;
+    }
+
+    const value = coercePrefillValue(targetField, rawValue);
+    if (value === undefined) {
+      continue;
+    }
+
+    prefilledFieldIds.add(targetField.id);
+    nextFields = nextFields.map((field) =>
+      field.id === targetField.id ? { ...field, value } : field
+    );
+  }
+
+  return nextFields;
+}

--- a/src/modules/service-catalog/utils/parseQueryStringPrefill.spec.ts
+++ b/src/modules/service-catalog/utils/parseQueryStringPrefill.spec.ts
@@ -1,0 +1,56 @@
+import { parseQueryStringPrefill } from "./parseQueryStringPrefill";
+import { MAX_PREFILL_URL_LENGTH } from "../constants";
+
+describe("parseQueryStringPrefill", () => {
+  it("returns an empty map when there are no params", () => {
+    expect(parseQueryStringPrefill("").size).toBe(0);
+    expect(parseQueryStringPrefill("?").size).toBe(0);
+  });
+
+  it("extracts only tf_ prefixed params, stripping the prefix", () => {
+    const result = parseQueryStringPrefill(
+      "?tf_subject=Laptop&category_id=42&tf_12345=Engineering"
+    );
+
+    expect(result.get("subject")).toBe("Laptop");
+    expect(result.get("12345")).toBe("Engineering");
+    expect(result.has("category_id")).toBe(false);
+    expect(result.size).toBe(2);
+  });
+
+  it("ignores non-prefill params entirely", () => {
+    const result = parseQueryStringPrefill("?category_id=42&preview=true");
+    expect(result.size).toBe(0);
+  });
+
+  it("ignores an empty field key (tf_ with nothing after it)", () => {
+    const result = parseQueryStringPrefill("?tf_=value");
+    expect(result.size).toBe(0);
+  });
+
+  it("decodes url-encoded values", () => {
+    const result = parseQueryStringPrefill("?tf_description=New+hire+setup");
+    expect(result.get("description")).toBe("New hire setup");
+  });
+
+  it("keeps the last value when a key is duplicated", () => {
+    const result = parseQueryStringPrefill("?tf_priority=low&tf_priority=high");
+    expect(result.get("priority")).toBe("high");
+  });
+
+  it("skips prefill entirely when the url exceeds the length limit", () => {
+    const result = parseQueryStringPrefill(
+      "?tf_subject=Laptop",
+      MAX_PREFILL_URL_LENGTH + 1
+    );
+    expect(result.size).toBe(0);
+  });
+
+  it("allows prefill exactly at the length limit", () => {
+    const result = parseQueryStringPrefill(
+      "?tf_subject=Laptop",
+      MAX_PREFILL_URL_LENGTH
+    );
+    expect(result.get("subject")).toBe("Laptop");
+  });
+});

--- a/src/modules/service-catalog/utils/parseQueryStringPrefill.ts
+++ b/src/modules/service-catalog/utils/parseQueryStringPrefill.ts
@@ -1,0 +1,29 @@
+import { MAX_PREFILL_URL_LENGTH, PREFILL_FIELD_PREFIX } from "../constants";
+
+export function parseQueryStringPrefill(
+  search: string,
+  fullUrlLength: number = search.length
+): Map<string, string> {
+  const prefill = new Map<string, string>();
+
+  if (fullUrlLength > MAX_PREFILL_URL_LENGTH) {
+    return prefill;
+  }
+
+  const params = new URLSearchParams(search);
+
+  for (const [key, value] of params) {
+    if (!key.startsWith(PREFILL_FIELD_PREFIX)) {
+      continue;
+    }
+
+    const fieldKey = key.substring(PREFILL_FIELD_PREFIX.length);
+    if (fieldKey.length === 0) {
+      continue;
+    }
+
+    prefill.set(fieldKey, value);
+  }
+
+  return prefill;
+}


### PR DESCRIPTION
## Description

Adds query-string prefill for Service Catalog item forms (PDSC-954), mirroring
the proven Help Center pattern (`new-request-form/usePrefilledTicketFields.tsx`).
Automation tools (Advanced Action Flows, AI Agents, Code Flows) can now link
users to an item with fields already populated via `tf_*` URL params, e.g.
`/services/<item_id>?tf_<field_id>=value&tf_priority=high`.
Prefill is best-effort and never breaks the page: invalid/unknown values are
silently ignored, values are present on first render (no flicker), remain
editable, and standard form validation still applies on submit.

https://zendesk.atlassian.net/browse/PDSC-954

## Screenshots

<!-- (optional) when applicable, please include some screenshots or gifs that illustrate the changes -->

## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->