### PR TITLE
fix: lighthouse workflow run on new request page

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -3,7 +3,7 @@ name: Lighthouse
 
 jobs:
   lighthouse:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, zendesk-stable]
     steps:
       - name: Checkout
         uses: zendesk/checkout@v3
@@ -37,6 +37,7 @@ jobs:
             https://${{ secrets.subdomain }}.zendesk.com/hc/en-us/categories/360002267479
             https://${{ secrets.subdomain }}.zendesk.com/hc/en-us/sections/360003307259
             https://${{ secrets.subdomain }}.zendesk.com/hc/en-us/articles/360010829359
+            https://${{ secrets.subdomain }}.zendesk.com/hc/en-us/requests/new
             https://${{ secrets.subdomain }}.zendesk.com/hc/en-us/search?utf8=%E2%9C%93&query=Help+Center
             https://${{ secrets.subdomain }}.zendesk.com/hc/en-us/community/topics
             https://${{ secrets.subdomain }}.zendesk.com/hc/en-us/community/topics/360000644279


### PR DESCRIPTION
- The edge team recommended using the self-hosted runner to ensure Cloudflare will not display
an overlay on the page and prevent the a11 checks
from running.

- Reverses https://github.com/zendesk/copenhagen_theme/pull/861/changes with the recommended fix.

## Description

<!-- a summary of the changes introduced by this PR and the motivation behind them -->

## Screenshots

<!-- (optional) when applicable, please include some screenshots or gifs that illustrate the changes -->

## Checklist

- [ ] :green_book: all commit messages follow the [conventional commits](https://conventionalcommits.org/) standard
- [ ] :arrow_left: changes are compatible with RTL direction
- [ ] :wheelchair: Changes to the UI are [tested for accessibility](./../README.md#accessibility-testing) and compliant with [WCAG 2.1](https://www.w3.org/TR/WCAG21/).
- [ ] :memo: changes are tested in Chrome, Firefox, Safari and Edge
- [ ] :iphone: changes are responsive and tested in mobile
- [ ] :+1: PR is approved by @zendesk/vikings

<!-- More info about the contribution process can be found at https://github.com/zendesk/copenhagen_theme#contributing -->