### PR TITLE
fix(service-catalog): restore via.channel on request submission

### DIFF
--- a/src/modules/service-catalog/components/service-catalog-item/submitServiceItemRequest.spec.tsx
+++ b/src/modules/service-catalog/components/service-catalog-item/submitServiceItemRequest.spec.tsx
@@ -122,6 +122,7 @@ describe("submitServiceItemRequest", () => {
       { id: 1, value: "value-1" },
       { id: associatedLookupField.id, value: mockItem.id },
     ]);
+    expect(request.via).toEqual({ channel: "web form", source: 50 });
   });
 
   it("encodes all user-controlled comment values as text", async () => {

--- a/src/modules/service-catalog/components/service-catalog-item/submitServiceItemRequest.tsx
+++ b/src/modules/service-catalog/components/service-catalog-item/submitServiceItemRequest.tsx
@@ -104,6 +104,10 @@ export async function submitServiceItemRequest(
             uploads: uploadTokens,
           },
           custom_fields: [...customFields, ...lookupFields],
+          via: {
+            channel: "web form",
+            source: 50,
+          },
           ...(isRequestingOnBehalf
             ? { requester_id: requesterId, collaborators: [submitterId] }
             : {}),


### PR DESCRIPTION
## Problem

PR #825 ("[PDSC-713] feat: migrate to the new endpoint and add submitter/user logic") migrated Service Catalog request submission from the public `/api/v2/requests` endpoint to the internal `/hc/api/v2/service_catalog/requests` proxy. In the same diff hunk, it silently dropped the explicit body block:

```ts
via: {
  channel: "web form",
  source: 50,
},
```

The PR's description is entirely about request-on-behalf/`requester_id`/`collaborators` logic and never mentions this change, which suggests it was an unintentional side effect of the endpoint switch rather than a deliberate decision.

## Why this matters

`submitServiceItemRequest` submits via `fetch()` (an AJAX JSON POST), not a native `<form>` submission. The theme's other main ticket-submission path (`src/modules/new-request-form/useFormSubmit.tsx`) does a real form POST, which Zendesk's backend automatically tags `via.channel = "web form"` — no override needed. The Service Catalog flow has no such implicit signal, which is presumably why the *old* code had to explicitly force the `via` block to get parity.

A downstream customer (running this theme) compared two real tickets in their instance:
- Pre-migration (old endpoint + explicit `via`): landed with `via.channel = "web"`, matched their omni-channel routing rule (`channel: web form`), got assigned, `status: open`.
- Post-migration (new proxy, no `via`): landed with `via.channel = "help_center"` instead, didn't match the routing rule, was never assigned, and stayed `status: new` indefinitely.

Everything else about the two tickets (form, brand, group, org, requester, tags) was identical — `via.channel` was the only variable that changed, exactly at the endpoint-migration boundary.

## Fix

Re-adds the `via: { channel: "web form", source: 50 }` block to the request body, matching the pre-#825 behavior. Diff is minimal and additive.

## ⚠️ Needs maintainer verification

`/hc/api/v2/service_catalog/requests` is an internal, undocumented proxy endpoint. I could not confirm from static code review whether it accepts/honors a client-supplied `via` object in its request body — that requires a live test against a real Zendesk sandbox. Worst case if it's ignored, behavior is unchanged from today (still broken); this PR cannot make things worse, but its *efficacy* needs to be confirmed by someone with sandbox access before merging. Please verify the resulting ticket's `via.channel` reflects `web form` after submitting through this endpoint with the change applied.

Note: I also found that #825 dropped `ticket_form_id: serviceCatalogItem.form_id` in the same hunk — that field is unrelated to this channel-routing issue so I left it out of scope here, but it may be worth a maintainer double-checking whether that drop was intentional too.

## Testing

- Updated `submitServiceItemRequest.spec.tsx` to assert the `via` block is present in the submitted request body.
- `yarn test src/modules/service-catalog/components/service-catalog-item/submitServiceItemRequest.spec.tsx` — all 7 tests pass.
- `yarn eslint` on both changed files — 0 errors (pre-existing warnings elsewhere in the repo are unrelated).

Note: Issues are disabled on this repo, so I'm opening this PR directly rather than filing a tracking issue first. Credit to @Aleyho for researching this issue and why our omnichannel recently got totally broken.

[PDSC-713]: https://zendesk.atlassian.net/browse/PDSC-713?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ