### PR TITLE
[GG-5229] Render request_list via {{component}} helper

### DIFF
--- a/templates/requests_page.hbs
+++ b/templates/requests_page.hbs
@@ -3,22 +3,5 @@
     <h1>{{t "requests"}}</h1>
   </header>
 
-  <div id="main-content">
-  </div>
+  {{component "request_list"}}
 </div>
-
-<script type="module">
-  import { renderRequestList } from "request-list"; 
-  
-  const container = document.getElementById("main-content"); 
-  const settings = {{json settings}}; 
-
-
-  const props = {   
-    locale: {{json help_center.base_locale}},
-    customStatusesEnabled: {{json help_center.custom_statuses_enabled}},
-    viewRequestsAcrossBrandsEnabled: {{json help_center.view_requests_across_brands_enabled}},
-  }; 
-  
-  renderRequestList(settings, props, container);
-</script>


### PR DESCRIPTION
Replace the import-map + module-script wiring that mounted the request-list React module with a single `{{component "request_list"}}` placement. The platform now resolves, delivers, and mounts the component from the registry, so the theme no longer pins a bundle URL or bootstraps data itself.

## Description

<!-- a summary of the changes introduced by this PR and the motivation behind them -->

## Screenshots

<!-- (optional) when applicable, please include some screenshots or gifs that illustrate the changes -->

## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->