### PR TITLE
fix: add missing plurals for requests translation

### DIFF
--- a/src/modules/request-list/translations/en-us.yml
+++ b/src/modules/request-list/translations/en-us.yml
@@ -29,8 +29,23 @@ parts:
       value: "{{count}} request"
       screenshot: "https://drive.google.com/file/d/1GKtVd7FnRbqu408DNBe-l_-fapj2bWRK/view?usp=sharing"
   - translation:
+      key: "guide-requests-app.requestCount.two"
+      title: "Label indicating the number of requests, when there are 2 requests"
+      value: "{{count}} requests"
+      screenshot: "https://drive.google.com/file/d/1GKtVd7FnRbqu408DNBe-l_-fapj2bWRK/view?usp=sharing"
+  - translation:
       key: guide-requests-app.requestCount.other
       title: "Label indicating the number of requests, when there are more than 1 request"
+      value: "{{count}} requests"
+      screenshot: "https://drive.google.com/file/d/1GKtVd7FnRbqu408DNBe-l_-fapj2bWRK/view?usp=sharing"
+  - translation:
+      key: "guide-requests-app.requestCount.few"
+      title: "Label indicating the number of requests, when there are a few requests"
+      value: "{{count}} requests"
+      screenshot: "https://drive.google.com/file/d/1GKtVd7FnRbqu408DNBe-l_-fapj2bWRK/view?usp=sharing"
+  - translation:
+      key: "guide-requests-app.requestCount.many"
+      title: "Label indicating the number of requests, when there are many requests"
       value: "{{count}} requests"
       screenshot: "https://drive.google.com/file/d/1GKtVd7FnRbqu408DNBe-l_-fapj2bWRK/view?usp=sharing"
   - translation:


### PR DESCRIPTION
## Description
We were missing some plural forms for "requests" translation.
<!-- a summary of the changes introduced by this PR and the motivation behind them -->

## Screenshots

<!-- (optional) when applicable, please include some screenshots or gifs that illustrate the changes -->

## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->