### PR TITLE
feat(templates): add applications_page with application_catalog helper

### DIFF
--- a/templates/applications_page.hbs
+++ b/templates/applications_page.hbs
@@ -1,0 +1,7 @@
+<div class="container">
+  <div class="sub-nav">
+    {{breadcrumbs}}
+  </div>
+
+  {{application_catalog}}
+</div>

--- a/templates/header.hbs
+++ b/templates/header.hbs
@@ -14,6 +14,7 @@
     <nav class="user-nav" id="user-nav" aria-label="{{t 'user_navigation'}}">
       <ul class="user-nav-list">
         <li>{{link 'community'}}</li>
+        <li>{{link 'applications'}}</li>
         <li>{{link 'service_catalog'}}</li>
         <li>{{link 'new_request' class='submit-a-request'}}</li>
         {{#unless signed_in}}
@@ -93,6 +94,7 @@
         {{/if}}
        
         <li class="item">{{link 'community'}}</li>
+        <li class="item">{{link 'applications'}}</li>
         <li class="item">{{link 'new_request' class='submit-a-request'}}</li>
         <li class="item">{{link 'service_catalog'}}</li>
         <li class="nav-divider"></li>


### PR DESCRIPTION
Adds `templates/applications_page.hbs` so the Applications catalog page can render via an independently-updatable app instead of requiring a native CPH build.

Keeps `{{breadcrumbs}}` in the same `.sub-nav` wrapper used by `service_list_page.hbs`/`category_page.hbs`. Calls a bare `{{application_catalog}}` helper with no local markup around it, so the app it renders can be updated without a CPH release — mirroring the existing `{{generative_answers}}` pattern in `search_results.hbs`.

This template alone has no effect until the corresponding backend helper is implemented and wired up. That work is tracked separately and isn't part of this PR.

Risks
risk:none

None: adds a new, unreferenced template file. No existing route maps to it yet, so this has zero effect on any live page until the backend-side wiring lands.