### PR TITLE
fix: cloudflare blocking lighthouse audits

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -37,7 +37,6 @@ jobs:
             https://${{ secrets.subdomain }}.zendesk.com/hc/en-us/categories/360002267479
             https://${{ secrets.subdomain }}.zendesk.com/hc/en-us/sections/360003307259
             https://${{ secrets.subdomain }}.zendesk.com/hc/en-us/articles/360010829359
-            https://${{ secrets.subdomain }}.zendesk.com/hc/en-us/requests/new
             https://${{ secrets.subdomain }}.zendesk.com/hc/en-us/search?utf8=%E2%9C%93&query=Help+Center
             https://${{ secrets.subdomain }}.zendesk.com/hc/en-us/community/topics
             https://${{ secrets.subdomain }}.zendesk.com/hc/en-us/community/topics/360000644279


### PR DESCRIPTION
## Description

Fix the broken pipeline
The following URL is intentionally omitted from .github/workflows/lighthouse.yml

https://${{ secrets.subdomain }}.zendesk.com/hc/en-us/requests/new This is because Cloudflare Bot Management serves
 an overlay on that page to headless Chrome,  so Lighthouse was auditing the challenge page
instead of the real one. Re-add it once bot protection is configured to allow CI traffic on this subdomain.


revert this pr once (and if) the edge allows the endpoint to receive traffic. Have made a request with the team here: https://zendesk.slack.com/archives/CADGE03M4/p1787570054017379



## Screenshots

<!-- (optional) when applicable, please include some screenshots or gifs that illustrate the changes -->

## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

