### PR TITLE
fix(service-catalog): preserve conditionally hidden fields on submission errors

### DIFF
--- a/src/modules/service-catalog/components/service-catalog-item/ServiceCatalogItem.spec.tsx
+++ b/src/modules/service-catalog/components/service-catalog-item/ServiceCatalogItem.spec.tsx
@@ -502,13 +502,21 @@ describe("ServiceCatalogItem", () => {
       fireEvent.submit(form);
 
       await waitFor(() => {
-        expect(setRequestFields).toHaveBeenCalledWith([
-          expect.objectContaining({
-            id: 1,
-            error: "Product name: cannot be blank",
-          }),
-        ]);
+        expect(setRequestFields).toHaveBeenCalledWith(expect.any(Function));
       });
+
+      // validateForm's client-side check also calls setRequestFields
+      // (clearing stale errors) before handleValidationErrors does, so we
+      // need the last call, not the first.
+      const calls = setRequestFields.mock.calls;
+      const updateFn = calls[calls.length - 1][0];
+      const result = updateFn(mockRequestFields);
+      expect(result).toEqual([
+        expect.objectContaining({
+          id: 1,
+          error: "Product name: cannot be blank",
+        }),
+      ]);
     });
 
     const renderLastNotifyMessage = () => {
@@ -688,6 +696,87 @@ describe("ServiceCatalogItem", () => {
       await waitFor(() => {
         expect(mockNotify).not.toHaveBeenCalled();
       });
+    });
+
+    it("should merge field errors onto the full field list via a functional update, preserving fields hidden by end-user conditions", async () => {
+      const mockSetRequestFields = jest.fn();
+      mockUseItemFormFields.mockReturnValue({
+        requestFields: mockRequestFields,
+        associatedLookupField: mockAssociatedLookupField,
+        categoryLookupField: null,
+        error: null,
+        setRequestFields: mockSetRequestFields,
+        handleChange: jest.fn(),
+        isRequestFieldsLoading: false,
+        assetTypeHiddenValue: "",
+        isAssetTypeHidden: false,
+        assetTypeIds: [],
+        assetIds: [],
+      });
+
+      const errorResponse = {
+        ok: false,
+        status: 422,
+        json: () =>
+          Promise.resolve({
+            error: "RecordInvalid",
+            description: "Record validation errors",
+            details: {
+              base: [
+                {
+                  description: "Field is required",
+                  error: "BlankValue",
+                  field_id: 1, // matches mockRequestFields[0]
+                },
+              ],
+            },
+          }),
+      };
+
+      mockSubmitServiceItemRequest.mockResolvedValue(
+        errorResponse as unknown as Response
+      );
+
+      renderWithTheme(<ServiceCatalogItem {...defaultProps} />);
+
+      const form = screen.getByTestId("item-request-form");
+      fireEvent.submit(form);
+
+      await waitFor(() => {
+        // validateForm's client-side check calls setRequestFields first
+        // (clearing stale errors); handleValidationErrors's merge is the
+        // subsequent call once the mocked 422 response resolves.
+        expect(mockSetRequestFields.mock.calls.length).toBeGreaterThanOrEqual(
+          2
+        );
+      });
+
+      // A field hidden by an end-user condition would be absent from the
+      // (visible-only) `requestFields` passed to the component, but must
+      // still exist in the full underlying list the functional update
+      // operates on.
+      const hiddenField: TicketFieldObject = {
+        id: 42,
+        name: "custom_fields_42",
+        type: "text",
+        description: "Hidden field",
+        label: "Hidden field",
+        required: false,
+        options: [],
+        value: "should be preserved",
+        error: null,
+      };
+      const fullFieldList = [...mockRequestFields, hiddenField];
+
+      const calls = mockSetRequestFields.mock.calls;
+      const updateFn = calls[calls.length - 1][0];
+      const result = updateFn(fullFieldList);
+
+      expect(result).toContainEqual(hiddenField);
+      expect(result).toHaveLength(fullFieldList.length);
+      expect(result.find((f: TicketFieldObject) => f.id === 1)?.error).toBe(
+        "Field is required"
+      );
     });
 
     it("should show error notification for non-422 error responses", async () => {

--- a/src/modules/service-catalog/components/service-catalog-item/ServiceCatalogItem.tsx
+++ b/src/modules/service-catalog/components/service-catalog-item/ServiceCatalogItem.tsx
@@ -327,13 +327,18 @@ export function ServiceCatalogItem({
       notifySubmitError();
     }
 
-    const updatedFields = requestFields.map((field) => {
-      const errorField = invalidFieldErrors.find(
-        (errorField) => errorField.field_id === field.id
-      );
-      return { ...field, error: errorField?.description || null };
-    });
-    setRequestFields(updatedFields);
+    // setRequestFields is backed by the full (not just visible) field list,
+    // so we must merge via a functional update rather than replacing it with
+    // a mapped copy of `requestFields` (the visible subset) — otherwise any
+    // field currently hidden by an end-user condition would be dropped.
+    setRequestFields((prevFields) =>
+      prevFields.map((field) => {
+        const errorField = invalidFieldErrors.find(
+          (errorField) => errorField.field_id === field.id
+        );
+        return { ...field, error: errorField?.description || null };
+      })
+    );
   }
 
   async function handleSubmitError(response: Response | undefined) {


### PR DESCRIPTION
## Description

Submitting the Service Catalog request form could permanently delete any ticket field currently hidden by an end-user condition from React state. Once dropped, the field never came back without a full page reload, so the form appeared to hang/fail and could become permanently unsubmittable.

**Root cause:** `useItemFormFields.tsx` stores the full field list in state (`allRequestFields`) but exposes only the currently-visible subset as `requestFields` (via `getVisibleFields(allRequestFields, endUserConditions)`). It hands callers `setRequestFields: setAllRequestFields` — the raw setter over the full list, under a name that reads like it operates on `requestFields`.

In `ServiceCatalogItem.tsx`, `handleValidationErrors()` (triggered on a 422 response) mapped over the visible-only `requestFields` and passed the result straight to `setRequestFields`. Since `requestFields` is only the visible subset, this call replaced the full state instead of merging into it — silently wiping any field hidden by a condition at that moment.

**Fix:** in `handleValidationErrors()`, merge onto the previous full list with a functional update instead of replacing it:

```ts
setRequestFields((prevFields) =>
  prevFields.map((field) => {
    const errorField = invalidFieldErrors.find(
      (errorField) => errorField.field_key === field.id
    );
    return { ...field, error: errorField?.description || null };
  })
);
```

Added coverage in `ServiceCatalogItem.spec.tsx`: asserts `setRequestFields` is called with a function, then invokes that function against a field list that includes one field not present in the mocked (visible) `requestFields`, asserting it's preserved unchanged in the result.

## Screenshots

N/A — this is a logic-only state management fix with no UI/markup changes.

## Checklist

- [x] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [x] :arrow_left: changes are compatible with RTL direction (no markup/UI changes)
- [x] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/) (no UI changes)
- [x] :memo: changes are tested in Chrome, Firefox, Safari and Edge (no UI changes; covered by unit tests)
- [x] :iphone: changes are responsive and tested in mobile (no UI changes)
- [x] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->
