### PR TITLE
fix: show more filters button hidden in search sidebar

### DIFF
--- a/style.css
+++ b/style.css
@@ -4330,7 +4330,7 @@ ul {
     display: block;
   }
 }
-.search-results-sidebar .multibrand-filter-list--collapsed li:nth-child(1n+6) {
+.search-results-sidebar .multibrand-filter-list--collapsed li:nth-child(1n+6):not(.see-all-filters-item) {
   display: none;
 }
 .search-results-sidebar .multibrand-filter-list .doc-count {

--- a/styles/_search_results.scss
+++ b/styles/_search_results.scss
@@ -90,7 +90,7 @@
       }
     }
 
-    .multibrand-filter-list--collapsed li:nth-child(1n + 6) {
+    .multibrand-filter-list--collapsed li:nth-child(1n + 6):not(.see-all-filters-item) {
       display: none;
     }
 

--- a/templates/search_results.hbs
+++ b/templates/search_results.hbs
@@ -37,7 +37,7 @@
                 </a>
               </li>
             {{/each}}
-            <li>
+            <li class="see-all-filters-item">
               <button class="see-all-filters" aria-hidden="true" aria-label="{{t 'show_more_sources'}}">{{t 'show_more_sources'}}</button>
             </li>
           </ul>
@@ -100,12 +100,12 @@
               </li>
             {{/each}}
             {{#is current_filter.identifier 'knowledge_base'}}
-              <li>
+              <li class="see-all-filters-item">
                 <button class="see-all-filters" aria-hidden="true" aria-label="{{t 'show_more_categories'}}">{{t 'show_more_categories'}}</button>
               </li>
             {{/is}}
             {{#is current_filter.identifier 'community'}}
-              <li>
+              <li class="see-all-filters-item">
                 <button class="see-all-filters" aria-hidden="true" aria-label="{{t 'show_more_topics'}}">{{t 'show_more_topics'}}</button>
               </li>
             {{/is}}


### PR DESCRIPTION
## Problem

On the search results page, the source / type / category filter sidebar never shows more than 5 items, and the **"Show more sources / types / categories"** button is not displayed — even when results span more than 5 sources/types/categories.

This regressed at least since **4.35.01** and is still present in the latest version. Version **4.6.0** is unaffected.

z2 ticket: https://support.zendesk.com/agent/tickets/15096912

## Root cause

Commit a5c2894 ("style: wrap button in `<li>` element") wrapped each `see-all-filters` button in an `<li>` to produce valid HTML (a `<ul>` should only contain `<li>` children).

However, the collapse rule in `styles/_search_results.scss` hides every list item from the 6th onward:

```scss
.multibrand-filter-list--collapsed li:nth-child(1n + 6) { display: none; }
```

Before that commit the button was a **direct child of the `<ul>`** (a bare `<button>`), so `li:nth-child()` never matched it. After the commit the button's wrapping `<li>` **is** counted — so once a filter list has 5+ items, the button's `<li>` lands at position 6 or beyond and is hidden.

`navigation.js` still correctly sets `aria-hidden="false"` on the button (its `filter.children.length > 6` check is unchanged, since the button counts as one child either way), but the button's parent `<li>` is `display: none`, so it never appears.

## Fix

- Add `class="see-all-filters-item"` to the three button-wrapping `<li>` elements (sources, categories, topics) in `templates/search_results.hbs`.
- Exclude that class from the collapse rule: `li:nth-child(1n + 6):not(.see-all-filters-item)`.
- Regenerate `style.css` via `yarn build`.

This preserves the valid `<ul>`/`<li>` structure that a5c2894 introduced while restoring the show-more behavior.

## Testing

- `yarn build` succeeds and regenerates `style.css`.
- Filter lists still collapse to 5 items; the "Show more" button `<li>` is no longer hidden, so `navigation.js` reveals it when there are more than 5 filters.